### PR TITLE
docs(#28): create adr structure

### DIFF
--- a/docs/architecture/decisions/0000-use-adrs.md
+++ b/docs/architecture/decisions/0000-use-adrs.md
@@ -1,0 +1,43 @@
+# ADR-0000: Use Architecture Decision Records
+
+## Status
+
+Accepted
+
+## Date
+
+2025-09-28
+
+## Context
+
+Right now, architecture and major design choices are made on the fly, often communicated through discussions. As the project grows, this approach leads to several problems:
+
+* **Knowledge Loss:** We might forget why we made certain choices.
+* **Wasted Time:** We may repeatedly discuss and revisit decisions that were already made.
+* **High Onboarding Cost:** Potential new team members will find it harder to understand the evolution of the architecture.
+
+## Decision
+
+We will start  using **Architecture Decision Records (ADRs)** to document all major design choices.
+
+1. Every major design choice will be a numbered **Markdown file** (e.g., `0000-use-adrs.md`) stored in a dedicated `docs/architecture/decisions/` folder.
+2. Each file will follow a standard template (`TEMPLATE.md`) covering the **Status**, **Date**, **Context**, **Decision**, **Consequences** and **Considered Alternatives**.
+3. The `Status` field within each ADR will be actively maintained (e.g., updated from Proposed to Accepted when approved, or marked as Deprecated if superseded).
+4. A main `INDEX.md` file will serve as the central, categorized log of all ADRs.
+
+## Consequences
+
+* ✅ Clear History of design choices.
+* ✅ Faster Onboarding for new team members.
+* ✅ Less time will be spent re-discussing old choices.
+* ⚠️ We must maintain the ADRs, adding a small amount of overhead to the development process.
+* ⚠️ There is a risk that ADRs could become outdated if they are not consistently updated when the architecture changes.
+
+## Considered Alternatives
+
+1. **Random Notes or Project Documents**
+    * Rejection Reason: Lacks a clear structure, easy to lose.
+2. **Separate Wiki**
+    * Rejection Reason: Another system to manage, not that close to code.
+3. **Code Comments or Inline Documentation**
+    * Rejection Reason: Too focused on small details, rather implementation than high-level architectural decisions, spread across the codebase.

--- a/docs/architecture/decisions/INDEX.md
+++ b/docs/architecture/decisions/INDEX.md
@@ -2,12 +2,8 @@
 
 This document serves as the central index and log for all significant **Architectural Decision Records (ADRs)** for our project.
 
-## How to Work with ADRs
-
-1. **To Add a New Decision:** Create a new Markdown file using the provided template (`template.md`) and name it sequentially (e.g., `adr-002.md`).
-2. **To Update Status:** Update the `Status` field inside the specific ADR file (e.g., changing from `Proposed` to `Accepted` or `Deprecated`).
-3. **To View:** Use the links in the **Decision Log** below to read the full context, rationale, and consequences for any recorded decision.
-
 ## Decision Log
 
-*This section will be populated as decisions are recorded.*
+### Common
+
+* [ADR-0000](0000-use-adrs.md) - Use Architecture Decision Records

--- a/docs/architecture/decisions/TEMPLATE.md
+++ b/docs/architecture/decisions/TEMPLATE.md
@@ -48,9 +48,7 @@ List all alternatives that were seriously considered. Briefly explain why each r
 
 1. **Direct streaming from primary servers**
     * Rejection Reason: Cannot scale to 10K concurrent users.
-
 2. **P2P (Peer-to-Peer) streaming**
     * Rejection Reason: Security concerns and unreliability/instability.
-
 3. **Third-party service (YouTube, Vimeo)**
     * Rejection Reason: Limited control and branding issues.


### PR DESCRIPTION
Resolves #28 

Moreover, initial ADR-0000 describing ADR usage was added
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Architecture Decision Records (ADRs) to standardize documenting major design decisions.
  * Added a central index to browse ADRs, including an initial entry on adopting ADRs.
  * Provided a reusable ADR template with sections for Status, Date, Context, Decision, Consequences, and Considered Alternatives, plus guidance on writing clear, traceable decisions.
  * Defined ADR status lifecycle (e.g., Proposed, Accepted, Deprecated) for consistent governance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->