### PR TITLE
docs(#29): make fr and nfr ids clickable in rtm

### DIFF
--- a/docs/requirements/requirements.md
+++ b/docs/requirements/requirements.md
@@ -4,36 +4,136 @@ This document defines the **Functional Requirements (FR)** and **Non-Functional 
 
 ## Functional Requirements
 
-| ID | Description |
-| --- | --- |
-| FR-001 | The system shall allow students to log in using their official NaUKMA corporate email. |
-| FR-002 | The system shall provide a catalog of all courses with pagination or "load more" functionality. |
-| FR-003 | The system shall display course metadata (name, professor, faculty, semester, credits) on each course’s detail page. |
-| FR-004 | The system shall allow searching for courses by full or partial name. |
-| FR-005 | The system shall allow filtering courses by attributes (rating, instructor, faculty, semester, credits, type, level of study). |
-| FR-006 | The system shall allow students to submit ratings (difficulty 1–5, usefulness 1–5) and optional text reviews anonymously. |
-| FR-007 | The system shall allow students to edit or delete their own feedback on a course after submission. |
-| FR-008 | The system shall display aggregated course ratings (averages, counts) and reviews on each course’s detail page, including existing text reviews. |
-| FR-009 | The system shall display an interactive scatter plot of courses with usefulness on the x-axis and difficulty on the y-axis. Each course shall correspond to a point on the plot, and interactions (hover, click) shall reveal details or navigate to the course page. |
-| FR-010 | The system shall provide personalized course recommendations based on student activity. Recommendations shall be shown on course detail pages and on the home page. |
-| FR-011 | The system shall show students their evaluation history and progress (total completed and per semester), including completion percentage. |
-| FR-012 | The system shall provide administrators with evaluation statistics (counts, filters, and trends over time). |
+### FR-001
+
+The system shall allow students to log in using their official NaUKMA corporate email.
+
+### FR-002
+
+The system shall provide a catalog of all courses with pagination or "load more" functionality.
+
+### FR-003
+
+The system shall display course metadata (name, professor, faculty, semester, credits) on each course’s detail page.
+
+### FR-004
+
+The system shall allow searching for courses by full or partial name.
+
+### FR-005
+
+The system shall allow filtering courses by attributes (rating, instructor, faculty, semester, credits, type, level of study).
+
+### FR-006
+
+The system shall allow students to submit ratings (difficulty 1–5, usefulness 1–5) and optional text reviews anonymously.
+
+### FR-007
+
+The system shall allow students to edit or delete their own feedback on a course after submission.
+
+### FR-008
+
+The system shall display aggregated course ratings (averages, counts) and reviews on each course’s detail page, including existing text reviews.
+
+### FR-009
+
+The system shall display an interactive scatter plot of courses with usefulness on the x-axis and difficulty on the y-axis. Each course shall correspond to a point on the plot, and interactions (hover, click) shall reveal details or navigate to the course page.
+
+### FR-010
+
+The system shall provide personalized course recommendations based on student activity. Recommendations shall be shown on course detail pages and on the home page.
+
+### FR-011
+
+The system shall show students their evaluation history and progress (total completed and per semester), including completion percentage.
+
+### FR-012
+
+The system shall provide administrators with evaluation statistics (counts, filters, and trends over time).
 
 ## Non-Functional Requirements (NFR)
 
-| Category | ID | Description | Measurable Metric |
-|--------------|------------|--------------------|------------------------|
-| **Performance Efficiency** | NFR-PE-001 | The system shall load any page within 1.5 seconds under normal network conditions. | Page load time ≤ 1.5 sec |
-| | NFR-PE-002 | The system shall display search results in real-time with a maximum response time of 1 second. | Response time ≤ 1 sec after input |
-| | NFR-PE-003 | The scatter plot on the home page shall render completely within 2 seconds for up to 500 courses. | Scatter plot rendering ≤ 2 sec |
-| | NFR-PE-004 | Filtering on scatter plot or course list shall update results within 1.5 seconds. | Filter response ≤ 1.5 sec |
-| **Reliability** | NFR-R-001 | The system shall ensure that no data is lost during a course evaluation submission. | 100% data persistence confirmation |
-| | NFR-R-002 | The system shall achieve 99.5% uptime monthly to ensure continuous availability. | Monthly uptime ≥ 99.5% |
-| | NFR-R-003 | When a failure occurs during rating submission, the system shall retry automatically up to 3 times before showing an error. | Automatic retry count = 3 |
-| | NFR-R-004 | Backups of all ratings and comments shall occur every 24 hours. | Backup frequency = daily |
-| **Usability** | NFR-U-001 | 90% of first-time users shall be able to successfully log in and find a course within 3 minutes without external help. | Success rate ≥ 90% in usability test |
-| | NFR-U-002 | Ratings and reviews shall be clearly visible and readable on desktop and mobile devices. | Readability test score ≥ 90% |
-| **Robustness** | NFR-RB-001 | The system shall correctly handle cases when a user has no data available without errors or broken UI. | System returns valid empty state within ≤ 1 sec |
-| **Security** | NFR-S-001 | The system shall require corporate email login using secure authentication. | 100% authentication via secure protocol |
-| | NFR-S-002 | Student ratings must remain anonymous to other users. | 0 data leaks in security tests |
-| | NFR-S-003 | User sessions shall expire after 30 minutes of inactivity. | Session timeout = 30 minutes |
+### NFR-PE-001
+
+- **Category**: Performance Efficiency
+- **Description**: The system shall load any page within 1.5 seconds under normal network conditions.
+- **Measurable Metric**: Page load time ≤ 1.5 sec
+
+### NFR-PE-002
+
+- **Category**: Performance Efficiency
+- **Description**: The system shall display search results in real-time with a maximum response time of 1 second.
+- **Measurable Metric**: Response time ≤ 1 sec after input
+
+### NFR-PE-003
+
+- **Category**: Performance Efficiency
+- **Description**: The scatter plot on the home page shall render completely within 2 seconds for up to 500 courses.
+- **Measurable Metric**: Scatter plot rendering ≤ 2 sec
+
+### NFR-PE-004
+
+- **Category**: Performance Efficiency
+- **Description**: Filtering on scatter plot or course list shall update results within 1.5 seconds.
+- **Measurable Metric**: Filter response ≤ 1.5 sec
+
+### NFR-R-001
+
+- **Category**: Reliability
+- **Description**: The system shall ensure that no data is lost during a course evaluation submission.
+- **Measurable Metric**: 100% data persistence confirmation
+
+### NFR-R-002
+
+- **Category**: Reliability
+- **Description**: The system shall achieve 99.5% uptime monthly to ensure continuous availability.
+- **Measurable Metric**: Monthly uptime ≥ 99.5%
+
+### NFR-R-003
+
+- **Category**: Reliability
+- **Description**: When a failure occurs during rating submission, the system shall retry automatically up to 3 times before showing an error.
+- **Measurable Metric**: Automatic retry count = 3
+
+### NFR-R-004
+
+- **Category**: Reliability
+- **Description**: Backups of all ratings and comments shall occur every 24 hours.
+- **Measurable Metric**: Backup frequency = daily
+
+### NFR-U-001
+
+- **Category**: Usability
+- **Description**: 90% of first-time users shall be able to successfully log in and find a course within 3 minutes without external help.
+- **Measurable Metric**: Success rate ≥ 90% in usability test
+
+### NFR-U-002
+
+- **Category**: Usability
+- **Description**: Ratings and reviews shall be clearly visible and readable on desktop and mobile devices.
+- **Measurable Metric**: Readability test score ≥ 90%
+
+### NFR-RB-001
+
+- **Category**: Robustness
+- **Description**: The system shall correctly handle cases when a user has no data available without errors or broken UI.
+- **Measurable Metric**: System returns valid empty state within ≤ 1 sec
+
+### NFR-S-001
+
+- **Category**: Security
+- **Description**: The system shall require corporate email login using secure authentication.
+- **Measurable Metric**: 100% authentication via secure protocol
+
+### NFR-S-002
+
+- **Category**: Security
+- **Description**: Student ratings must remain anonymous to other users.
+- **Measurable Metric**: 0 data leaks in security tests
+
+### NFR-S-003
+
+- **Category**: Security
+- **Description**: User sessions shall expire after 30 minutes of inactivity.
+- **Measurable Metric**: Session timeout = 30 minutes

--- a/docs/requirements/rtm.md
+++ b/docs/requirements/rtm.md
@@ -1,64 +1,63 @@
 # Requirements Traceability Matrix
+
 This document defines the **Requirements Traceability Matrix** for the *Rate UKMA* system.
 
 See also: [requirements.md](./requirements.md)
 
-
-
-| **User Story ID** | **Requirement ID** | **Requirement Description** | **Non-Functional Requirement ID** | **Potential Test Case** | 
+| **User Story ID** | **Requirement ID** | **Requirement Description** | **Non-Functional Requirement ID** | **Potential Test Case** |
 |-------------|---------------|----------------------------------------------------------------|----------------------------|--------------------------------------------------------------------------------|
-|[US-001](./user-stories.md#us-001-login-with-corporate-email) |FR-001 |Login with corporate email |NFR-S-001 |Test-01: Authenticated user accesses protected page |
-| |FR-001 |Login with corporate email |NFR-S-001 |Test-02: User provides correct credentials |
-| |FR-001 |Login with corporate email |NFR-S-001 |Test-03: User provides incorrect credentials |
-| |FR-001 |Login with corporate email |NFR-S-003 |Test-04: Authenticated user is inactive for 30+ minutes |
-| |FR-001 |Login with corporate email |NFR-U-001 |Test-05: Most first-time users (9/10) spend less than 3 minutes logging in|
-| |FR-001 |Login with corporate email | NFR-R-002 | Test-06: Monitor login endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-002](./user-stories.md#us-002-course-browsing) |FR-002 |User browses courses |NFR-PE-001 |Test-01: 300 users access courses' list |
-| |FR-002 |User browses courses |NFR-PE-002 |Test-02: 300 users paginate courses |
-|[US-003](./user-stories.md#us-003-course-search) |FR-004 |User searches courses |NFR-PE-002 |Test-01: 300 users attempt course searching |
-| |FR-004 |User searches courses |NFR-PE-002 |Test-02: Search for partial course name |
-| |FR-004 |User searches courses |NFR-PE-002 |Test-03: Search with no match |
-| |FR-004 |User searches courses |NFR-PE-002 , NFR-RB-001 |Test-04: Clear search input |
-| |FR-004 |User searches courses |NFR-PE-002 |Test-05: Case-insensitive search |
-| |FR-004 |User searches courses | NFR-R-002 | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-004](./user-stories.md#us-004-course-filtering) |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-01: 300 users attempt filtering queries |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-02: No filter search |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-03: Search + filters |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-04: Filter with no match |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-05: Separate filters |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-06: Multiple filters at the same time |
-| |FR-005 |User applies filters to list of courses |NFR-PE-002 |Test-07: Clear filters |
-|[US-005](./user-stories.md#us-005-scatter-plot-of-courses) |FR-009 |User sees/interacts with scatter plot of courses |NFR-PE-003 |Test-01: 300 users attempt rendering scatter plot |
-| |FR-009 |User sees/interacts with scatter plot of courses |NFR-PE-004 |Test-02: 300 users attempt rendering scatter plot with filters applied |
-| |FR-009 |User sees/interacts with scatter plot of courses |NFR-PE-004 |Test-03: Apply filter returning zero courses |
-| |FR-009 |User sees/interacts with scatter plot of courses |NFR-PE-003 |Test-04: Hovering over points to display metadata |
-| |FR-009 |User sees/interacts with scatter plot of courses |NFR-PE-003 |Test-05: Navigate to the course's page via point |
-| |FR-009 |User sees/interacts with scatter plot of courses | NFR-R-002 | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-006](./user-stories.md#us-006-course-ratings-and-reviews-on-course-page) |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-PE-001 |Test-01: 300 users access courses' pages |
-| |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-U-002 |Test-02: Automated readability |
-| |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-U-002 |Test-03: UI desktop |
-| |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-U-002 |Test-04: UI mobile |
-| |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-R-004 |Test-05: Course ratings display correctly after backup restoration |
-| |FR-003 / FR-008 |User sees course's page (inc. metadata, ratings) |NFR-R-002 | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-007](./user-stories.md#us-007-course-recommendations-on-course-page) |FR-010 |User sees personalized course recommendation on course's page |NFR-RB-001 |Test-01: Not enough rating/enroll data for proper algorithm work |
-|[US-008](./user-stories.md#us-008-course-recommendations-on-home-page) |FR-010 |User sees personalized course recommendation on home page |NFR-RB-001 |Test-01: User has not rated any course yet |
-|[US-009](./user-stories.md#us-009-course-grading) |FR-006 |Student submits ratings and optional reviews |NFR-R-001 |Test-01: User submits a rating |
-| |FR-006 |Student submits ratings and optional reviews |NFR-R-003 |Test-02: Submission failure occurs during rating/review submission |
-| |FR-006 |Student submits ratings and optional reviews |NFR-S-002 |Test-03: User submits review anonymously |
-| |FR-007 |Student submits ratings and optional reviews |NFR-R-001 |Test-04: User edits an existing review |
-| |FR-007 |Student submits ratings and optional reviews |NFR-R-003 |Test-05: User deletes an existing review |
-| |FR-007 |Student submits ratings and optional reviews |NFR-R-004 |Test-06: Daily backup includes newly submitted ratings and comments|
-| |FR-007 |Student submits ratings and optional reviews | NFR-R-002 | Test-07: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-010](./user-stories.md#us-010-students-total-evaluated-courses) |FR-011 |Student sees his overall progress in course rating |NFR-PE-001 |Test-01: 300 users attempt viewing their profile |
-| |FR-011 |Student sees his progress in course rating |NFR-R-001 |Test-02: Verify that no ratings or feedback data are lost when loading profile |
-| |FR-011 |Student sees his progress in course rating |NFR-RB-001 |Test-03: Student has not rated any courses yet |
-| |FR-011 |Student sees his progress in course rating |NFR-R-004 |Test-04: Student progress data is recoverable from daily backups |
-| |FR-011 |Student sees his progress in course rating | NFR-R-002 | Test-05: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-011](./user-stories.md#us-011-students-evaluated-courses-per-semester) |FR-011 |Student sees information about courses rated in current semester |NFR-PE-001 |Test-01: 300 students opens ratings page |
-| |FR-011 |Student sees information about courses rated in current semester |NFR-U-002 |Test-02: Progress bar visible and readable on desktop/mobile |
-| |FR-011 |Student sees information about courses rated in current semester |NFR-PE-004 |Test-03: Filter updates results < 1.5 sec |
-| |FR-011 |Student sees information about courses rated in current semester| NFR-R-002 | Test-04: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
-|[US-012](./user-stories.md#us-012-course-evaluation-statistics-for-admin) |FR-012 |Admin sees evaluating statistics |NFR-PE-001 |Test-01: Admin opens statistics page |
-| |FR-012 |Admin sees evaluating statistics |NFR-PE-004 |Test-02: Admin applies filters on statistics |
-| |FR-012 |Admin sees evaluation statistics |NFR-R-004 |Test-03: Statistics include data restored from backups. |
-| |FR-012 |Admin sees evaluating statistics | NFR-R-002 |Test-04: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-001](./user-stories.md#us-001-login-with-corporate-email) |[FR-001](./requirements.md#fr-001) |Login with corporate email |[NFR-S-001](./requirements.md#nfr-s-001) |Test-01: Authenticated user accesses protected page |
+| |[FR-001](./requirements.md#fr-001) |Login with corporate email |[NFR-S-001](./requirements.md#nfr-s-001) |Test-02: User provides correct credentials |
+| |[FR-001](./requirements.md#fr-001) |Login with corporate email |[NFR-S-001](./requirements.md#nfr-s-001) |Test-03: User provides incorrect credentials |
+| |[FR-001](./requirements.md#fr-001) |Login with corporate email |[NFR-S-003](./requirements.md#nfr-s-003) |Test-04: Authenticated user is inactive for 30+ minutes |
+| |[FR-001](./requirements.md#fr-001) |Login with corporate email |[NFR-U-001](./requirements.md#nfr-u-001) |Test-05: Most first-time users (9/10) spend less than 3 minutes logging in|
+| |[FR-001](./requirements.md#fr-001) |Login with corporate email | [NFR-R-002](./requirements.md#nfr-r-002) | Test-06: Monitor login endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-002](./user-stories.md#us-002-course-browsing) |[FR-002](./requirements.md#fr-002) |User browses courses |[NFR-PE-001](./requirements.md#nfr-pe-001) |Test-01: 300 users access courses' list |
+| |[FR-002](./requirements.md#fr-002) |User browses courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-02: 300 users paginate courses |
+|[US-003](./user-stories.md#us-003-course-search) |[FR-004](./requirements.md#fr-004) |User searches courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-01: 300 users attempt course searching |
+| |[FR-004](./requirements.md#fr-004) |User searches courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-02: Search for partial course name |
+| |[FR-004](./requirements.md#fr-004) |User searches courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-03: Search with no match |
+| |[FR-004](./requirements.md#fr-004) |User searches courses |[NFR-PE-002](./requirements.md#nfr-pe-002) , [NFR-RB-001](./requirements.md#nfr-rb-001) |Test-04: Clear search input |
+| |[FR-004](./requirements.md#fr-004) |User searches courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-05: Case-insensitive search |
+| |[FR-004](./requirements.md#fr-004) |User searches courses | [NFR-R-002](./requirements.md#nfr-r-002) | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-004](./user-stories.md#us-004-course-filtering) |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-01: 300 users attempt filtering queries |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-02: No filter search |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-03: Search + filters |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-04: Filter with no match |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-05: Separate filters |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-06: Multiple filters at the same time |
+| |[FR-005](./requirements.md#fr-005) |User applies filters to list of courses |[NFR-PE-002](./requirements.md#nfr-pe-002) |Test-07: Clear filters |
+|[US-005](./user-stories.md#us-005-scatter-plot-of-courses) |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses |[NFR-PE-003](./requirements.md#nfr-pe-003) |Test-01: 300 users attempt rendering scatter plot |
+| |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses |[NFR-PE-004](./requirements.md#nfr-pe-004) |Test-02: 300 users attempt rendering scatter plot with filters applied |
+| |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses |[NFR-PE-004](./requirements.md#nfr-pe-004) |Test-03: Apply filter returning zero courses |
+| |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses |[NFR-PE-003](./requirements.md#nfr-pe-003) |Test-04: Hovering over points to display metadata |
+| |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses |[NFR-PE-003](./requirements.md#nfr-pe-003) |Test-05: Navigate to the course's page via point |
+| |[FR-009](./requirements.md#fr-009) |User sees/interacts with scatter plot of courses | [NFR-R-002](./requirements.md#nfr-r-002) | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-006](./user-stories.md#us-006-course-ratings-and-reviews-on-course-page) |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-PE-001](./requirements.md#nfr-pe-001) |Test-01: 300 users access courses' pages |
+| |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-U-002](./requirements.md#nfr-u-002) |Test-02: Automated readability |
+| |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-U-002](./requirements.md#nfr-u-002) |Test-03: UI desktop |
+| |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-U-002](./requirements.md#nfr-u-002) |Test-04: UI mobile |
+| |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-R-004](./requirements.md#nfr-r-004) |Test-05: Course ratings display correctly after backup restoration |
+| |[FR-003](./requirements.md#fr-003) / [FR-008](./requirements.md#fr-008) |User sees course's page (inc. metadata, ratings) |[NFR-R-002](./requirements.md#nfr-r-002) | Test-06: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-007](./user-stories.md#us-007-course-recommendations-on-course-page) |[FR-010](./requirements.md#fr-010) |User sees personalized course recommendation on course's page |[NFR-RB-001](./requirements.md#nfr-rb-001) |Test-01: Not enough rating/enroll data for proper algorithm work |
+|[US-008](./user-stories.md#us-008-course-recommendations-on-home-page) |[FR-010](./requirements.md#fr-010) |User sees personalized course recommendation on home page |[NFR-RB-001](./requirements.md#nfr-rb-001) |Test-01: User has not rated any course yet |
+|[US-009](./user-stories.md#us-009-course-grading) |[FR-006](./requirements.md#fr-006) |Student submits ratings and optional reviews |[NFR-R-001](./requirements.md#nfr-r-001) |Test-01: User submits a rating |
+| |[FR-006](./requirements.md#fr-006) |Student submits ratings and optional reviews |[NFR-R-003](./requirements.md#nfr-r-003) |Test-02: Submission failure occurs during rating/review submission |
+| |[FR-006](./requirements.md#fr-006) |Student submits ratings and optional reviews |[NFR-S-002](./requirements.md#nfr-s-002) |Test-03: User submits review anonymously |
+| |[FR-007](./requirements.md#fr-007) |Student submits ratings and optional reviews |[NFR-R-001](./requirements.md#nfr-r-001) |Test-04: User edits an existing review |
+| |[FR-007](./requirements.md#fr-007) |Student submits ratings and optional reviews |[NFR-R-003](./requirements.md#nfr-r-003) |Test-05: User deletes an existing review |
+| |[FR-007](./requirements.md#fr-007) |Student submits ratings and optional reviews |[NFR-R-004](./requirements.md#nfr-r-004) |Test-06: Daily backup includes newly submitted ratings and comments|
+| |[FR-007](./requirements.md#fr-007) |Student submits ratings and optional reviews | [NFR-R-002](./requirements.md#nfr-r-002) | Test-07: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-010](./user-stories.md#us-010-students-total-evaluated-courses) |[FR-011](./requirements.md#fr-011) |Student sees his overall progress in course rating |[NFR-PE-001](./requirements.md#nfr-pe-001) |Test-01: 300 users attempt viewing their profile |
+| |[FR-011](./requirements.md#fr-011) |Student sees his progress in course rating |[NFR-R-001](./requirements.md#nfr-r-001) |Test-02: Verify that no ratings or feedback data are lost when loading profile |
+| |[FR-011](./requirements.md#fr-011) |Student sees his progress in course rating |[NFR-RB-001](./requirements.md#nfr-rb-001) |Test-03: Student has not rated any courses yet |
+| |[FR-011](./requirements.md#fr-011) |Student sees his progress in course rating |[NFR-R-004](./requirements.md#nfr-r-004) |Test-04: Student progress data is recoverable from daily backups |
+| |[FR-011](./requirements.md#fr-011) |Student sees his progress in course rating | [NFR-R-002](./requirements.md#nfr-r-002) | Test-05: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-011](./user-stories.md#us-011-students-evaluated-courses-per-semester) |[FR-011](./requirements.md#fr-011) |Student sees information about courses rated in current semester |[NFR-PE-001](./requirements.md#nfr-pe-001) |Test-01: 300 students opens ratings page |
+| |[FR-011](./requirements.md#fr-011) |Student sees information about courses rated in current semester |[NFR-U-002](./requirements.md#nfr-u-002) |Test-02: Progress bar visible and readable on desktop/mobile |
+| |[FR-011](./requirements.md#fr-011) |Student sees information about courses rated in current semester |[NFR-PE-004](./requirements.md#nfr-pe-004) |Test-03: Filter updates results < 1.5 sec |
+| |[FR-011](./requirements.md#fr-011) |Student sees information about courses rated in current semester| [NFR-R-002](./requirements.md#nfr-r-002) | Test-04: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |
+|[US-012](./user-stories.md#us-012-course-evaluation-statistics-for-admin) |[FR-012](./requirements.md#fr-012) |Admin sees evaluating statistics |[NFR-PE-001](./requirements.md#nfr-pe-001) |Test-01: Admin opens statistics page |
+| |[FR-012](./requirements.md#fr-012) |Admin sees evaluating statistics |[NFR-PE-004](./requirements.md#nfr-pe-004) |Test-02: Admin applies filters on statistics |
+| |[FR-012](./requirements.md#fr-012) |Admin sees evaluation statistics |[NFR-R-004](./requirements.md#nfr-r-004) |Test-03: Statistics include data restored from backups. |
+| |[FR-012](./requirements.md#fr-012) |Admin sees evaluating statistics | [NFR-R-002](./requirements.md#nfr-r-002) |Test-04: Monitor endpoint for 14 days; ensure ≥ 99.5% availability |


### PR DESCRIPTION
## Summary
Using Markdown headers for each requirement allows GitHub to automatically generate anchors, providing direct access from `rtm.md` to the specific requirement in `requirements.md`
Resolves #29



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted Functional Requirements from a single table into individual sections (FR-001 … FR-012) without changing content.
  * Reformatted Non-Functional Requirements into individual sections with Category, Description, and Measurable Metric fields; content unchanged.
  * Enhanced the Requirements Traceability Matrix by turning plain IDs into links to corresponding requirement anchors for easier navigation.
  * Updated table headers, spacing, and formatting to improve readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->