### PR TITLE
docs(#32): fix path to ADR-0001 in hld doc

### DIFF
--- a/docs/architecture/high-level-design.md
+++ b/docs/architecture/high-level-design.md
@@ -2,7 +2,7 @@
 # High-Level Architecture Overview
 
 The **Rate UKMA** system is built using a **layered / N-tier architecture**  
-(see [ADR-0001: N-tier Architecture](../decisions/0001-n-tier-arch.md)), separating the application into presentation, edge/API, business logic, data access, and data layers, while integrating external systems.
+(see [ADR-0001: N-tier Architecture](./decisions/0001-n-tier-arch.md)), separating the application into presentation, edge/API, business logic, data access, and data layers, while integrating external systems.
 
 ---
 


### PR DESCRIPTION
## Summary
The changes in doc directory structure have caused an issue with linking ADR-0001 in high-level-design.md.
I changed link to point to correct path.

Closes #32 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a broken link in the High-Level Architecture Overview to the related Architecture Decision Record, ensuring it resolves correctly.
  * Improved documentation navigation and reduced the chance of 404 or missing-page errors when browsing.
  * No content or behavior changes to the product; this update only enhances the accuracy and accessibility of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->