### PR TITLE
doc(lab03): fix broken link to lab report

### DIFF
--- a/labs/Lab03/videoKaterynaBratiuk.txt
+++ b/labs/Lab03/videoKaterynaBratiuk.txt
@@ -1,1 +1,1 @@
-https://www.loom.com/share/eb3602aa08664a99b4d60afcee874012
+https://www.loom.com/share/0ce1123aec424301ac15c11ecd1c6ff5?sid=d955ecfd-3cbc-4581-aa2e-e4afb5dd77f5


### PR DESCRIPTION
## Summary
I unfortunately uploaded a broken link to the lab report. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Lab 03 video reference to a new Loom share URL, ensuring the latest recording is accessible to users.
  - Improves reliability of the video link (includes updated parameters) with no changes to application behavior or logic.
  - Users following the lab instructions will now be directed to the correct video resource without broken or outdated links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->