### PR TITLE
chore(#75): add workflow to restrict merges into 'live' branch to 'main' only

### DIFF
--- a/.github/workflows/restrict-merge-live.yml
+++ b/.github/workflows/restrict-merge-live.yml
@@ -1,0 +1,17 @@
+name: Restrict live merges to main
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+    branches: ['live']
+
+jobs:
+  block-non-main:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Block if head is not main
+        if: github.base_ref == 'live' && github.head_ref != 'main'
+        run: |
+          echo "ERROR: Only PRs from 'main' into 'live' are allowed. (Got head='${GITHUB_HEAD_REF}')"
+          exit 1


### PR DESCRIPTION
## Summary 
1. Created new live branch 
2. Since there's no mechanism to allow merges only from specific branches, restrict-merge-live.yml workflow was created. 
3. Defined and activated ruleset for the branch protection. 

Part of #75 

## Notes
After this PR is merged into main, a follow-up PR will be opened to merge main → live, ensuring the workflow exists on the live branch and begins enforcing the correct PR checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to enforce merge policy: only pull requests from the primary branch can merge into the production branch; others are automatically blocked with a clear error message.
  * Applies to PR events (opened, reopened, synchronized, edited, ready for review) targeting the production branch, preventing accidental merges from non-approved sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->