### PR TITLE
fix(#65): copy orval config + openapi schema to container

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -33,8 +33,8 @@ services:
 
   webapp:
     build:
-      context: ./webapp
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: ./src/webapp/Dockerfile
       target: ${NODE_ENV:-development}
     container_name: "${COMPOSE_PROJECT_NAME}_webapp"
     volumes:
@@ -51,8 +51,8 @@ services:
 
   webapp-build:
     build:
-      context: ./webapp
-      dockerfile: Dockerfile
+      context: ..
+      dockerfile: ./src/webapp/Dockerfile
       target: production
     env_file:
       - .env

--- a/src/webapp/Dockerfile
+++ b/src/webapp/Dockerfile
@@ -7,14 +7,18 @@ RUN npm install -g pnpm
 # Set working directory
 WORKDIR /app
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy package files and orval config
+COPY src/webapp/package.json src/webapp/pnpm-lock.yaml src/webapp/orval.config.ts ./
+
+# Create docs/api directory structure at the correct location for orval
+RUN mkdir -p /docs/api
+COPY docs/api/openapi-generated.yaml /docs/api/openapi-generated.yaml
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile
 
-# Copy source code
-COPY . .
+# Copy remaining source code
+COPY src/webapp/ ./
 
 # Development stage - uses base directly without building
 FROM base AS development


### PR DESCRIPTION
## Summary
Fixes webapp docker build problems which I've created in #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - API specification is now bundled within the app image under a dedicated docs directory, making generated OpenAPI files available in the build output.
- Chores
  - Updated container build configuration to align with the current source layout, adjusting build contexts and Dockerfile location for the web app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->