### PR TITLE
fix(#91): read bandit config from toml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Bandit security scan
         working-directory: ${{ env.BACKEND_DIR }}
-        run: uv run bandit -r . --severity-level high --confidence-level high -f sarif -o bandit-results.sarif
+        run: uv run bandit -c pyproject.toml -r . --severity-level high --confidence-level high -f sarif -o bandit-results.sarif
         continue-on-error: true
 
       - name: Upload Bandit SARIF to GitHub Security

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -56,7 +56,7 @@ dev = [
     
     # Security Audit Tools
     "safety>=3.6.2",
-    "bandit>=1.8.6",
+    "bandit[toml]>=1.8.6",
     "bandit-sarif-formatter>=1.1.1",
 ]
 


### PR DESCRIPTION
## Summary
<!-- What changed and why? Include any context or screenshots that help reviewers. -->
Bandit didn't ignore .venv which results in audits for internals of used by us deps
e.g. https://github.com/ukma-cs-ssdm-2025/rate-ukma/security/code-scanning/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration security scanning to use a centralized project configuration, ensuring consistent rules across scans while maintaining non-blocking behavior on findings.
  * Updated development tooling to support the new configuration format for the security scanner, aligning local and CI environments.
  * No changes to user-facing functionality or behavior; these updates refine internal quality checks and maintain overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->