### PR TITLE
fix(#89): add proxy ssl header for https

### DIFF
--- a/src/backend/rateukma/settings/_base.py
+++ b/src/backend/rateukma/settings/_base.py
@@ -264,10 +264,3 @@ SAZ_PASSWORD = config("SAZ_PASSWORD", default="")
 
 # Base URL for parsing
 PARSE_BASE_URL = "https://my.ukma.edu.ua"
-
-# Session configuration
-SESSION_COOKIE_SECURE = not DEBUG
-CSRF_COOKIE_SECURE = not DEBUG
-
-# Proxy SSL header for HTTPS
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")

--- a/src/backend/rateukma/settings/prod.py
+++ b/src/backend/rateukma/settings/prod.py
@@ -1,2 +1,9 @@
 from ._base import *  # noqa: F403
 from ._logging import *  # noqa: F403
+
+# Session configuration
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+
+# Proxy SSL header for HTTPS
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
## Summary
Add proxy ssl header for https
This is a needed change for production env
Fixes #89



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened production security: session and CSRF cookies are now enforced as secure and the app properly detects HTTPS when behind a proxy, improving session protection and cross-site request forgery defenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->