### PR TITLE
fix(#118): fix django static and media folders mount path

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -19,10 +19,13 @@ services:
     container_name: "${COMPOSE_PROJECT_NAME}_django_backend"
     env_file:
       - .env
+    environment:
+      - STATIC_ROOT=/static
+      - MEDIA_ROOT=/media
     volumes:
       - ./backend:/app
-      - ${MEDIA_ROOT}:${MEDIA_ROOT}
-      - ${STATIC_ROOT}:${STATIC_ROOT}
+      - ${STATIC_ROOT}:/static
+      - ${MEDIA_ROOT}:/media
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
Fixed django static and media files container folder path in bind mount
Tested on staging server
Resolves #118



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized backend configuration for static and media handling by defining container paths for static and media files and updating volume bindings accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->