### PR TITLE
ci(#169): run docker build in parallel with other jobs

### DIFF
--- a/.github/workflows/dev-pipeline.yml
+++ b/.github/workflows/dev-pipeline.yml
@@ -14,5 +14,4 @@ jobs:
     secrets: inherit
 
   build:
-    needs: [test, openapi-validation, audit]
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   test:
@@ -18,7 +18,6 @@ jobs:
     secrets: inherit
 
   build:
-    needs: [test, openapi-validation, audit]
     uses: ./.github/workflows/build.yml
 
   deploy-staging:

--- a/.github/workflows/prod-pipeline.yml
+++ b/.github/workflows/prod-pipeline.yml
@@ -19,7 +19,6 @@ jobs:
     secrets: inherit
 
   build:
-    needs: [test, openapi-validation, audit]
     uses: ./.github/workflows/build.yml
 
   deploy-live:


### PR DESCRIPTION
## Summary
Simple change - run build step in parallel with other pre-deploy jobs
Resolves #169




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline workflows by removing explicit job interdependencies in dev, main, and prod pipelines, enabling improved build execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->