### PR TITLE
ci(#191): disable concurrent runs for all deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ env:
   SERVICES_HEALTHCHECK_TIMEOUT: 10
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: deploy-${{ inputs.environment }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
disabled concurrent runs for all deployment workflows
Resolves #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced deployment workflow concurrency to prevent overlapping runs and automatically cancel in-progress deployments, improving deployment reliability and resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->