### PR TITLE
fix(#297): fix pushing unversioned images to repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: docker compose --profile prod build --build-arg BACKEND_IMAGE_TAG=${BACKEND_IMAGE_TAG} backend
 
       - name: Push backend image
-        if: inputs.version_tag != ''
+        if: inputs.version_tag
         env:
           BACKEND_IMAGE_TAG: ${{ inputs.version_tag }}
         working-directory: ${{ env.SOURCE_CODE_DIR }}
@@ -110,7 +110,7 @@ jobs:
             webapp-build
 
       - name: Push staging webapp
-        if: inputs.version_tag != ''
+        if: inputs.version_tag
         env:
           WEBAPP_IMAGE_TAG: staging-${{ inputs.version_tag }}
         working-directory: ${{ env.SOURCE_CODE_DIR }}
@@ -131,7 +131,7 @@ jobs:
             webapp-build
 
       - name: Push live webapp
-        if: inputs.version_tag != ''
+        if: inputs.version_tag
         env:
           WEBAPP_IMAGE_TAG: live-${{ inputs.version_tag }}
         working-directory: ${{ env.SOURCE_CODE_DIR }}

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -57,7 +57,7 @@ jobs:
     needs: [version, test, openapi-validation, audit, changes-filter]
     uses: ./.github/workflows/build.yml
     with:
-      version_tag: ${{ needs.version.outputs.version_tag || '' }}
+      version_tag: ${{ needs.version.outputs.version_tag }}
       backend_changed: ${{ fromJSON(needs.changes-filter.outputs.backend_changed) }}
       webapp_changed: ${{ fromJSON(needs.changes-filter.outputs.webapp_changed) }}
 

--- a/.github/workflows/prod-pipeline.yml
+++ b/.github/workflows/prod-pipeline.yml
@@ -71,7 +71,6 @@ jobs:
     needs: [changes-filter, test, openapi-validation, audit]
     uses: ./.github/workflows/build.yml
     with:
-      version_tag: ${{ inputs.version_tag }}
       backend_changed: ${{ fromJSON(needs.changes-filter.outputs.backend_changed) }}
       webapp_changed: ${{ fromJSON(needs.changes-filter.outputs.webapp_changed) }}
 


### PR DESCRIPTION
## Summary
Fix of pushing unversioned images to repo. The bug was in a default value on a version tag in build.yml
Resolves #297 

## Testing
Tested on private CI tester repo:
<img width="1021" height="437" alt="image" src="https://github.com/user-attachments/assets/bb95ee06-e712-49f2-b7c4-14e0d9c1648e" />
<img width="1000" height="458" alt="image" src="https://github.com/user-attachments/assets/bf6a9619-0661-4f25-b070-f169fc3d5a11" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD pipeline configuration to require explicit version tag specification for deployments, eliminating automatic "latest" defaults.
  * Streamlined workflow input handling by updating conditional checks and removing fallback values across build and deployment processes.
  * Improved deployment workflow clarity by enforcing stricter version specification requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->