### PR TITLE
fix(#296): allow concurrent jobs to wait for each other

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,7 +23,6 @@ permissions:
 
 concurrency:
   group: security-audit-${{ github.ref }}
-  cancel-in-progress: true
 
 env:
   FRONTEND_DIR: src/webapp

--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -52,7 +52,6 @@ env:
 
 concurrency:
   group: deploy-${{ github.workflow }} # main-pipeline or prod-pipeline
-  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
Removed cancel-in-progress concurrency attribute,  allowing concurrent jobs to wait for each other

Before->After
<img width="300" height="190" alt="image" src="https://github.com/user-attachments/assets/ba16fa7f-7762-40f7-944e-4bb873c9ff21" />
<img width="300" height="190" alt="image" src="https://github.com/user-attachments/assets/e4a638d2-7ad3-44d4-8063-1a95d5f19379" />
Resolves #296

## Testing
Tested in private CI testing repo