### PR TITLE
fix(#259): group courses by academic years

### DIFF
--- a/src/webapp/src/routes/my-ratings.tsx
+++ b/src/webapp/src/routes/my-ratings.tsx
@@ -127,10 +127,10 @@ interface YearGroup {
 	ratedCount: number;
 }
 
-const SEASON_ORDER: Record<string, number> = {
-	FALL: 1,
+const TERM_ORDER: Record<string, number> = {
+	SUMMER: 1,
 	SPRING: 2,
-	SUMMER: 3,
+	FALL: 3,
 };
 
 function getAcademicYear(
@@ -196,7 +196,7 @@ function groupRatingsByYearAndSemester(
 					? getSemesterTermDisplay(seasonRaw, "Невідомий семестр")
 					: "Семестр не вказано"
 				: "Без семестра";
-		const seasonOrder = SEASON_ORDER[seasonRaw ?? ""] ?? 99;
+		const seasonOrder = TERM_ORDER[seasonRaw ?? ""] ?? 99;
 
 		const yearEntry = years.get(yearKey);
 		if (yearEntry) {


### PR DESCRIPTION
## Summary
Courses on 'Мої оцінки' page are now grouped by academic years rather than calendar ones.
Resolves #259

<img width="1606" height="3147" alt="image" src="https://github.com/user-attachments/assets/269d32cd-7f73-4be1-bf22-04636100280f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved academic year calculation and display in the ratings view; year ranges now show correctly based on semester boundaries.
  * Adjusted term ordering and semester labeling to present semesters in a clearer, consistent sequence.
  * Better handling and labeling when semester or year data are missing or unknown; grouping and ordering now use the computed academic year for clearer presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->