### PR TITLE
fix(cache): invalidate analytics cache after rating change

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -7,9 +7,10 @@ paths:
   /api/v1/analytics/:
     get:
       operationId: analytics_list
-      description: Get course analytics with optional filtersReturns courses analytics
-        with aggregated ratings.
-      summary: Get course analytics
+      description: |-
+        Get courses analytics with optional filters.
+        Returns courses analytics with aggregated ratings.
+      summary: Get courses analytics
       parameters:
       - in: query
         name: avg_difficulty_max
@@ -179,7 +180,7 @@ paths:
   /api/v1/analytics/{course_id}/:
     get:
       operationId: analytics_retrieve
-      description: Get course analytics with optional filtersReturns courses analytics
+      description: Get course analytics with optional filtersReturns course's analytics
         with aggregated ratings.
       summary: Get course analytics
       parameters:

--- a/src/backend/rating_app/views/analytics.py
+++ b/src/backend/rating_app/views/analytics.py
@@ -31,8 +31,8 @@ class AnalyticsViewSet(viewsets.ViewSet):
     course_service: CourseService | None = None
 
     @extend_schema(
-        summary="Get course analytics",
-        description="Get course analytics with optional filters"
+        summary="Get courses analytics",
+        description="Get courses analytics with optional filters.\n"
         "Returns courses analytics with aggregated ratings.",
         parameters=to_openapi((CourseFilterCriteria, OpenApiParameter.QUERY)),
         responses=R_ANALYTICS,
@@ -54,7 +54,7 @@ class AnalyticsViewSet(viewsets.ViewSet):
     @extend_schema(
         summary="Get course analytics",
         description="Get course analytics with optional filters"
-        "Returns courses analytics with aggregated ratings.",
+        "Returns course's analytics with aggregated ratings.",
         parameters=to_openapi((CourseReadParams, OpenApiParameter.PATH)),
         responses=R_ANALYTICS,
     )

--- a/src/backend/rating_app/views/rating_viewset.py
+++ b/src/backend/rating_app/views/rating_viewset.py
@@ -136,8 +136,7 @@ class RatingViewSet(viewsets.ViewSet):
 
         rating = self.rating_service.create_rating(rating_params)
 
-        self.cache_manager.invalidate_pattern(f"*{str(student.id)}*")
-        self.cache_manager.invalidate_pattern("*RatingViewSet.list*")
+        self._invalidate_caches_after_rating_change(student)
 
         logger.info(
             "rating_created",
@@ -187,8 +186,7 @@ class RatingViewSet(viewsets.ViewSet):
 
         rating = self.rating_service.update_rating(rating, update_params)
 
-        self.cache_manager.invalidate_pattern(f"*{str(student.id)}*")
-        self.cache_manager.invalidate_pattern("*RatingViewSet.list*")
+        self._invalidate_caches_after_rating_change(student)
 
         logger.info("rating_updated", rating_id=rating.id)
         response_serializer = RatingReadSerializer(rating)
@@ -214,8 +212,7 @@ class RatingViewSet(viewsets.ViewSet):
 
         response_serializer = RatingReadSerializer(rating)
 
-        self.cache_manager.invalidate_pattern(f"*{str(student.id)}*")
-        self.cache_manager.invalidate_pattern("*RatingViewSet.list*")
+        self._invalidate_caches_after_rating_change(student)
 
         return Response(response_serializer.data, status=status.HTTP_200_OK)
 
@@ -231,7 +228,13 @@ class RatingViewSet(viewsets.ViewSet):
 
         self.rating_service.delete_rating(rating.id)
 
-        self.cache_manager.invalidate_pattern(f"*{str(student.id)}*")
-        self.cache_manager.invalidate_pattern("*RatingViewSet.list*")
+        self._invalidate_caches_after_rating_change(student)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _invalidate_caches_after_rating_change(self, student: Student) -> None:
+        assert self.cache_manager is not None
+
+        self.cache_manager.invalidate_pattern(f"*{str(student.id)}*")
+        self.cache_manager.invalidate_pattern("*RatingViewSet.list*")
+        self.cache_manager.invalidate_pattern("*AnalyticsViewSet.list*")


### PR DESCRIPTION
Added cache analytics invalidation after rating change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated analytics API endpoint descriptions for improved clarity and accuracy, refining terminology for singular and plural course references.

* **Refactor**
  * Consolidated cache invalidation logic to ensure consistent and efficient cache management across all rating modification operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->