### PR TITLE
chore(#403): cleanup 7-days old docker images in the end of deployment, fix retrieval of previous image tags

### DIFF
--- a/.github/workflows/deploy-script.yml
+++ b/.github/workflows/deploy-script.yml
@@ -208,7 +208,8 @@ jobs:
 
               # Get current image tags
               if [ -z "$PREV_WEBAPP_TAG" ]; then
-                PREV_WEBAPP_TAG=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "webapp.*live-" | head -1 | awk -F: '{print $2}' || echo "")
+                WEBAPP_PATTERN="webapp.*${ENVIRONMENT}-"
+                PREV_WEBAPP_TAG=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "$WEBAPP_PATTERN" | head -1 | awk -F: '{print $2}' || echo "")
               fi
               if [ -z "$PREV_BACKEND_TAG" ]; then
                 PREV_BACKEND_TAG=$(sudo docker images --format "{{.Repository}}:{{.Tag}}" | grep "backend.*v" | head -1 | awk -F: '{print $2}' || echo "")
@@ -279,14 +280,14 @@ jobs:
 
 
               echo "Deployment successful, cleaning up old images for the last 7 days..."
-              docker image prune -a -f --filter "until=168h"
-              docker container prune -f --filter "until=168h"
+              sudo docker image prune -a -f --filter "until=168h"
+              sudo docker container prune -f --filter "until=168h"
 
               echo "Cleaning up unused networks..."
-              docker network prune -f
+              sudo docker network prune -f
 
               echo "Reclaimed space:"
-              docker system df
+              sudo docker system df
 
               echo "Deployment successful"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stores previous deployment image tags to improve rollback safety and enable conditional rollback behavior.
  * Adds conditional shutdown that uses stored tags when available, otherwise proceeds with standard shutdown.
  * Enhances post-deployment cleanup: prunes recent images/containers (last 7 days), removes unused networks, and reports reclaimed disk space.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->