### PR TITLE
chore(ci): create guard condition against transitive dependencies skipping

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
 
   release:
     needs: [version, deploy-staging, release-needed]
-    if: needs.release-needed.outputs.release_needed == 'true'
+    if: always() && needs.release-needed.result != 'failure' && needs.release-needed.outputs.release_needed == 'true'
     uses: ./.github/workflows/release.yml
     with:
       version_tag: ${{ needs.version.outputs.version_tag }}


### PR DESCRIPTION
I have encountered such behavior of GH actions: when a job A has dependencies (e.g. job B), the result state of transitive "parent" dependencies of job B are shared (e.g. job C).  -> A needs B, B needs C

Therefore, if any previous dependant job is skipped (even without direct dependency), the given job is also skipped. -> If job C is skipped, and B is successful, job A is also skipped. 

There already are issues on this behaviour: https://github.com/actions/runner/issues/2205 

I have created a guard conditions to check only the direct dependencies of a "release" job after case of build https://github.com/ukma-cs-ssdm-2025/rate-ukma/actions/runs/20009133000, where it was skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline release process to improve reliability and support pre-release deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->