### PR TITLE
fix(#100): allow up to 3 newlines in the comment

### DIFF
--- a/src/backend/rating_app/services/rating_service.py
+++ b/src/backend/rating_app/services/rating_service.py
@@ -150,7 +150,7 @@ class RatingService(IObservable[Rating]):
 
     @staticmethod
     def _normalize_comment(comment: str | None) -> str | None:
-        if comment is "":
+        if comment == "":
             return comment
 
         # normalize line breaks

--- a/src/webapp/src/features/ratings/components/RatingComment.tsx
+++ b/src/webapp/src/features/ratings/components/RatingComment.tsx
@@ -8,7 +8,7 @@ export function RatingComment({
 	emptyMessage = "Студент не лишив коментар.",
 }: RatingCommentProps) {
 	if (comment) {
-		const formattedComment = comment.replace(/\n{4,}/g, "\n\n\n");
+		const formattedComment = comment.replaceAll(/\n{4,}/g, "\n\n\n");
 		return (
 			<p className="text-sm leading-relaxed text-foreground/90 whitespace-pre-wrap">
 				{formattedComment}


### PR DESCRIPTION
## Summary
Resolves #100



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Comments are cleaned and presented more consistently: line endings normalized to Unix style, sequences of excessive blank lines are collapsed (4+ → 3), and trailing spaces on each line are trimmed.
  * Normalization is applied both when comments are saved/updated and when rendered, producing cleaner, more predictable comment display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->