### PR TITLE
fix(#261): highlight the last course in the table

### DIFF
--- a/src/webapp/src/components/ui/Table.tsx
+++ b/src/webapp/src/components/ui/Table.tsx
@@ -34,7 +34,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
 	return (
 		<tbody
 			data-slot="table-body"
-			className={cn("[&_tr:last-child]:border-0", className)}
+			className={cn("[&_tr:last-child]:border-b-0", className)}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
## Summary
If a student attended all the courses in the table, the last one wouldn't be highlighted.
Resolves #261

## Testing
Before:
<img width="1175" height="1038" alt="image" src="https://github.com/user-attachments/assets/468228cd-3b91-4c54-a659-047007d2d863" />
After:
<img width="1162" height="1005" alt="image" src="https://github.com/user-attachments/assets/3e1c47cf-faa7-4daf-ad4e-8b95c3aa2c48" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table component styling to adjust the bottom border rendering on the last row for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->