### PR TITLE
fix(#281): reset rating list state when course changes

### DIFF
--- a/src/webapp/src/features/ratings/hooks/useInfiniteScrollRatings.ts
+++ b/src/webapp/src/features/ratings/hooks/useInfiniteScrollRatings.ts
@@ -27,8 +27,17 @@ export function useInfiniteScrollRatings(
 	const { pageSize = DEFAULT_PAGE_SIZE, separateCurrentUser = false } = options;
 
 	const [ratingsPage, setRatingsPage] = useState(1);
+	const [lastCourseId, setLastCourseId] = useState(courseId);
 	const [allRatings, setAllRatings] = useState<RatingRead[]>([]);
 	const [userRating, setUserRating] = useState<RatingRead | undefined>();
+
+	// Reset pagination and state when courseId changes (during render)
+	if (courseId !== lastCourseId) {
+		setRatingsPage(1);
+		setAllRatings([]);
+		setUserRating(undefined);
+		setLastCourseId(courseId);
+	}
 
 	const { data: ratings, isLoading: isRatingsLoading } = useCoursesRatingsList(
 		courseId,
@@ -53,10 +62,13 @@ export function useInfiniteScrollRatings(
 
 			if (currentUserRatings && currentUserRatings.length > 0) {
 				setUserRating(currentUserRatings[0]);
+			} else if (ratingsPage === 1) {
+				setUserRating(undefined);
 			}
 
 			setAllRatings((prev) => {
 				if (ratingsPage === 1) {
+					// Always replace when on page 1 (initial load or after reset)
 					return ratingsList;
 				}
 				const existingIds = new Set(prev.map((r) => r.id));


### PR DESCRIPTION
## Summary
Fixed course data not updating after rating deletion (reason behind e2e failing).
Resolves #281

## Testing
Run e2e tests locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ratings pagination and user rating display when switching between courses. Ratings are now properly reset and isolated per course, preventing data from previous courses from appearing in the current course's ratings list. Pagination correctly restarts when viewing a new course, and rating status is properly updated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->