### PR TITLE
fix(#402): set default value for WEBAPP_IMAGE_TAG in docker-compose

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       - dev
 
   webapp-build:
-    image: ghcr.io/ukma-cs-ssdm-2025/rate-ukma/webapp:${WEBAPP_IMAGE_TAG}
+    image: ghcr.io/ukma-cs-ssdm-2025/rate-ukma/webapp:${WEBAPP_IMAGE_TAG:-latest}
     build:
       context: ..
       dockerfile: ./src/webapp/Dockerfile


### PR DESCRIPTION
Resolves #402



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to provide a default image tag fallback when not explicitly set.
  * Minor formatting adjustments to Docker configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->