### PR TITLE
feat(#384): ratings caching on service layer

### DIFF
--- a/src/backend/rating_app/services/rating_service.py
+++ b/src/backend/rating_app/services/rating_service.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 from django.db.models import QuerySet
 
+from rateukma.caching.decorators import rcached
 from rateukma.protocols import implements
 from rateukma.protocols.generic import IEventListener, IObservable
 from rating_app.application_schemas.pagination import PaginationMetadata
@@ -68,6 +69,7 @@ class RatingService(IObservable[Rating]):
     def get_aggregated_course_stats(self, course: Course) -> AggregatedCourseRatingStats:
         return self.rating_repository.get_aggregated_course_stats(course)
 
+    @rcached(ttl=300)
     def filter_ratings(
         self,
         filters: RatingFilterCriteria,

--- a/src/backend/rating_app/views/rating_viewset.py
+++ b/src/backend/rating_app/views/rating_viewset.py
@@ -6,7 +6,6 @@ import structlog
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from pydantic import ValidationError as ModelValidationError
 
-from rateukma.caching.decorators import rcached
 from rating_app.application_schemas.rating import (
     RatingCourseFilterParams,
     RatingCreateParams,
@@ -58,7 +57,6 @@ class RatingViewSet(viewsets.ViewSet):
         ],
         responses=R_RATING_LIST,
     )
-    @rcached(ttl=300)
     @with_optional_student
     def list(self, request, course_id=None, student=None) -> Response:
         assert self.rating_service is not None


### PR DESCRIPTION
Resolves #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Ratings filtering operations now use result caching
  * Ratings list endpoint caching has been removed

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->