### PR TITLE
fix(#420): tighten Sentry payload and silence expected noise

### DIFF
--- a/src/backend/rateukma/settings/prod.py
+++ b/src/backend/rateukma/settings/prod.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import DisallowedHost
+
 import sentry_sdk
 
 from ._base import *  # noqa: F403
@@ -28,4 +30,8 @@ if SENTRY_DSN:
         # Set profile_lifecycle to "trace" to automatically
         # run the profiler on when there is an active transaction
         profile_lifecycle="trace",
+        # DisallowedHost is triggered by internet bots sending a raw bind-address
+        # (e.g. Host: 0.0.0.0) or invalid Host headers. Django already rejects
+        # these with HTTP 400 — there is nothing actionable for us to fix.
+        ignore_errors=[DisallowedHost],
     )


### PR DESCRIPTION
Closes #420

## What & Why

Three sources of Sentry noise fixed in one pass:

### 1. Strip PII from Axios error payload (frontend)
`captureException(error)` was sending the raw `AxiosError` to Sentry, which includes `config.data` (request body) and `response.data` (response body) — potential PII or large payloads. Now we send `new Error(error.message)` with only method/status/url/code in `tags` and `extra`.

### 2. Silence 401 from `/auth/session` (frontend)
Every page load calls `/auth/session` to check authentication. For unauthenticated users this returns 401 — a normal, expected state. `handleSessionExpiry` was already skipping this URL intentionally, but that caused it to fall through to `logErrorToSentry`. Added an early-return guard for `401 + /auth/session`.

### 3. Ignore `DisallowedHost` in backend Sentry (backend)
~1K Sentry events were coming from internet bot scanners probing for PHP admin panels (`/admin/config.php`) with `Host: 0.0.0.0`. Django correctly rejects these with HTTP 400 — nothing for us to fix. Added `ignore_errors=[DisallowedHost]` to `sentry_sdk.init()` to stop the noise.

## Test plan

- [ ] Verify no real errors are suppressed: load the app as authenticated user → no new Sentry events from normal usage
- [ ] Load app as unauthenticated user → no 401 Sentry events from `/auth/session`
- [ ] Trigger a real API error (e.g. network drop) → confirm it still appears in Sentry with method/status/url tags
- [ ] Deploy to staging → confirm `DisallowedHost` events stop appearing in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error monitoring to better handle authorization-related requests and reduce unnecessary error logs
  * Enhanced error reporting to prevent sensitive information from being transmitted in error logs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->