### PR TITLE
fix(#535): stabilize viewport width when scrollbars appear or disappear

### DIFF
--- a/src/webapp/src/styles.css
+++ b/src/webapp/src/styles.css
@@ -17,6 +17,19 @@ html {
 	scrollbar-gutter: stable;
 }
 
+/*
+ * react-remove-scroll-bar (used by Radix Dialog) adds margin-right to
+ * compensate for the removed scrollbar. With scrollbar-gutter: stable the
+ * browser already reserves that space, so the margin causes a double-offset
+ * layout shift. Override it when the gutter handles compensation natively.
+ * See: https://github.com/radix-ui/primitives/issues/3251
+ */
+@supports (scrollbar-gutter: stable) {
+	html body[data-scroll-locked] {
+		margin-right: 0 !important; /* biome-ignore lint/complexity/noImportantStyles: remove-scroll-bar override */
+	}
+}
+
 code {
 	font-family:
 		source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;


### PR DESCRIPTION
## Summary
(Reopened PR #538)
Resolves #535


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized scrollbar spacing to prevent layout shifts when scrollbars appear or disappear, improving visual consistency during scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->