### PR TITLE
fix(#582): increase instructor field length

### DIFF
--- a/src/backend/rating_app/application_schemas/rating.py
+++ b/src/backend/rating_app/application_schemas/rating.py
@@ -124,7 +124,7 @@ def strip_string(value: str | None) -> str | None:
     return stripped if stripped else None
 
 
-MAX_INSTRUCTOR_LENGTH = 30
+MAX_INSTRUCTOR_LENGTH = 256
 
 
 def strip_instructor(value: str | None) -> str | None:

--- a/src/backend/rating_app/migrations/0026_update_instructor_max_length.py
+++ b/src/backend/rating_app/migrations/0026_update_instructor_max_length.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("rating_app", "0025_add_instructor_to_rating"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="rating",
+            name="instructor",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Temporary free-text field; will be replaced with a verified instructor FK.",
+                max_length=256,
+            ),
+        ),
+    ]

--- a/src/backend/rating_app/models/rating.py
+++ b/src/backend/rating_app/models/rating.py
@@ -27,7 +27,7 @@ class Rating(models.Model):
     usefulness = models.IntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
     comment = models.TextField(blank=True, default="")
     instructor = models.CharField(
-        max_length=30,
+        max_length=256,
         blank=True,
         default="",
         help_text="Temporary free-text field; will be replaced with a verified instructor FK.",

--- a/src/backend/rating_app/views/test_rating.py
+++ b/src/backend/rating_app/views/test_rating.py
@@ -1274,7 +1274,7 @@ def test_create_rating_instructor_too_long(
         "course_offering": str(offering.id),
         "difficulty": 4,
         "usefulness": 5,
-        "instructor": "A" * 31,
+        "instructor": "A" * 257,
         "is_anonymous": False,
     }
 

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -93,8 +93,9 @@ export function RatingCardBody({
 			</div>
 
 			{instructor && (
-				<p className="mt-2 flex items-center gap-1 text-sm text-muted-foreground">
-					<span className="font-medium">Викладач:</span> {instructor}
+				<p className="mt-2 flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
+					<span className="shrink-0 font-medium">Викладач:</span>
+					<span className="min-w-0 break-words">{instructor}</span>
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<Info className="h-3.5 w-3.5 shrink-0 cursor-help text-muted-foreground/60" />

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -93,7 +93,7 @@ export function RatingCardBody({
 			</div>
 
 			{instructor && (
-				<p className="mt-2 flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
+				<p className="mt-2 flex min-w-0 items-start gap-1 text-sm text-muted-foreground">
 					<span className="shrink-0 font-medium">Викладач:</span>
 					<span className="min-w-0 break-words">{instructor}</span>
 					<Tooltip>

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -41,7 +41,7 @@ const ratingSchema = z.object({
 	// TODO: temporary free-text field; will be replaced with a verified instructor dropdown
 	instructor: z
 		.string()
-		.max(30, "Ім'я викладача не може перевищувати 30 символів")
+		.max(256, "Ім'я викладача не може перевищувати 256 символів")
 		.transform((val) => val?.trim() || undefined)
 		.optional(),
 	is_anonymous: z.boolean(),


### PR DESCRIPTION
## Summary
Increased instructor field length ( 30 -> 256), updated UI
Resolves #582



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instructor names can now accommodate up to 256 characters (previously limited to 30).
  * Improved display of longer instructor names with better text wrapping to prevent overflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->