### PR TITLE
fix(#473): nested comments cache

### DIFF
--- a/src/backend/rating_app/ioc_container/services.py
+++ b/src/backend/rating_app/ioc_container/services.py
@@ -171,10 +171,7 @@ def rating_vote_cache_invalidator() -> RatingVoteCacheInvalidator:
 
 @once
 def comment_cache_invalidator() -> CommentCacheInvalidator:
-    return CommentCacheInvalidator(
-        cache_manager=redis_cache_manager(),
-        comment_repository=comment_repository(),
-    )
+    return CommentCacheInvalidator(cache_manager=redis_cache_manager())
 
 
 @once

--- a/src/backend/rating_app/ioc_container/services.py
+++ b/src/backend/rating_app/ioc_container/services.py
@@ -171,7 +171,10 @@ def rating_vote_cache_invalidator() -> RatingVoteCacheInvalidator:
 
 @once
 def comment_cache_invalidator() -> CommentCacheInvalidator:
-    return CommentCacheInvalidator(cache_manager=redis_cache_manager())
+    return CommentCacheInvalidator(
+        cache_manager=redis_cache_manager(),
+        comment_repository=comment_repository(),
+    )
 
 
 @once

--- a/src/backend/rating_app/services/comment_events.py
+++ b/src/backend/rating_app/services/comment_events.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -14,3 +15,4 @@ class CommentAction(StrEnum):
 class CommentEvent:
     comment: CommentDTO
     action: CommentAction
+    parent_parent_id: uuid.UUID | None = None

--- a/src/backend/rating_app/services/comment_service.py
+++ b/src/backend/rating_app/services/comment_service.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from rateukma.caching.decorators import rcached
@@ -51,18 +52,27 @@ class CommentService(IObservable[CommentEvent]):
         self._listeners.append(observer)
 
     def create_comment(self, params: CommentCreateParams) -> CommentDTO:
-        self._validate_parent_comment_matches_rating(params)
+        parent = self._validate_parent_comment_matches_rating(params)
         params.content = self.comment_normalizer.normalize_comment(params.content)
         comment = self.comment_repository.create(params)
-        self._notify_comment(comment, CommentAction.CREATED)
+        self._notify_comment(
+            comment,
+            CommentAction.CREATED,
+            parent_parent_id=parent.parent_id if parent else None,
+        )
         return self._with_manage_permission(comment, params.user_id)
 
     def get_comment(self, comment_id: str) -> CommentDTO:
         return self.comment_repository.get_by_id(comment_id)
 
     def delete_comment(self, comment: CommentDTO) -> None:
+        parent_parent_id = self._get_parent_parent_id(comment)
         self.comment_repository.delete(str(comment.id))
-        self._notify_comment(comment, CommentAction.DELETED)
+        self._notify_comment(
+            comment,
+            CommentAction.DELETED,
+            parent_parent_id=parent_parent_id,
+        )
 
     def update_comment(
         self,
@@ -76,16 +86,39 @@ class CommentService(IObservable[CommentEvent]):
         self._notify_comment(updated_comment, CommentAction.UPDATED)
         return self._with_manage_permission(updated_comment, updated_comment.user_id)
 
-    def _notify_comment(self, comment: CommentDTO, action: CommentAction) -> None:
-        self.notify(CommentEvent(comment=comment, action=action))
+    def _notify_comment(
+        self,
+        comment: CommentDTO,
+        action: CommentAction,
+        parent_parent_id: uuid.UUID | None = None,
+    ) -> None:
+        self.notify(
+            CommentEvent(
+                comment=comment,
+                action=action,
+                parent_parent_id=parent_parent_id,
+            )
+        )
 
-    def _validate_parent_comment_matches_rating(self, params: CommentCreateParams) -> None:
+    def _validate_parent_comment_matches_rating(
+        self,
+        params: CommentCreateParams,
+    ) -> CommentDTO | None:
         if params.parent_comment is None:
-            return
+            return None
 
         parent = self.comment_repository.get_by_id(str(params.parent_comment))
         if parent.rating_id != params.rating_id:
             raise CommentParentRatingMismatchError()
+
+        return parent
+
+    def _get_parent_parent_id(self, comment: CommentDTO) -> uuid.UUID | None:
+        if comment.parent_id is None:
+            return None
+
+        parent = self.comment_repository.get_by_id(str(comment.parent_id))
+        return parent.parent_id
 
     @rcached(ttl=300, versioned_by=_comments_namespace)
     def filter_comments(

--- a/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
@@ -11,8 +11,12 @@ from rateukma.protocols import implements
 from rateukma.protocols.generic import IEventListener
 from rating_app.application_schemas.rating import Rating as RatingDTO
 from rating_app.application_schemas.rating_vote import RatingVote as RatingVoteDTO
-from rating_app.repositories import RatingRepository
-from rating_app.services.comment_events import CommentEvent
+from rating_app.exception.comment_exception import (
+    CommentNotFoundError,
+    InvalidCommentIdentifierError,
+)
+from rating_app.repositories import CommentRepository, RatingRepository
+from rating_app.services.comment_events import CommentAction, CommentEvent
 
 # TODO: implement a generic cache invalidator with patterns
 
@@ -44,8 +48,13 @@ class RatingVoteCacheInvalidator(IEventListener[RatingVoteDTO]):
 
 
 class CommentCacheInvalidator(IEventListener[CommentEvent]):
-    def __init__(self, cache_manager: ICacheManager):
+    def __init__(
+        self,
+        cache_manager: ICacheManager,
+        comment_repository: CommentRepository,
+    ):
         self.cache_manager = cache_manager
+        self.comment_repository = comment_repository
 
     @implements
     def on_event(self, event: CommentEvent, *args, **kwargs) -> None:
@@ -54,5 +63,16 @@ class CommentCacheInvalidator(IEventListener[CommentEvent]):
         self.cache_manager.bump_version(comment_replies_namespace(str(comment.id)))
         if comment.parent_id is not None:
             self.cache_manager.bump_version(comment_replies_namespace(str(comment.parent_id)))
+            if event.action in (CommentAction.CREATED, CommentAction.DELETED):
+                self._bump_parent_container_replies_namespace(str(comment.parent_id))
 
         self.cache_manager.bump_version(course_ratings_namespace(str(comment.course_id)))
+
+    def _bump_parent_container_replies_namespace(self, parent_id: str) -> None:
+        try:
+            parent = self.comment_repository.get_by_id(parent_id)
+        except (CommentNotFoundError, InvalidCommentIdentifierError):
+            return
+
+        if parent.parent_id is not None:
+            self.cache_manager.bump_version(comment_replies_namespace(str(parent.parent_id)))

--- a/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
@@ -71,7 +71,7 @@ class CommentCacheInvalidator(IEventListener[CommentEvent]):
     def _bump_parent_container_replies_namespace(self, parent_id: str) -> None:
         try:
             parent = self.comment_repository.get_by_id(parent_id)
-        except (CommentNotFoundError, InvalidCommentIdentifierError):
+        except (CommentNotFoundError):
             return
 
         if parent.parent_id is not None:

--- a/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/cache_invalidator.py
@@ -11,11 +11,7 @@ from rateukma.protocols import implements
 from rateukma.protocols.generic import IEventListener
 from rating_app.application_schemas.rating import Rating as RatingDTO
 from rating_app.application_schemas.rating_vote import RatingVote as RatingVoteDTO
-from rating_app.exception.comment_exception import (
-    CommentNotFoundError,
-    InvalidCommentIdentifierError,
-)
-from rating_app.repositories import CommentRepository, RatingRepository
+from rating_app.repositories import RatingRepository
 from rating_app.services.comment_events import CommentAction, CommentEvent
 
 # TODO: implement a generic cache invalidator with patterns
@@ -48,13 +44,8 @@ class RatingVoteCacheInvalidator(IEventListener[RatingVoteDTO]):
 
 
 class CommentCacheInvalidator(IEventListener[CommentEvent]):
-    def __init__(
-        self,
-        cache_manager: ICacheManager,
-        comment_repository: CommentRepository,
-    ):
+    def __init__(self, cache_manager: ICacheManager):
         self.cache_manager = cache_manager
-        self.comment_repository = comment_repository
 
     @implements
     def on_event(self, event: CommentEvent, *args, **kwargs) -> None:
@@ -64,15 +55,10 @@ class CommentCacheInvalidator(IEventListener[CommentEvent]):
         if comment.parent_id is not None:
             self.cache_manager.bump_version(comment_replies_namespace(str(comment.parent_id)))
             if event.action in (CommentAction.CREATED, CommentAction.DELETED):
-                self._bump_parent_container_replies_namespace(str(comment.parent_id))
+                self._bump_parent_container_replies_namespace(event)
 
         self.cache_manager.bump_version(course_ratings_namespace(str(comment.course_id)))
 
-    def _bump_parent_container_replies_namespace(self, parent_id: str) -> None:
-        try:
-            parent = self.comment_repository.get_by_id(parent_id)
-        except (CommentNotFoundError, InvalidCommentIdentifierError):
-            return
-
-        if parent.parent_id is not None:
-            self.cache_manager.bump_version(comment_replies_namespace(str(parent.parent_id)))
+    def _bump_parent_container_replies_namespace(self, event: CommentEvent) -> None:
+        if event.parent_parent_id is not None:
+            self.cache_manager.bump_version(comment_replies_namespace(str(event.parent_parent_id)))

--- a/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
@@ -158,10 +158,15 @@ class TestCommentCacheInvalidator:
         cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
         assert cache_manager.bump_version.call_count == 4
 
-    def test_bumps_parent_container_replies_namespace_for_nested_reply_create(
+    @pytest.mark.parametrize(
+        "action",
+        [CommentAction.CREATED, CommentAction.DELETED],
+    )
+    def test_bumps_parent_container_replies_namespace_for_nested_reply_count_changes(
         self,
         invalidator,
         cache_manager,
+        action,
     ):
         grandparent_id = uuid.uuid4()
         parent_id = uuid.uuid4()
@@ -169,7 +174,7 @@ class TestCommentCacheInvalidator:
         comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
         event = CommentEvent(
             comment=comment,
-            action=CommentAction.CREATED,
+            action=action,
             parent_parent_id=grandparent_id,
         )
 

--- a/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
@@ -122,17 +122,8 @@ class TestCommentCacheInvalidator:
         return MagicMock()
 
     @pytest.fixture
-    def comment_repository(self):
-        repository = MagicMock()
-        repository.get_by_id.return_value = _make_comment_dto()
-        return repository
-
-    @pytest.fixture
-    def invalidator(self, cache_manager, comment_repository):
-        return CommentCacheInvalidator(
-            cache_manager=cache_manager,
-            comment_repository=comment_repository,
-        )
+    def invalidator(self, cache_manager):
+        return CommentCacheInvalidator(cache_manager=cache_manager)
 
     def test_bumps_rating_comments_and_course_ratings_namespaces(
         self,
@@ -171,17 +162,16 @@ class TestCommentCacheInvalidator:
         self,
         invalidator,
         cache_manager,
-        comment_repository,
     ):
         grandparent_id = uuid.uuid4()
         parent_id = uuid.uuid4()
         course_id = uuid.uuid4()
-        comment_repository.get_by_id.return_value = _make_comment_dto(
-            parent_id=grandparent_id,
-            course_id=course_id,
-        )
         comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
-        event = CommentEvent(comment=comment, action=CommentAction.CREATED)
+        event = CommentEvent(
+            comment=comment,
+            action=CommentAction.CREATED,
+            parent_parent_id=grandparent_id,
+        )
 
         invalidator.on_event(event)
 

--- a/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
@@ -122,8 +122,17 @@ class TestCommentCacheInvalidator:
         return MagicMock()
 
     @pytest.fixture
-    def invalidator(self, cache_manager):
-        return CommentCacheInvalidator(cache_manager=cache_manager)
+    def comment_repository(self):
+        repository = MagicMock()
+        repository.get_by_id.return_value = _make_comment_dto()
+        return repository
+
+    @pytest.fixture
+    def invalidator(self, cache_manager, comment_repository):
+        return CommentCacheInvalidator(
+            cache_manager=cache_manager,
+            comment_repository=comment_repository,
+        )
 
     def test_bumps_rating_comments_and_course_ratings_namespaces(
         self,
@@ -157,3 +166,25 @@ class TestCommentCacheInvalidator:
 
         cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
         assert cache_manager.bump_version.call_count == 4
+
+    def test_bumps_parent_container_replies_namespace_for_nested_reply_create(
+        self,
+        invalidator,
+        cache_manager,
+        comment_repository,
+    ):
+        grandparent_id = uuid.uuid4()
+        parent_id = uuid.uuid4()
+        course_id = uuid.uuid4()
+        comment_repository.get_by_id.return_value = _make_comment_dto(
+            parent_id=grandparent_id,
+            course_id=course_id,
+        )
+        comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
+        event = CommentEvent(comment=comment, action=CommentAction.CREATED)
+
+        invalidator.on_event(event)
+
+        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
+        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(grandparent_id)))
+        assert cache_manager.bump_version.call_count == 5

--- a/src/backend/rating_app/services/test_comment_service.py
+++ b/src/backend/rating_app/services/test_comment_service.py
@@ -80,6 +80,40 @@ def test_create_comment_notifies_created_action(
     )
 
 
+def test_create_nested_reply_notifies_with_parent_parent_id(
+    service,
+    comment_repository,
+    comment_normalizer,
+):
+    listener = MagicMock()
+    service.add_observer(listener)
+    rating_id = uuid.uuid4()
+    parent_id = uuid.uuid4()
+    grandparent_id = uuid.uuid4()
+    parent = _make_comment_dto(rating_id=rating_id, parent_id=grandparent_id)
+    params = CommentCreateParams(
+        rating_id=rating_id,
+        user_id=1,
+        parent_comment=parent_id,
+        content=" Nested reply ",
+        is_anonymous=False,
+    )
+    comment = _make_comment_dto(rating_id=rating_id, parent_id=parent_id)
+    comment_repository.get_by_id.return_value = parent
+    comment_repository.create.return_value = comment
+    comment_normalizer.normalize_comment.return_value = "Nested reply"
+
+    service.create_comment(params)
+
+    listener.on_event.assert_called_once_with(
+        CommentEvent(
+            comment=comment,
+            action=CommentAction.CREATED,
+            parent_parent_id=grandparent_id,
+        )
+    )
+
+
 def test_create_comment_rejects_parent_from_another_rating(
     service,
     comment_repository,
@@ -116,6 +150,32 @@ def test_delete_comment_notifies_deleted_action(service, comment_repository):
         CommentEvent(comment=comment, action=CommentAction.DELETED)
     )
     comment_repository.delete.assert_called_once_with(str(comment.id))
+
+
+def test_delete_nested_reply_notifies_with_parent_parent_id(service, comment_repository):
+    listener = MagicMock()
+    service.add_observer(listener)
+    parent_id = uuid.uuid4()
+    grandparent_id = uuid.uuid4()
+    comment = _make_comment_dto(parent_id=parent_id)
+    parent = _make_comment_dto(
+        rating_id=comment.rating_id,
+        parent_id=grandparent_id,
+        course_id=comment.course_id,
+    )
+    comment_repository.get_by_id.return_value = parent
+
+    service.delete_comment(comment)
+
+    comment_repository.get_by_id.assert_called_once_with(str(parent_id))
+    comment_repository.delete.assert_called_once_with(str(comment.id))
+    listener.on_event.assert_called_once_with(
+        CommentEvent(
+            comment=comment,
+            action=CommentAction.DELETED,
+            parent_parent_id=grandparent_id,
+        )
+    )
 
 
 def test_delete_comment_does_not_notify_when_repository_fails(service, comment_repository):

--- a/src/backend/rating_app/views/test_comment.py
+++ b/src/backend/rating_app/views/test_comment.py
@@ -169,6 +169,44 @@ def test_comment_reply_caches_invalidated_after_reply_create(
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_nested_reply_create_invalidates_parent_replies_cache(
+    token_client,
+    rating_factory,
+    comment_factory,
+):
+    rating = rating_factory()
+    parent = comment_factory(rating=rating)
+    reply = comment_factory(rating=rating, parent_comment=parent)
+
+    response = token_client.get(f"/api/v1/comments/{parent.id}/replies/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["replies_count"] == 0
+
+    response = token_client.get(f"/api/v1/comments/{reply.id}/replies/")
+    assert response.status_code == 200
+    assert response.json()["total"] == 0
+
+    payload = {
+        "content": "Fresh nested reply",
+        "parent_comment": str(reply.id),
+        "is_anonymous": False,
+    }
+    response = token_client.post(f"/api/v1/ratings/{rating.id}/comments/", payload, format="json")
+    assert response.status_code == 201
+
+    response = token_client.get(f"/api/v1/comments/{parent.id}/replies/")
+    assert response.status_code == 200
+    assert response.json()["items"][0]["replies_count"] == 1
+
+    response = token_client.get(f"/api/v1/comments/{reply.id}/replies/")
+    data = response.json()
+    assert response.status_code == 200
+    assert data["total"] == 1
+    assert data["items"][0]["content"] == "Fresh nested reply"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_comment_reply_parent_must_belong_to_rating(
     token_client,
     rating_factory,

--- a/src/webapp/src/features/ratings/components/RatingComments.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingComments.test.tsx
@@ -383,6 +383,87 @@ describe("RatingComments", () => {
 		});
 	});
 
+	it("invalidates the parent replies cache when creating a nested reply", async () => {
+		const user = userEvent.setup();
+		apiMocks.ratingsCommentsList.mockResolvedValue(
+			mockCommentList([
+				{
+					id: "comment-1",
+					rating_id: "rating-1",
+					parent_id: null,
+					content: "Parent comment",
+					user_id: 8,
+					user_name: "Parent Author",
+					user_avatar_url: null,
+					is_anonymous: false,
+					created_at: "2026-05-11T12:00:00Z",
+					replies_count: 1,
+				},
+			]),
+		);
+		apiMocks.commentsRepliesRetrieve.mockImplementation((commentId: string) =>
+			Promise.resolve(
+				commentId === "comment-1"
+					? mockCommentList([
+							{
+								id: "reply-1",
+								rating_id: "rating-1",
+								parent_id: "comment-1",
+								content: "Reply body",
+								user_id: 7,
+								user_name: "Reply Author",
+								user_avatar_url: null,
+								is_anonymous: false,
+								created_at: "2026-05-11T12:05:00Z",
+								replies_count: 0,
+							},
+						])
+					: mockCommentList([]),
+			),
+		);
+		const { queryClient } = renderWithQuery(
+			<RatingComments ratingId="rating-1" commentsCount={2} />,
+		);
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+		await user.click(screen.getByTestId(testIds.comments.toggleButton));
+		await screen.findByText("Parent comment");
+		await user.click(screen.getByRole("button", { name: /1/ }));
+		const replyItem = (await screen.findByText("Reply body")).closest(
+			`[data-testid="${testIds.comments.item}"]`,
+		);
+		expect(replyItem).not.toBeNull();
+
+		await user.click(within(replyItem as HTMLElement).getByRole("button"));
+		await user.type(
+			within(replyItem as HTMLElement).getByTestId(testIds.comments.textarea),
+			"Nested reply",
+		);
+		await user.click(
+			within(replyItem as HTMLElement).getByTestId(
+				testIds.comments.submitButton,
+			),
+		);
+
+		expect(apiMocks.createComment).toHaveBeenCalledWith({
+			ratingId: "rating-1",
+			data: {
+				content: "Nested reply",
+				is_anonymous: false,
+				parent_comment: "reply-1",
+			},
+		});
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["comment-replies", "reply-1"],
+		});
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["comment-replies", "comment-1"],
+		});
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: ["rating-comments", "rating-1"],
+		});
+	});
+
 	it("creates a top-level comment", async () => {
 		const user = userEvent.setup();
 

--- a/src/webapp/src/features/ratings/components/RatingComments.tsx
+++ b/src/webapp/src/features/ratings/components/RatingComments.tsx
@@ -62,6 +62,7 @@ interface RatingCommentItemProps {
 	readonly comment: CommentRead;
 	readonly ratingId: string;
 	readonly courseId?: string;
+	readonly parentListCommentId?: string | null;
 }
 
 interface CommentActionsProps {
@@ -87,6 +88,19 @@ function invalidateRatingCommentQueries(
 			refetchType: "none",
 		});
 	}
+}
+
+function invalidateRepliesQuery(
+	queryClient: ReturnType<typeof useQueryClient>,
+	commentId: string | null | undefined,
+) {
+	if (!commentId) {
+		return;
+	}
+
+	queryClient.invalidateQueries({
+		queryKey: getCommentsRepliesRetrieveQueryKey(commentId),
+	});
 }
 
 function getAuthorName(author: {
@@ -397,6 +411,7 @@ function RatingCommentItem({
 	comment,
 	ratingId,
 	courseId,
+	parentListCommentId = null,
 }: RatingCommentItemProps) {
 	const queryClient = useQueryClient();
 	const [isReplying, setIsReplying] = useState(false);
@@ -440,9 +455,8 @@ function RatingCommentItem({
 
 		setIsReplying(false);
 		setShowReplies(true);
-		queryClient.invalidateQueries({
-			queryKey: getCommentsRepliesRetrieveQueryKey(commentId),
-		});
+		invalidateRepliesQuery(queryClient, commentId);
+		invalidateRepliesQuery(queryClient, comment.parent_id);
 		invalidateRatingCommentQueries(queryClient, ratingId, courseId);
 		toast.success("Відповідь додано");
 	};
@@ -473,11 +487,8 @@ function RatingCommentItem({
 	const handleDelete = async () => {
 		try {
 			await deleteComment.mutateAsync({ commentId });
-			queryClient.invalidateQueries({
-				queryKey: comment.parent_id
-					? getCommentsRepliesRetrieveQueryKey(comment.parent_id)
-					: getRatingsCommentsListQueryKey(ratingId),
-			});
+			invalidateRepliesQuery(queryClient, comment.parent_id);
+			invalidateRepliesQuery(queryClient, parentListCommentId);
 			invalidateRatingCommentQueries(queryClient, ratingId, courseId);
 			toast.success("Коментар видалено");
 		} catch (error) {
@@ -505,6 +516,7 @@ function RatingCommentItem({
 							comment={reply}
 							ratingId={ratingId}
 							courseId={courseId}
+							parentListCommentId={comment.parent_id}
 						/>
 					))}
 					{repliesQuery.hasNextPage && (


### PR DESCRIPTION
isRelatedTo #473

## Bug
Nested replies did not appear after being created.
For example:
```text
Comment A
  Reply B
    Reply C
```
the backend invalidated the cache for replies under B, so C itself could be fetched. But it did not invalidate the cache for replies under A, where B is displayed with its replies_count. Because of that, B could still look like it had 0 replies, so the UI did not immediately show the next level until the cache refreshed later.

## Fix
The bug was fixed by invalidating one more cache namespace when a nested reply is created or deleted. The backend now fetches the direct parent comment and, if that parent is also a reply, invalidates the parent’s container list too. So in the A -> B -> C case, creating C invalidates both the replies under B and the cached list under A.

The frontend React Query invalidation was also updated so already-loaded nested reply queries are refreshed locally.

Regression tests were added for both backend cache invalidation and frontend nested reply behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Nested replies (replies to replies) now properly refresh parent comment caches when created or deleted, ensuring all reply lists display accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->