### PR TITLE
ci: add k8s-beta webapp build target for k8s-beta.rateukma.com

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
             api_url_var: STAGING_URL
           - environment: live
             api_url_var: LIVE_URL
+          - environment: k8s-beta
+            api_url_var: K8S_BETA_URL
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Quick PR for creating a specific image tag for beta Kubernetes deployment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new `k8s-beta` environment configuration to the build pipeline, enabling application builds for beta Kubernetes deployments with dedicated API URL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->