### PR TITLE
feat(#563): instructor multi-select on ratings + courses filter

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -3235,6 +3235,11 @@ components:
           type: string
           readOnly: true
           nullable: true
+        instructors:
+          type: array
+          items:
+            $ref: '#/components/schemas/RatingInstructor'
+          readOnly: true
         created_at:
           type: string
           format: date-time

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -91,15 +91,6 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
-        name: last_review_order
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        description: Sort order for most recent review timestamp (asc/desc); courses
-          without reviews appear last in both directions
-      - in: query
         name: name
         schema:
           type: string
@@ -956,15 +947,6 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
-        name: last_review_order
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        description: Sort order for most recent review timestamp (asc/desc); courses
-          without reviews appear last in both directions
-      - in: query
         name: name
         schema:
           type: string
@@ -1764,23 +1746,90 @@ paths:
                     detail: You do not have permission to perform this action
                     status: 403
           description: Forbidden
-  /api/v1/flags/:
+  /api/v1/instructors/:
     get:
-      operationId: flags_list
-      summary: List public feature flags evaluated for the current user
+      operationId: instructors_list
+      description: Paginated instructor list ordered by mention count. Pass `course_offering_id`
+        and/or `speciality_id` to boost instructors most mentioned on that course
+        offering or speciality.
+      summary: List instructors
+      parameters:
+      - in: query
+        name: course_offering_id
+        schema:
+          type: string
+          format: uuid
+        description: Boost instructors most mentioned on this course offering
+      - in: query
+        name: page
+        schema:
+          type: integer
+        description: Page number (1-based)
+      - in: query
+        name: page_size
+        schema:
+          type: integer
+        description: Page size
+      - in: query
+        name: search
+        schema:
+          type: string
+        description: Substring match on name or email (case-insensitive)
+      - in: query
+        name: speciality_id
+        schema:
+          type: string
+          format: uuid
+        description: Boost instructors most mentioned on this speciality
       tags:
-      - flags
+      - instructors
       security:
       - cookieAuth: []
       - tokenAuth: []
-      - {}
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/FeatureFlags'
+                $ref: '#/components/schemas/InstructorListResponse'
           description: OK
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                ValidationError:
+                  value:
+                    detail: Validation failed
+                    status: 400
+                    fields:
+                      difficulty:
+                      - Must be between 1 and 5.
+                  summary: Validation error
+          description: Bad request
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                Unauthorized:
+                  value:
+                    detail: Authentication credentials were not provided
+                    status: 401
+          description: Unauthorized
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorEnvelope'
+              examples:
+                Forbidden:
+                  value:
+                    detail: You do not have permission to perform this action
+                    status: 403
+          description: Forbidden
   /api/v1/instructors/{instructor_id}:
     get:
       operationId: instructors_retrieve
@@ -3089,16 +3138,6 @@ components:
       - id
       - name
       - specialities
-    FeatureFlags:
-      type: object
-      properties:
-        flags:
-          type: object
-          additionalProperties:
-            type: boolean
-          readOnly: true
-          description: Map of public feature flag name to its enabled state for the
-            current user.
     FilterOptions:
       type: object
       properties:
@@ -3266,6 +3305,38 @@ components:
           type: string
           format: email
           readOnly: true
+    InstructorListResponse:
+      type: object
+      description: Schema for GET /api/v1/instructors/ response envelope.
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Instructor'
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total:
+          type: integer
+        total_pages:
+          type: integer
+        next_page:
+          type: integer
+          minimum: 1
+          nullable: true
+        previous_page:
+          type: integer
+          minimum: 1
+          nullable: true
+      required:
+      - items
+      - next_page
+      - page
+      - page_size
+      - previous_page
+      - total
+      - total_pages
     InstructorOption:
       type: object
       properties:
@@ -3375,6 +3446,13 @@ components:
           default: null
           title: Instructor
           type: string
+        instructor_ids:
+          default: null
+          items:
+            format: uuid
+            type: string
+          title: Instructor Ids
+          type: array
         is_anonymous:
           default: null
           title: Is Anonymous
@@ -3412,10 +3490,17 @@ components:
           type: string
         instructor:
           default: null
-          description: Temp. free-text instructor name; will be replaced with a verified
-            dropdown.
+          description: Legacy free-text instructor name. Kept for backward compatibility
+            with old clients. New clients should populate `instructor_ids` instead.
           title: Instructor
           type: string
+        instructor_ids:
+          description: UUIDs of Instructor entities mentioned in this rating.
+          items:
+            format: uuid
+            type: string
+          title: Instructor Ids
+          type: array
         is_anonymous:
           default: false
           title: Is Anonymous
@@ -3426,6 +3511,26 @@ components:
       - usefulness
       title: RatingCreateRequest
       type: object
+    RatingInstructor:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          readOnly: true
+        first_name:
+          type: string
+          readOnly: true
+        patronymic:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
     RatingPutParams:
       properties:
         difficulty:
@@ -3446,6 +3551,12 @@ components:
           default: null
           title: Instructor
           type: string
+        instructor_ids:
+          items:
+            format: uuid
+            type: string
+          title: Instructor Ids
+          type: array
         is_anonymous:
           default: false
           title: Is Anonymous
@@ -3506,6 +3617,11 @@ components:
           type: string
           readOnly: true
           nullable: true
+        instructors:
+          type: array
+          items:
+            $ref: '#/components/schemas/RatingInstructor'
+          readOnly: true
         is_anonymous:
           type: boolean
           readOnly: true

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -1755,6 +1755,12 @@ paths:
       summary: List instructors
       parameters:
       - in: query
+        name: course_id
+        schema:
+          type: string
+          format: uuid
+        description: Boost instructors mentioned on any offering of this course
+      - in: query
         name: course_offering_id
         schema:
           type: string

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -3311,10 +3311,6 @@ components:
         last_name:
           type: string
           readOnly: true
-        email:
-          type: string
-          format: email
-          readOnly: true
     InstructorListResponse:
       type: object
       description: Schema for GET /api/v1/instructors/ response envelope.
@@ -3536,10 +3532,6 @@ components:
           readOnly: true
         last_name:
           type: string
-          readOnly: true
-        email:
-          type: string
-          format: email
           readOnly: true
     RatingPutParams:
       properties:

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -91,6 +91,15 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
+        name: last_review_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for most recent review timestamp (asc/desc); courses
+          without reviews appear last in both directions
+      - in: query
         name: name
         schema:
           type: string
@@ -947,6 +956,15 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
+        name: last_review_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for most recent review timestamp (asc/desc); courses
+          without reviews appear last in both directions
+      - in: query
         name: name
         schema:
           type: string
@@ -1746,6 +1764,23 @@ paths:
                     detail: You do not have permission to perform this action
                     status: 403
           description: Forbidden
+  /api/v1/flags/:
+    get:
+      operationId: flags_list
+      summary: List public feature flags evaluated for the current user
+      tags:
+      - flags
+      security:
+      - cookieAuth: []
+      - tokenAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureFlags'
+          description: OK
   /api/v1/instructors/:
     get:
       operationId: instructors_list
@@ -3144,6 +3179,16 @@ components:
       - id
       - name
       - specialities
+    FeatureFlags:
+      type: object
+      properties:
+        flags:
+          type: object
+          additionalProperties:
+            type: boolean
+          readOnly: true
+          description: Map of public feature flag name to its enabled state for the
+            current user.
     FilterOptions:
       type: object
       properties:

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -3206,6 +3206,11 @@ components:
         instructor:
           type: string
           nullable: true
+        instructors:
+          type: array
+          items:
+            $ref: '#/components/schemas/RatingInstructor'
+          readOnly: true
         created_at:
           type: string
           format: date-time

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -1815,7 +1815,7 @@ paths:
         name: search
         schema:
           type: string
-        description: Substring match on name or email (case-insensitive)
+        description: Substring match on first name, last name or patronymic (case-insensitive)
       - in: query
         name: speciality_id
         schema:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -56,15 +56,18 @@ it ships with a deploy. **Toggling** an already-exposed flag is runtime-only
    const isOn = useFeatureFlag("fe_my_new_flag");
    return isOn ? <NewThing /> : <OldThing />;
    ```
-   For non-trivial content where a flash of the wrong variant matters, wait for
-   `isReady` so you do not render the OFF state before flags resolve:
+   For non-trivial content where a flash of the wrong variant matters, use
+   `useFeatureFlagState` — it returns the value *and* whether flags have
+   resolved, so an unresolved flag is not silently treated as OFF:
    ```tsx
-   import { useFeatureFlags } from "@/lib/feature-flags";
+   import { useFeatureFlagState } from "@/lib/feature-flags";
 
-   const { flags, isReady } = useFeatureFlags();
+   const { enabled, isReady } = useFeatureFlagState("fe_my_new_flag");
    if (!isReady) return null; // or a skeleton
-   return flags.fe_my_new_flag ? <NewThing /> : <OldThing />;
+   return enabled ? <NewThing /> : <OldThing />;
    ```
+   Gate write paths on `isReady` too — submitting before flags resolve can
+   persist the OFF variant's shape.
 
 ## Server-only flags
 

--- a/src/backend/rateukma/settings/_base.py
+++ b/src/backend/rateukma/settings/_base.py
@@ -319,4 +319,4 @@ PARSE_BASE_URL = "https://my.ukma.edu.ua"
 # ONLY when added to this allowlist in a reviewed PR — the endpoint fails closed,
 # so server-only flags can never leak through a naming mistake. `fe_` is a soft
 # naming convention for client-facing flags, not the security boundary.
-PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+PUBLIC_FEATURE_FLAGS = ["fe_test_header", "fe_instructor_multiselect"]

--- a/src/backend/rating_app/application_schemas/instructor.py
+++ b/src/backend/rating_app/application_schemas/instructor.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from pydantic import BaseModel, Field
 from pydantic.alias_generators import to_snake
 
+from rating_app.application_schemas.pagination import PaginationMetadata
+
 
 class InstructorReadParams(BaseModel):
     model_config = {
@@ -12,6 +14,28 @@ class InstructorReadParams(BaseModel):
     }
 
     instructor_id: uuid.UUID = Field(description="Unique identifier of instructor")
+
+
+class InstructorListParams(BaseModel):
+    model_config = {
+        "alias_generator": to_snake,
+        "populate_by_name": True,
+    }
+
+    page: int = Field(default=1, ge=1, description="Page number (1-based)")
+    page_size: int = Field(default=20, ge=1, le=100, description="Page size")
+    search: str | None = Field(
+        default=None,
+        description="Substring match on name or email (case-insensitive)",
+    )
+    course_offering_id: uuid.UUID | None = Field(
+        default=None,
+        description="Boost instructors most mentioned on this course offering",
+    )
+    speciality_id: uuid.UUID | None = Field(
+        default=None,
+        description="Boost instructors most mentioned on this speciality",
+    )
 
 
 @dataclass(frozen=True)
@@ -29,3 +53,9 @@ class Instructor:
     patronymic: str | None
     last_name: str
     email: str
+
+
+@dataclass(frozen=True)
+class InstructorListResult:
+    items: list[Instructor]
+    pagination: PaginationMetadata

--- a/src/backend/rating_app/application_schemas/instructor.py
+++ b/src/backend/rating_app/application_schemas/instructor.py
@@ -32,6 +32,10 @@ class InstructorListParams(BaseModel):
         default=None,
         description="Boost instructors most mentioned on this course offering",
     )
+    course_id: uuid.UUID | None = Field(
+        default=None,
+        description="Boost instructors mentioned on any offering of this course",
+    )
     speciality_id: uuid.UUID | None = Field(
         default=None,
         description="Boost instructors most mentioned on this speciality",

--- a/src/backend/rating_app/application_schemas/instructor.py
+++ b/src/backend/rating_app/application_schemas/instructor.py
@@ -26,7 +26,7 @@ class InstructorListParams(BaseModel):
     page_size: int = Field(default=20, ge=1, le=100, description="Page size")
     search: str | None = Field(
         default=None,
-        description="Substring match on name or email (case-insensitive)",
+        description="Substring match on first name, last name or patronymic (case-insensitive)",
     )
     course_offering_id: uuid.UUID | None = Field(
         default=None,

--- a/src/backend/rating_app/application_schemas/rating.py
+++ b/src/backend/rating_app/application_schemas/rating.py
@@ -136,6 +136,20 @@ def strip_instructor(value: str | None) -> str | None:
     return result
 
 
+class RatingInstructor(BaseModel):
+    model_config = {
+        "from_attributes": True,
+        "alias_generator": to_snake,
+        "populate_by_name": True,
+    }
+
+    id: uuid.UUID
+    first_name: str
+    patronymic: str | None = ""
+    last_name: str
+    email: str
+
+
 class Rating(BaseModel):
     model_config = {
         "from_attributes": True,
@@ -155,6 +169,7 @@ class Rating(BaseModel):
     usefulness: int
     comment: str | None
     instructor: str | None = None
+    instructors: list[RatingInstructor] = Field(default_factory=list)
     is_anonymous: bool
     created_at: datetime.datetime
 
@@ -191,7 +206,14 @@ class RatingCreateRequest(BaseModel):
     )
     instructor: Annotated[str | SkipJsonSchema[None], BeforeValidator(strip_instructor)] = Field(
         default=None,
-        description="Temp. free-text instructor name; will be replaced with a verified dropdown.",
+        description=(
+            "Legacy free-text instructor name. Kept for backward compatibility "
+            "with old clients. New clients should populate `instructor_ids` instead."
+        ),
+    )
+    instructor_ids: list[uuid.UUID] = Field(
+        default_factory=list,
+        description="UUIDs of Instructor entities mentioned in this rating.",
     )
     is_anonymous: bool = Field(default=False)
 
@@ -215,6 +237,7 @@ class RatingPutParams(BaseModel):
     instructor: Annotated[str | SkipJsonSchema[None], BeforeValidator(strip_instructor)] = Field(
         default=None,
     )
+    instructor_ids: list[uuid.UUID] = Field(default_factory=list)
     is_anonymous: bool = Field(default=False)
 
 
@@ -237,6 +260,7 @@ class RatingPatchParams(BaseModel):
     instructor: Annotated[str | SkipJsonSchema[None], BeforeValidator(strip_instructor)] = Field(
         default=None,
     )
+    instructor_ids: list[uuid.UUID] | SkipJsonSchema[None] = Field(default=None)
     is_anonymous: bool | SkipJsonSchema[None] = Field(
         default=None,
     )

--- a/src/backend/rating_app/application_schemas/rating.py
+++ b/src/backend/rating_app/application_schemas/rating.py
@@ -147,7 +147,6 @@ class RatingInstructor(BaseModel):
     first_name: str
     patronymic: str | None = ""
     last_name: str
-    email: str
 
 
 class Rating(BaseModel):

--- a/src/backend/rating_app/exception/instructor_exceptions.py
+++ b/src/backend/rating_app/exception/instructor_exceptions.py
@@ -1,6 +1,11 @@
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, ValidationError
 
 
 class InstructorNotFoundError(NotFound):
     default_detail = "Instructor not found"
     default_code = "instructor_not_found"
+
+
+class InvalidInstructorIdsError(ValidationError):
+    default_detail = "One or more instructor ids do not reference an existing instructor"
+    default_code = "invalid_instructor_ids"

--- a/src/backend/rating_app/ioc_container/services.py
+++ b/src/backend/rating_app/ioc_container/services.py
@@ -7,6 +7,7 @@ from rating_app.ioc_container.repositories import (
     department_repository,
     enrollment_repository,
     faculty_repository,
+    instructor_mapper,
     instructor_repository,
     notification_cursor_repository,
     notification_repository,
@@ -19,6 +20,7 @@ from rating_app.ioc_container.repositories import (
     user_repository,
     vote_repository,
 )
+from rating_app.pagination.paginator import GenericQuerysetPaginator
 from rating_app.services import (
     CommentNormalizer,
     CommentService,
@@ -129,7 +131,11 @@ def rating_cache_invalidator() -> RatingCacheInvalidator:
 
 @once
 def instructor_service() -> InstructorService:
-    return InstructorService(instructor_repository=instructor_repository())
+    return InstructorService(
+        instructor_repository=instructor_repository(),
+        mapper=instructor_mapper(),
+        paginator=GenericQuerysetPaginator(),
+    )
 
 
 @once

--- a/src/backend/rating_app/ioc_container/services.py
+++ b/src/backend/rating_app/ioc_container/services.py
@@ -105,6 +105,7 @@ def rating_service() -> RatingService:
         vote_repository=vote_repository(),
         vote_mapper=rating_vote_mapper(),
         comment_normalizer=comment_normalizer(),
+        instructor_repository=instructor_repository(),
     )
 
 

--- a/src/backend/rating_app/ioc_container/web.py
+++ b/src/backend/rating_app/ioc_container/web.py
@@ -129,6 +129,11 @@ def instructor_detail_view():
 
 
 @once
+def instructor_list_view():
+    return InstructorViewSet.as_view({"get": "list"}, instructor_service=instructor_service())
+
+
+@once
 def microsoft_login_view() -> Callable[[HttpRequest], HttpResponse]:
     return microsoft_login
 
@@ -309,6 +314,11 @@ def rest_urlpatterns() -> list:
             "students/me/grades/",
             course_detailed_rating_stats(),
             name="student-courses-grades",
+        ),
+        path(
+            "instructors/",
+            instructor_list_view(),
+            name="instructor-list",
         ),
         path(
             "instructors/<str:instructor_id>",

--- a/src/backend/rating_app/migrations/0029_rating_instructors_m2m.py
+++ b/src/backend/rating_app/migrations/0029_rating_instructors_m2m.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add Rating.instructors M2M; keep Rating.instructor text field as legacy backward-compat."""
+
+    dependencies = [
+        ('rating_app', '0028_simplify_instructor_add_email'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rating',
+            name='instructors',
+            field=models.ManyToManyField(blank=True, related_name='ratings', to='rating_app.instructor'),
+        ),
+        migrations.AlterField(
+            model_name='rating',
+            name='instructor',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    'Legacy free-text field. Kept for backward compatibility with old '
+                    'clients; new clients should use the `instructors` M2M instead.'
+                ),
+                max_length=256,
+            ),
+        ),
+    ]

--- a/src/backend/rating_app/migrations/0029_rating_instructors_m2m.py
+++ b/src/backend/rating_app/migrations/0029_rating_instructors_m2m.py
@@ -5,24 +5,26 @@ class Migration(migrations.Migration):
     """Add Rating.instructors M2M; keep Rating.instructor text field as legacy backward-compat."""
 
     dependencies = [
-        ('rating_app', '0028_simplify_instructor_add_email'),
+        ("rating_app", "0028_simplify_instructor_add_email"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='rating',
-            name='instructors',
-            field=models.ManyToManyField(blank=True, related_name='ratings', to='rating_app.instructor'),
+            model_name="rating",
+            name="instructors",
+            field=models.ManyToManyField(
+                blank=True, related_name="ratings", to="rating_app.instructor"
+            ),
         ),
         migrations.AlterField(
-            model_name='rating',
-            name='instructor',
+            model_name="rating",
+            name="instructor",
             field=models.CharField(
                 blank=True,
-                default='',
+                default="",
                 help_text=(
-                    'Legacy free-text field. Kept for backward compatibility with old '
-                    'clients; new clients should use the `instructors` M2M instead.'
+                    "Legacy free-text field. Kept for backward compatibility with old "
+                    "clients; new clients should use the `instructors` M2M instead."
                 ),
                 max_length=256,
             ),

--- a/src/backend/rating_app/models/rating.py
+++ b/src/backend/rating_app/models/rating.py
@@ -9,6 +9,7 @@ from django.db.models import Q
 from django.db.models.manager import Manager
 
 from .course_offering import CourseOffering
+from .instructor import Instructor
 from .student import Student
 
 if TYPE_CHECKING:
@@ -30,7 +31,15 @@ class Rating(models.Model):
         max_length=256,
         blank=True,
         default="",
-        help_text="Temporary free-text field; will be replaced with a verified instructor FK.",
+        help_text=(
+            "Legacy free-text field. Kept for backward compatibility with old "
+            "clients; new clients should use the `instructors` M2M instead."
+        ),
+    )
+    instructors = models.ManyToManyField(
+        Instructor,
+        related_name="ratings",
+        blank=True,
     )
     created_at = models.DateTimeField(auto_now_add=True)
     is_anonymous = models.BooleanField(default=False)

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -25,18 +25,26 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         *,
         search: str | None = None,
         course_offering_id: uuid.UUID | None = None,
+        course_id: uuid.UUID | None = None,
         speciality_id: uuid.UUID | None = None,
     ) -> QuerySet[InstructorModel]:
         """Annotate instructors with mention counts and order by relevance.
 
-        Ordering: per-offering mentions DESC, per-speciality mentions DESC,
-        global mentions DESC, Cyrillic names before Latin, last_name ASC,
-        first_name ASC. Per-offering and per-speciality counts are zero when the
-        corresponding filter is omitted.
+        Ordering, most specific first: mentions on this exact offering DESC,
+        mentions on any offering of the same course DESC, per-speciality
+        mentions DESC, global mentions DESC (so anyone ever rated outranks the
+        never-rated directory tail, which includes students), then Cyrillic
+        before Latin, last_name ASC, first_name ASC. Each scoped count is zero
+        when the corresponding filter is omitted.
         """
         offering_filter = (
             Q(ratings__course_offering_id=course_offering_id)
             if course_offering_id
+            else Q(pk__in=[])
+        )
+        course_filter = (
+            Q(ratings__course_offering__course_id=course_id)
+            if course_id
             else Q(pk__in=[])
         )
         speciality_filter = (
@@ -49,6 +57,11 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
             offering_mentions=Count(
                 "ratings",
                 filter=offering_filter,
+                distinct=True,
+            ),
+            course_mentions=Count(
+                "ratings",
+                filter=course_filter,
                 distinct=True,
             ),
             speciality_mentions=Count(
@@ -73,6 +86,7 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
 
         return qs.order_by(
             "-offering_mentions",
+            "-course_mentions",
             "-speciality_mentions",
             "-global_mentions",
             "starts_latin",

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Literal, overload
 
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Case, Count, IntegerField, Q, QuerySet, Value, When
 
 from rating_app.application_schemas.instructor import Instructor, InstructorInput
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
@@ -30,8 +30,9 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         """Annotate instructors with mention counts and order by relevance.
 
         Ordering: per-offering mentions DESC, per-speciality mentions DESC,
-        global mentions DESC, last_name ASC, first_name ASC. Per-offering and
-        per-speciality counts are zero when the corresponding filter is omitted.
+        global mentions DESC, Cyrillic names before Latin, last_name ASC,
+        first_name ASC. Per-offering and per-speciality counts are zero when the
+        corresponding filter is omitted.
         """
         offering_filter = (
             Q(ratings__course_offering_id=course_offering_id)
@@ -56,6 +57,11 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
                 distinct=True,
             ),
             global_mentions=Count("ratings", distinct=True),
+            starts_latin=Case(
+                When(last_name__regex=r"^[A-Za-z]", then=Value(1)),
+                default=Value(0),
+                output_field=IntegerField(),
+            ),
         )
 
         if search:
@@ -69,6 +75,7 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
             "-offering_mentions",
             "-speciality_mentions",
             "-global_mentions",
+            "starts_latin",
             "last_name",
             "first_name",
             "id",

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -1,6 +1,7 @@
+import uuid
 from typing import Literal, overload
 
-from django.db.models import QuerySet
+from django.db.models import Count, Q, QuerySet
 
 from rating_app.application_schemas.instructor import Instructor, InstructorInput
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
@@ -18,6 +19,65 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         if ordered:
             qs = qs.order_by("last_name", "first_name", "id")
         return self._map_to_domain_models(qs)
+
+    def list_ranked(
+        self,
+        *,
+        search: str | None = None,
+        course_offering_id: uuid.UUID | None = None,
+        speciality_id: uuid.UUID | None = None,
+    ) -> QuerySet[InstructorModel]:
+        """Annotate instructors with mention counts and order by relevance.
+
+        Ordering: per-offering mentions DESC, per-speciality mentions DESC,
+        global mentions DESC, last_name ASC, first_name ASC. Per-offering and
+        per-speciality counts are zero when the corresponding filter is omitted.
+        """
+        offering_filter = (
+            Q(ratings__course_offering_id=course_offering_id)
+            if course_offering_id
+            else Q(pk__in=[])
+        )
+        speciality_filter = (
+            Q(ratings__course_offering__specialities__id=speciality_id)
+            if speciality_id
+            else Q(pk__in=[])
+        )
+
+        qs = InstructorModel.objects.annotate(
+            offering_mentions=Count(
+                "ratings",
+                filter=offering_filter,
+                distinct=True,
+            ),
+            speciality_mentions=Count(
+                "ratings",
+                filter=speciality_filter,
+                distinct=True,
+            ),
+            global_mentions=Count("ratings", distinct=True),
+        )
+
+        if search:
+            qs = qs.filter(
+                Q(first_name__icontains=search)
+                | Q(last_name__icontains=search)
+                | Q(email__icontains=search)
+            )
+
+        return qs.order_by(
+            "-offering_mentions",
+            "-speciality_mentions",
+            "-global_mentions",
+            "last_name",
+            "first_name",
+            "id",
+        )
+
+    def get_many_by_ids(self, ids: list[uuid.UUID]) -> list[InstructorModel]:
+        if not ids:
+            return []
+        return list(InstructorModel.objects.filter(id__in=ids))
 
     def get_by_id(self, id: str) -> Instructor:
         model = self._get_by_id(id)

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -78,11 +78,12 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         )
 
         if search:
-            qs = qs.filter(
-                Q(first_name__icontains=search)
-                | Q(last_name__icontains=search)
-                | Q(email__icontains=search)
-            )
+            for token in search.split():
+                qs = qs.filter(
+                    Q(first_name__icontains=token)
+                    | Q(last_name__icontains=token)
+                    | Q(patronymic__icontains=token)
+                )
 
         return qs.order_by(
             "-offering_mentions",

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -70,11 +70,12 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         4. global mentions, DESC — anyone ever rated outranks the never-rated tail
         5. Cyrillic before Latin, then last_name, first_name, id
 
-        ``exclude_current_students`` (default) drops an instructor when their
-        email matches a bachelor ``Student`` whose programme started within the
-        last four academic years AND they have never been rated. Masters and
-        rated instructors are always kept, so no real teacher becomes
-        unselectable.
+        ``exclude_current_students`` (default) drops an instructor from the
+        *browsing* list when their email matches a bachelor ``Student`` whose
+        programme started within the last four academic years AND they have
+        never been rated. Masters and rated instructors are always kept, and a
+        non-empty ``search`` bypasses the rule entirely, so no real teacher is
+        unreachable.
         """
         offering_filter = (
             Q(ratings__course_offering_id=course_offering_id)
@@ -114,7 +115,10 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
             ),
         )
 
-        if exclude_current_students:
+        # Only while browsing: a search means the user has someone specific in
+        # mind, and hiding them there would be a deadlock — an excluded person
+        # cannot be picked, so they can never earn the rating that reveals them.
+        if exclude_current_students and not search:
             cutoff_year = current_academic_year_start() - (_BACHELOR_PROGRAMME_YEARS - 1)
             current_bachelor_emails = (
                 StudentModel.objects.filter(

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -82,9 +82,7 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
             else Q(pk__in=[])
         )
         course_filter = (
-            Q(ratings__course_offering__course_id=course_id)
-            if course_id
-            else Q(pk__in=[])
+            Q(ratings__course_offering__course_id=course_id) if course_id else Q(pk__in=[])
         )
         speciality_filter = (
             Q(ratings__course_offering__specialities__id=speciality_id)

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -61,19 +61,19 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
     ) -> QuerySet[InstructorModel]:
         """Annotate instructors with mention counts and order by relevance.
 
-        Ordering, most specific first: mentions on this exact offering DESC,
-        mentions on any offering of the same course DESC, per-speciality
-        mentions DESC, global mentions DESC (so anyone ever rated outranks the
-        never-rated directory tail), then Cyrillic before Latin, last_name ASC,
-        first_name ASC. Each scoped count is zero when the corresponding filter
-        is omitted.
+        Ordering, most specific first (each scoped count is zero when its
+        filter is omitted):
 
-        With ``exclude_current_students`` (default) the never-rated tail is
-        trimmed of people who are still enrolled bachelor students: an
-        instructor is dropped when their email matches a bachelor ``Student``
-        whose programme started within the last four academic years AND they
-        have never been rated. Masters are intentionally kept (they teach), and
-        any rated instructor is always kept — so no real teacher becomes
+        1. mentions on this exact offering, DESC
+        2. mentions on any offering of the same course, DESC
+        3. mentions within the speciality, DESC
+        4. global mentions, DESC — anyone ever rated outranks the never-rated tail
+        5. Cyrillic before Latin, then last_name, first_name, id
+
+        ``exclude_current_students`` (default) drops an instructor when their
+        email matches a bachelor ``Student`` whose programme started within the
+        last four academic years AND they have never been rated. Masters and
+        rated instructors are always kept, so no real teacher becomes
         unselectable.
         """
         offering_filter = (

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -1,13 +1,43 @@
 import uuid
+from datetime import date
 from typing import Literal, overload
 
-from django.db.models import Case, Count, IntegerField, Q, QuerySet, Value, When
+from django.db.models import (
+    Case,
+    Count,
+    IntegerField,
+    Q,
+    QuerySet,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Lower
 
 from rating_app.application_schemas.instructor import Instructor, InstructorInput
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
 from rating_app.models import Instructor as InstructorModel
+from rating_app.models import Student as StudentModel
+from rating_app.models.choices import EducationLevel
 from rating_app.repositories.protocol import IDomainOrmRepository
 from rating_app.repositories.to_domain_mappers import InstructorMapper
+
+# A bachelor programme is 4 academic years; a student who started within the
+# last 4 years is still enrolled. Masters are excluded from the rule on purpose
+# (master students routinely teach practicums), and anyone ever rated is kept
+# regardless (see list_ranked).
+_BACHELOR_PROGRAMME_YEARS = 4
+
+
+def current_academic_year_start(today: date | None = None) -> int:
+    """Academic year currently in progress, as its starting calendar year.
+
+    The UKMA academic year begins in September, so Jan–Aug belongs to the year
+    that started the previous September. Derived from the wall clock rather than
+    the scraped ``Semester`` table, which also holds *planned* future semesters.
+    """
+    today = today or date.today()
+    return today.year if today.month >= 9 else today.year - 1
 
 
 class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
@@ -27,15 +57,24 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         course_offering_id: uuid.UUID | None = None,
         course_id: uuid.UUID | None = None,
         speciality_id: uuid.UUID | None = None,
+        exclude_current_students: bool = True,
     ) -> QuerySet[InstructorModel]:
         """Annotate instructors with mention counts and order by relevance.
 
         Ordering, most specific first: mentions on this exact offering DESC,
         mentions on any offering of the same course DESC, per-speciality
         mentions DESC, global mentions DESC (so anyone ever rated outranks the
-        never-rated directory tail, which includes students), then Cyrillic
-        before Latin, last_name ASC, first_name ASC. Each scoped count is zero
-        when the corresponding filter is omitted.
+        never-rated directory tail), then Cyrillic before Latin, last_name ASC,
+        first_name ASC. Each scoped count is zero when the corresponding filter
+        is omitted.
+
+        With ``exclude_current_students`` (default) the never-rated tail is
+        trimmed of people who are still enrolled bachelor students: an
+        instructor is dropped when their email matches a bachelor ``Student``
+        whose programme started within the last four academic years AND they
+        have never been rated. Masters are intentionally kept (they teach), and
+        any rated instructor is always kept — so no real teacher becomes
+        unselectable.
         """
         offering_filter = (
             Q(ratings__course_offering_id=course_offering_id)
@@ -76,6 +115,22 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
                 output_field=IntegerField(),
             ),
         )
+
+        if exclude_current_students:
+            cutoff_year = current_academic_year_start() - (_BACHELOR_PROGRAMME_YEARS - 1)
+            current_bachelor_emails = (
+                StudentModel.objects.filter(
+                    education_level=EducationLevel.BACHELOR,
+                    program_start_academic_year_start__gte=cutoff_year,
+                )
+                .exclude(email="")
+                .annotate(email_lower=Lower("email"))
+                .values("email_lower")
+            )
+            qs = qs.annotate(email_lower=Lower("email")).exclude(
+                email_lower__in=Subquery(current_bachelor_emails),
+                global_mentions=0,
+            )
 
         if search:
             for token in search.split():

--- a/src/backend/rating_app/repositories/rating_repository.py
+++ b/src/backend/rating_app/repositories/rating_repository.py
@@ -233,6 +233,9 @@ class RatingRepository(
         except IntegrityError as err:
             raise DuplicateRatingException() from err
 
+        if create_params.instructor_ids:
+            rating.instructors.set([str(iid) for iid in create_params.instructor_ids])
+
         # Refetch with related fields for mapper
         rating = self._build_lightweight_queryset().get(pk=rating.pk)
         return self._map_to_domain_model(rating)
@@ -245,6 +248,9 @@ class RatingRepository(
         rating_model = self._get_by_id_shallow(str(obj.id))
         is_patch = isinstance(update_data, RatingPatchParams)
         update_data_map = update_data.model_dump(exclude_unset=is_patch)
+
+        # M2M not assignable via setattr — pop it first.
+        instructor_ids = update_data_map.pop("instructor_ids", None)
 
         # normalizing nullable text fields to empty strings for the DB
         # TODO: consider making DB fields nullable and removing this logic
@@ -260,11 +266,15 @@ class RatingRepository(
         except IntegrityError as err:
             raise DuplicateRatingException() from err
 
+        if instructor_ids is not None:
+            rating_model.instructors.set([str(iid) for iid in instructor_ids])
+
         logger.info(
             "rating_partially_updated",
             rating_id=obj.id,
             student_id=str(obj.student_id) if obj.student_id else None,
-            updated_fields=list(update_data_map.keys()),
+            updated_fields=list(update_data_map.keys())
+            + (["instructor_ids"] if instructor_ids is not None else []),
         )
 
         rating_model = self._build_base_queryset().get(pk=rating_model.pk)
@@ -333,11 +343,12 @@ class RatingRepository(
             "course_offering__semester",
             "student",
         ).prefetch_related(
+            "instructors",
             Prefetch(
                 "comments",
                 queryset=self._build_latest_unique_comment_authors_queryset(),
                 to_attr="comment_preview_comments",
-            )
+            ),
         )
 
     def _build_latest_unique_comment_authors_queryset(self) -> QuerySet[Comment]:

--- a/src/backend/rating_app/repositories/student_stats_repository.py
+++ b/src/backend/rating_app/repositories/student_stats_repository.py
@@ -15,7 +15,6 @@ def _serialize_rating_instructors(rating_obj: Rating) -> list[dict[str, Any]]:
             "first_name": instructor.first_name,
             "patronymic": instructor.patronymic,
             "last_name": instructor.last_name,
-            "email": instructor.email,
         }
         for instructor in rating_obj.instructors.all()
     ]

--- a/src/backend/rating_app/repositories/student_stats_repository.py
+++ b/src/backend/rating_app/repositories/student_stats_repository.py
@@ -8,6 +8,19 @@ from rating_app.models import CourseOffering, Rating, Student
 from rating_app.repositories.to_domain_mappers import StudentMapper
 
 
+def _serialize_rating_instructors(rating_obj: Rating) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": str(instructor.id),
+            "first_name": instructor.first_name,
+            "patronymic": instructor.patronymic,
+            "last_name": instructor.last_name,
+            "email": instructor.email,
+        }
+        for instructor in rating_obj.instructors.all()
+    ]
+
+
 class StudentStatisticsRepository:
     """
     Get student specific statistics (specifically on courses/offerings rated).
@@ -31,7 +44,9 @@ class StudentStatisticsRepository:
         """
         student_ratings = Prefetch(
             "ratings",
-            queryset=Rating.objects.filter(student_id=student_id),
+            queryset=Rating.objects.filter(student_id=student_id).prefetch_related(
+                "instructors"
+            ),
             to_attr="student_ratings_list",
         )
 
@@ -60,6 +75,7 @@ class StudentStatisticsRepository:
                     "usefulness": rating_obj.usefulness,
                     "comment": rating_obj.comment,
                     "instructor": rating_obj.instructor or None,
+                    "instructors": _serialize_rating_instructors(rating_obj),
                     "created_at": rating_obj.created_at,
                     "is_anonymous": rating_obj.is_anonymous,
                 }
@@ -87,7 +103,9 @@ class StudentStatisticsRepository:
 
         student_ratings = Prefetch(
             "ratings",
-            queryset=Rating.objects.filter(student_id=student_id),
+            queryset=Rating.objects.filter(student_id=student_id).prefetch_related(
+                "instructors"
+            ),
             to_attr="student_ratings_list",
         )
 
@@ -114,6 +132,7 @@ class StudentStatisticsRepository:
                     "usefulness": rating_obj.usefulness,
                     "comment": rating_obj.comment,
                     "instructor": rating_obj.instructor or None,
+                    "instructors": _serialize_rating_instructors(rating_obj),
                     "created_at": rating_obj.created_at,
                     "is_anonymous": rating_obj.is_anonymous,
                 }

--- a/src/backend/rating_app/repositories/student_stats_repository.py
+++ b/src/backend/rating_app/repositories/student_stats_repository.py
@@ -43,9 +43,7 @@ class StudentStatisticsRepository:
         """
         student_ratings = Prefetch(
             "ratings",
-            queryset=Rating.objects.filter(student_id=student_id).prefetch_related(
-                "instructors"
-            ),
+            queryset=Rating.objects.filter(student_id=student_id).prefetch_related("instructors"),
             to_attr="student_ratings_list",
         )
 
@@ -102,9 +100,7 @@ class StudentStatisticsRepository:
 
         student_ratings = Prefetch(
             "ratings",
-            queryset=Rating.objects.filter(student_id=student_id).prefetch_related(
-                "instructors"
-            ),
+            queryset=Rating.objects.filter(student_id=student_id).prefetch_related("instructors"),
             to_attr="student_ratings_list",
         )
 

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -108,3 +108,23 @@ def test_get_many_by_ids_returns_only_matching_and_omits_unknown(repo):
 
     assert [instructor.id for instructor in result] == [existing.id]
     assert other.id not in {instructor.id for instructor in result}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_orders_cyrillic_before_latin_at_equal_mentions(repo):
+    # No ratings => equal (zero) mentions, so script ordering decides:
+    # Cyrillic names come before Latin ones, each group alphabetical.
+    latin_a = InstructorFactory.create(first_name="Anna", last_name="Adams")
+    cyrillic_ya = InstructorFactory.create(first_name="Юрій", last_name="Яременко")
+    cyrillic_a = InstructorFactory.create(first_name="Андрій", last_name="Андрієнко")
+    latin_z = InstructorFactory.create(first_name="Zach", last_name="Zorin")
+
+    ranked = list(repo.list_ranked())
+
+    assert [i.id for i in ranked] == [
+        cyrillic_a.id,
+        cyrillic_ya.id,
+        latin_a.id,
+        latin_z.id,
+    ]

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -6,7 +6,12 @@ from rating_app.application_schemas.instructor import Instructor as InstructorDT
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
 from rating_app.ioc_container.repositories import instructor_mapper
 from rating_app.repositories.instructor_repository import InstructorRepository
-from rating_app.tests.factories import InstructorFactory
+from rating_app.tests.factories import (
+    CourseFactory,
+    CourseOfferingFactory,
+    InstructorFactory,
+    RatingFactory,
+)
 
 
 @pytest.fixture
@@ -127,4 +132,34 @@ def test_list_ranked_orders_cyrillic_before_latin_at_equal_mentions(repo):
         cyrillic_ya.id,
         latin_a.id,
         latin_z.id,
+    ]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_tiers_offering_then_course_then_global(repo):
+    # Same course, two offerings (semesters).
+    course = CourseFactory.create()
+    offering_a = CourseOfferingFactory.create(course=course)
+    offering_b = CourseOfferingFactory.create(course=course)
+    other_offering = CourseOfferingFactory.create()  # unrelated course
+
+    on_offering = InstructorFactory.create(last_name="Aaa")  # exact offering
+    on_course = InstructorFactory.create(last_name="Bbb")  # same course, other offering
+    rated_elsewhere = InstructorFactory.create(last_name="Ccc")  # only global mention
+    never_rated = InstructorFactory.create(last_name="Ddd")  # directory tail
+
+    RatingFactory.create(course_offering=offering_a).instructors.add(on_offering)
+    RatingFactory.create(course_offering=offering_b).instructors.add(on_course)
+    RatingFactory.create(course_offering=other_offering).instructors.add(rated_elsewhere)
+
+    ranked = list(
+        repo.list_ranked(course_offering_id=offering_a.id, course_id=course.id)
+    )
+
+    assert [i.id for i in ranked] == [
+        on_offering.id,
+        on_course.id,
+        rated_elsewhere.id,
+        never_rated.id,
     ]

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -6,6 +6,7 @@ from rating_app.application_schemas.instructor import Instructor as InstructorDT
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
 from rating_app.ioc_container.repositories import instructor_mapper
 from rating_app.repositories.instructor_repository import InstructorRepository
+from rating_app.tests.factories import InstructorFactory
 
 
 @pytest.fixture
@@ -75,3 +76,35 @@ def test_get_or_create_is_idempotent_on_email(repo):
     assert created_first is True
     assert created_second is False
     assert first.id == second.id
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_breaks_ties_alphabetically(repo):
+    # No ratings => all mention counts are zero, so ordering falls back to
+    # (last_name, first_name, id).
+    second = InstructorFactory.create(first_name="Bohdan", last_name="Petrenko")
+    first = InstructorFactory.create(first_name="Anna", last_name="Kovalenko")
+    third = InstructorFactory.create(first_name="Anna", last_name="Petrenko")
+
+    ranked = list(repo.list_ranked())
+
+    assert [instructor.id for instructor in ranked] == [first.id, third.id, second.id]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_many_by_ids_with_empty_list_returns_empty(repo):
+    assert repo.get_many_by_ids([]) == []
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_many_by_ids_returns_only_matching_and_omits_unknown(repo):
+    existing = InstructorFactory.create()
+    other = InstructorFactory.create()
+
+    result = repo.get_many_by_ids([existing.id, uuid4()])
+
+    assert [instructor.id for instructor in result] == [existing.id]
+    assert other.id not in {instructor.id for instructor in result}

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -5,12 +5,17 @@ import pytest
 from rating_app.application_schemas.instructor import Instructor as InstructorDTO
 from rating_app.exception.instructor_exceptions import InstructorNotFoundError
 from rating_app.ioc_container.repositories import instructor_mapper
-from rating_app.repositories.instructor_repository import InstructorRepository
+from rating_app.models.choices import EducationLevel
+from rating_app.repositories.instructor_repository import (
+    InstructorRepository,
+    current_academic_year_start,
+)
 from rating_app.tests.factories import (
     CourseFactory,
     CourseOfferingFactory,
     InstructorFactory,
     RatingFactory,
+    StudentFactory,
 )
 
 
@@ -163,3 +168,70 @@ def test_list_ranked_tiers_offering_then_course_then_global(repo):
         rated_elsewhere.id,
         never_rated.id,
     ]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_hides_unrated_current_bachelor_student(repo):
+    # Instructor row that is really a still-enrolled bachelor student (matched
+    # by email) and was never rated: dropped by default, shown when the filter
+    # is disabled.
+    email = "current.bachelor@ukma.edu.ua"
+    instructor = InstructorFactory.create(email=email)
+    StudentFactory.create(
+        email=email,
+        education_level=EducationLevel.BACHELOR,
+        program_start_academic_year_start=current_academic_year_start() - 1,
+    )
+
+    default_ids = {i.id for i in repo.list_ranked()}
+    unfiltered_ids = {i.id for i in repo.list_ranked(exclude_current_students=False)}
+
+    assert instructor.id not in default_ids
+    assert instructor.id in unfiltered_ids
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_keeps_current_bachelor_student_when_rated(repo):
+    # A rated instructor is never hidden, even if they match a current student.
+    email = "rated.bachelor@ukma.edu.ua"
+    instructor = InstructorFactory.create(email=email)
+    StudentFactory.create(
+        email=email,
+        education_level=EducationLevel.BACHELOR,
+        program_start_academic_year_start=current_academic_year_start(),
+    )
+    RatingFactory.create().instructors.add(instructor)
+
+    assert instructor.id in {i.id for i in repo.list_ranked()}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_keeps_master_current_student(repo):
+    # Masters routinely teach practicums, so current master students stay.
+    email = "current.master@ukma.edu.ua"
+    instructor = InstructorFactory.create(email=email)
+    StudentFactory.create(
+        email=email,
+        education_level=EducationLevel.MASTER,
+        program_start_academic_year_start=current_academic_year_start(),
+    )
+
+    assert instructor.id in {i.id for i in repo.list_ranked()}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_keeps_graduated_bachelor(repo):
+    # Started long enough ago to have graduated a 4-year bachelor: kept.
+    email = "alumnus@ukma.edu.ua"
+    instructor = InstructorFactory.create(email=email)
+    StudentFactory.create(
+        email=email,
+        education_level=EducationLevel.BACHELOR,
+        program_start_academic_year_start=current_academic_year_start() - 6,
+    )
+
+    assert instructor.id in {i.id for i in repo.list_ranked()}

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -191,6 +191,23 @@ def test_list_ranked_hides_unrated_current_bachelor_student(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_list_ranked_search_reveals_unrated_current_bachelor_student(repo):
+    # Searching must find them, or they could never be picked and so could never
+    # earn the rating that would reveal them.
+    email = "searchable.bachelor@ukma.edu.ua"
+    instructor = InstructorFactory.create(email=email, last_name="Небачений")
+    StudentFactory.create(
+        email=email,
+        education_level=EducationLevel.BACHELOR,
+        program_start_academic_year_start=current_academic_year_start() - 1,
+    )
+
+    assert instructor.id not in {i.id for i in repo.list_ranked()}
+    assert instructor.id in {i.id for i in repo.list_ranked(search="Небачений")}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_list_ranked_keeps_current_bachelor_student_when_rated(repo):
     # A rated instructor is never hidden, even if they match a current student.
     email = "rated.bachelor@ukma.edu.ua"

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -158,9 +158,7 @@ def test_list_ranked_tiers_offering_then_course_then_global(repo):
     RatingFactory.create(course_offering=offering_b).instructors.add(on_course)
     RatingFactory.create(course_offering=other_offering).instructors.add(rated_elsewhere)
 
-    ranked = list(
-        repo.list_ranked(course_offering_id=offering_a.id, course_id=course.id)
-    )
+    ranked = list(repo.list_ranked(course_offering_id=offering_a.id, course_id=course.id))
 
     assert [i.id for i in ranked] == [
         on_offering.id,

--- a/src/backend/rating_app/repositories/test_student_stats_repository.py
+++ b/src/backend/rating_app/repositories/test_student_stats_repository.py
@@ -7,10 +7,23 @@ from rating_app.tests.factories import (
     CourseFactory,
     CourseOfferingFactory,
     EnrollmentFactory,
+    InstructorFactory,
     RatingFactory,
     SemesterFactory,
     StudentFactory,
 )
+
+
+def _rated_with_two_instructors(student):
+    course = CourseFactory()
+    semester = SemesterFactory(term=SemesterTerm.SPRING, year=2025)
+    offering = CourseOfferingFactory(course=course, semester=semester)
+    EnrollmentFactory(student=student, offering=offering)
+    rating = RatingFactory(student=student, course_offering=offering)
+    first = InstructorFactory(first_name="Олена", patronymic="Ігорівна", last_name="Коваленко")
+    second = InstructorFactory(first_name="Іван", patronymic="Петрович", last_name="Петренко")
+    rating.instructors.set([first, second])
+    return rating, first, second
 
 
 @pytest.fixture
@@ -503,3 +516,47 @@ def test_get_detailed_by_student_includes_all_course_fields(repo):
     assert "year" in record["semester"]
     assert "season" in record["semester"]
     assert "rated" in record
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_rating_stats_includes_m2m_instructors(repo):
+    student = StudentFactory()
+    rating, first, second = _rated_with_two_instructors(student)
+
+    result = repo.get_rating_stats(student_id=str(student.id))
+
+    rated = result[0]["offerings"][0]["rated"]
+    assert rated["id"] == str(rating.id)
+    instructors_by_id = {i["id"]: i for i in rated["instructors"]}
+    assert set(instructors_by_id) == {str(first.id), str(second.id)}
+    assert instructors_by_id[str(first.id)]["last_name"] == "Коваленко"
+    assert instructors_by_id[str(first.id)]["patronymic"] == "Ігорівна"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_detailed_rating_stats_includes_m2m_instructors(repo):
+    student = StudentFactory()
+    rating, first, second = _rated_with_two_instructors(student)
+
+    result = repo.get_detailed_rating_stats(student_id=str(student.id))
+
+    rated = result[0]["rated"]
+    assert rated["id"] == str(rating.id)
+    assert {i["id"] for i in rated["instructors"]} == {str(first.id), str(second.id)}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_rating_stats_returns_empty_instructors_when_none_linked(repo):
+    student = StudentFactory()
+    course = CourseFactory()
+    semester = SemesterFactory(term=SemesterTerm.SPRING, year=2025)
+    offering = CourseOfferingFactory(course=course, semester=semester)
+    EnrollmentFactory(student=student, offering=offering)
+    RatingFactory(student=student, course_offering=offering)
+
+    result = repo.get_rating_stats(student_id=str(student.id))
+
+    assert result[0]["offerings"][0]["rated"]["instructors"] == []

--- a/src/backend/rating_app/repositories/to_domain_mappers.py
+++ b/src/backend/rating_app/repositories/to_domain_mappers.py
@@ -214,6 +214,7 @@ class RatingMapper(IProcessor[[RatingModel], RatingDTO]):
             usefulness=model.usefulness,
             comment=model.comment if model.comment else None,
             instructor=model.instructor if model.instructor else None,
+            instructors=self._map_rating_instructors(model),
             is_anonymous=model.is_anonymous,
             created_at=model.created_at,
             upvotes=upvotes,
@@ -222,6 +223,13 @@ class RatingMapper(IProcessor[[RatingModel], RatingDTO]):
             comments_count=comments_count,
             comment_authors=self._map_comment_authors(model),
         )
+
+    def _map_rating_instructors(self, model: RatingModel):
+        from rating_app.application_schemas.rating import RatingInstructor
+
+        prefetched = getattr(model, "_prefetched_objects_cache", {}).get("instructors")
+        instructors = prefetched if prefetched is not None else model.instructors.all()
+        return [RatingInstructor.model_validate(instr) for instr in instructors]
 
     def _map_comment_authors(self, model: RatingModel) -> list[CommentAuthor]:
         comments = getattr(model, "comment_preview_comments", [])

--- a/src/backend/rating_app/repositories/to_domain_mappers.py
+++ b/src/backend/rating_app/repositories/to_domain_mappers.py
@@ -227,9 +227,12 @@ class RatingMapper(IProcessor[[RatingModel], RatingDTO]):
     def _map_rating_instructors(self, model: RatingModel):
         from rating_app.application_schemas.rating import RatingInstructor
 
-        prefetched = getattr(model, "_prefetched_objects_cache", {}).get("instructors")
-        instructors = prefetched if prefetched is not None else model.instructors.all()
-        return [RatingInstructor.model_validate(instr) for instr in instructors]
+        # `.all()` transparently uses the prefetch cache when callers prefetch
+        # "instructors" (every read path goes through _build_lightweight_queryset).
+        return [
+            RatingInstructor.model_validate(instr)
+            for instr in model.instructors.all()
+        ]
 
     def _map_comment_authors(self, model: RatingModel) -> list[CommentAuthor]:
         comments = getattr(model, "comment_preview_comments", [])

--- a/src/backend/rating_app/repositories/to_domain_mappers.py
+++ b/src/backend/rating_app/repositories/to_domain_mappers.py
@@ -229,10 +229,7 @@ class RatingMapper(IProcessor[[RatingModel], RatingDTO]):
 
         # `.all()` transparently uses the prefetch cache when callers prefetch
         # "instructors" (every read path goes through _build_lightweight_queryset).
-        return [
-            RatingInstructor.model_validate(instr)
-            for instr in model.instructors.all()
-        ]
+        return [RatingInstructor.model_validate(instr) for instr in model.instructors.all()]
 
     def _map_comment_authors(self, model: RatingModel) -> list[CommentAuthor]:
         comments = getattr(model, "comment_preview_comments", [])

--- a/src/backend/rating_app/serializers/__init__.py
+++ b/src/backend/rating_app/serializers/__init__.py
@@ -8,6 +8,7 @@ from .course.filter_options import FilterOptionsSerializer
 from .error_envelope import ErrorEnvelopeSerializer
 from .feature_flags import FeatureFlagsSerializer
 from .instructor import InstructorSerializer
+from .instructor_list_resp import InstructorListResponseSerializer
 from .notification import NotificationGroupSerializer, UnreadCountSerializer
 from .rating_list_resp import RatingsWithUserListSerializer
 from .rating_read import RatingReadSerializer
@@ -26,6 +27,7 @@ __all__ = [
     "StudentRatingsLightSerializer",
     "StudentRatingsDetailedSerializer",
     "InstructorSerializer",
+    "InstructorListResponseSerializer",
     "ErrorEnvelopeSerializer",
     "FeatureFlagsSerializer",
     "FilterOptionsSerializer",

--- a/src/backend/rating_app/serializers/course_offering.py
+++ b/src/backend/rating_app/serializers/course_offering.py
@@ -12,7 +12,6 @@ class InstructorDTOSerializer(serializers.Serializer):
     first_name = serializers.CharField(read_only=True)
     patronymic = serializers.CharField(read_only=True, allow_null=True)
     last_name = serializers.CharField(read_only=True)
-    email = serializers.EmailField(read_only=True)
 
 
 class CourseOfferingSpecialitySerializer(serializers.Serializer):

--- a/src/backend/rating_app/serializers/instructor_list_resp.py
+++ b/src/backend/rating_app/serializers/instructor_list_resp.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from rating_app.serializers.instructor import InstructorSerializer
+
+
+class InstructorListResponseSerializer(serializers.Serializer):
+    """Schema for GET /api/v1/instructors/ response envelope."""
+
+    items = InstructorSerializer(many=True)
+    page = serializers.IntegerField()
+    page_size = serializers.IntegerField()
+    total = serializers.IntegerField()
+    total_pages = serializers.IntegerField()
+    next_page = serializers.IntegerField(allow_null=True, min_value=1)
+    previous_page = serializers.IntegerField(allow_null=True, min_value=1)

--- a/src/backend/rating_app/serializers/rating_read.py
+++ b/src/backend/rating_app/serializers/rating_read.py
@@ -10,6 +10,14 @@ class CommentAuthorSerializer(serializers.Serializer):
     is_anonymous = serializers.BooleanField(read_only=True)
 
 
+class RatingInstructorSerializer(serializers.Serializer):
+    id = serializers.UUIDField(read_only=True)
+    first_name = serializers.CharField(read_only=True)
+    patronymic = serializers.CharField(read_only=True, allow_blank=True)
+    last_name = serializers.CharField(read_only=True)
+    email = serializers.EmailField(read_only=True)
+
+
 class RatingReadSerializer(serializers.Serializer):
     """Serializer for reading RatingDTO. Nulls identity fields for anonymous ratings."""
 
@@ -27,6 +35,7 @@ class RatingReadSerializer(serializers.Serializer):
     usefulness = serializers.IntegerField(read_only=True)
     comment = serializers.CharField(read_only=True, allow_null=True)
     instructor = serializers.CharField(read_only=True, allow_null=True)
+    instructors = RatingInstructorSerializer(many=True, read_only=True)
     is_anonymous = serializers.BooleanField(read_only=True)
     created_at = serializers.DateTimeField(read_only=True)
     upvotes = serializers.IntegerField(read_only=True)

--- a/src/backend/rating_app/serializers/rating_read.py
+++ b/src/backend/rating_app/serializers/rating_read.py
@@ -15,7 +15,6 @@ class RatingInstructorSerializer(serializers.Serializer):
     first_name = serializers.CharField(read_only=True)
     patronymic = serializers.CharField(read_only=True, allow_blank=True)
     last_name = serializers.CharField(read_only=True)
-    email = serializers.EmailField(read_only=True)
 
 
 class RatingReadSerializer(serializers.Serializer):

--- a/src/backend/rating_app/serializers/student_ratings.py
+++ b/src/backend/rating_app/serializers/student_ratings.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from rating_app.serializers.rating_read import RatingInstructorSerializer
+
 
 class InlineRatingSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
@@ -7,6 +9,7 @@ class InlineRatingSerializer(serializers.Serializer):
     usefulness = serializers.IntegerField()
     comment = serializers.CharField(allow_blank=True, required=False, allow_null=True)
     instructor = serializers.CharField(allow_blank=True, required=False, allow_null=True)
+    instructors = RatingInstructorSerializer(many=True, read_only=True)
     created_at = serializers.DateTimeField(read_only=True)
     is_anonymous = serializers.BooleanField()
 

--- a/src/backend/rating_app/serializers/student_ratings_detailed.py
+++ b/src/backend/rating_app/serializers/student_ratings_detailed.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from rating_app.serializers.rating_read import RatingInstructorSerializer
+
 
 class InlineRatingDetailedSerializer(serializers.Serializer):
     id = serializers.CharField(read_only=True)
@@ -7,6 +9,7 @@ class InlineRatingDetailedSerializer(serializers.Serializer):
     usefulness = serializers.IntegerField(read_only=True)
     comment = serializers.CharField(allow_blank=True, read_only=True)
     instructor = serializers.CharField(allow_blank=True, allow_null=True, read_only=True)
+    instructors = RatingInstructorSerializer(many=True, read_only=True)
     created_at = serializers.DateTimeField(read_only=True)
     is_anonymous = serializers.BooleanField(read_only=True)
 

--- a/src/backend/rating_app/services/instructor_service.py
+++ b/src/backend/rating_app/services/instructor_service.py
@@ -5,10 +5,7 @@ from rating_app.application_schemas.instructor import (
     InstructorListParams,
     InstructorListResult,
 )
-from rating_app.application_schemas.pagination import (
-    PaginationFilters,
-    PaginationMetadata,
-)
+from rating_app.application_schemas.pagination import PaginationFilters
 from rating_app.pagination.paginator import GenericQuerysetPaginator
 from rating_app.repositories import InstructorRepository
 from rating_app.repositories.to_domain_mappers import InstructorMapper
@@ -54,4 +51,4 @@ class InstructorService(IFilterable):
         ]
 
 
-__all__ = ["InstructorService", "PaginationMetadata"]
+__all__ = ["InstructorService"]

--- a/src/backend/rating_app/services/instructor_service.py
+++ b/src/backend/rating_app/services/instructor_service.py
@@ -50,6 +50,3 @@ class InstructorService(IFilterable):
             }
             for instructor in instructors
         ]
-
-
-__all__ = ["InstructorService"]

--- a/src/backend/rating_app/services/instructor_service.py
+++ b/src/backend/rating_app/services/instructor_service.py
@@ -30,6 +30,7 @@ class InstructorService(IFilterable):
         qs = self.instructor_repository.list_ranked(
             search=params.search,
             course_offering_id=params.course_offering_id,
+            course_id=params.course_id,
             speciality_id=params.speciality_id,
         )
         paginated = self.paginator.process(

--- a/src/backend/rating_app/services/instructor_service.py
+++ b/src/backend/rating_app/services/instructor_service.py
@@ -1,16 +1,46 @@
 from typing import Any
 
-from rating_app.application_schemas.instructor import Instructor
+from rating_app.application_schemas.instructor import (
+    Instructor,
+    InstructorListParams,
+    InstructorListResult,
+)
+from rating_app.application_schemas.pagination import (
+    PaginationFilters,
+    PaginationMetadata,
+)
+from rating_app.pagination.paginator import GenericQuerysetPaginator
 from rating_app.repositories import InstructorRepository
+from rating_app.repositories.to_domain_mappers import InstructorMapper
 from rating_app.services.protocols import IFilterable
 
 
 class InstructorService(IFilterable):
-    def __init__(self, instructor_repository: InstructorRepository):
+    def __init__(
+        self,
+        instructor_repository: InstructorRepository,
+        mapper: InstructorMapper,
+        paginator: GenericQuerysetPaginator,
+    ):
         self.instructor_repository = instructor_repository
+        self.mapper = mapper
+        self.paginator = paginator
 
     def get_instructor_by_id(self, instructor_id: str) -> Instructor:
         return self.instructor_repository.get_by_id(instructor_id)
+
+    def list_instructors(self, params: InstructorListParams) -> InstructorListResult:
+        qs = self.instructor_repository.list_ranked(
+            search=params.search,
+            course_offering_id=params.course_offering_id,
+            speciality_id=params.speciality_id,
+        )
+        paginated = self.paginator.process(
+            qs,
+            PaginationFilters(page=params.page, page_size=params.page_size),
+        )
+        items = [self.mapper.process(obj) for obj in paginated.page_objects]
+        return InstructorListResult(items=items, pagination=paginated.metadata)
 
     def get_filter_options(self) -> list[dict[str, Any]]:
         instructors = self.instructor_repository.get_all(ordered=True)
@@ -22,3 +52,6 @@ class InstructorService(IFilterable):
             }
             for instructor in instructors
         ]
+
+
+__all__ = ["InstructorService", "PaginationMetadata"]

--- a/src/backend/rating_app/services/rating_service.py
+++ b/src/backend/rating_app/services/rating_service.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime
 from typing import Any
 
@@ -25,6 +26,7 @@ from rating_app.application_schemas.semester import (
     Semester,
     SemesterInput,
 )
+from rating_app.exception.instructor_exceptions import InvalidInstructorIdsError
 from rating_app.exception.rating_exceptions import (
     DuplicateRatingException,
     NotEnrolledException,
@@ -36,6 +38,7 @@ from rating_app.repositories import (
     RatingVoteMapper,
     RatingVoteRepository,
 )
+from rating_app.repositories.instructor_repository import InstructorRepository
 from rating_app.services.comment_normalizer import CommentNormalizer
 from rating_app.services.course_offering_service import CourseOfferingService
 from rating_app.services.semester_service import SemesterService
@@ -63,6 +66,7 @@ class RatingService(IObservable[RatingDTO]):
         vote_repository: RatingVoteRepository,
         vote_mapper: RatingVoteMapper,
         comment_normalizer: CommentNormalizer,
+        instructor_repository: InstructorRepository,
     ):
         self.rating_repository = rating_repository
         self.enrollment_repository = enrollment_repository
@@ -71,6 +75,7 @@ class RatingService(IObservable[RatingDTO]):
         self.vote_repository = vote_repository
         self.vote_mapper = vote_mapper
         self.comment_normalizer = comment_normalizer
+        self.instructor_repository = instructor_repository
         self._listeners: list[IEventListener[RatingDTO]] = []
 
     @implements
@@ -170,6 +175,7 @@ class RatingService(IObservable[RatingDTO]):
             raise DuplicateRatingException()
 
         params.comment = self.comment_normalizer.normalize_comment(params.comment)
+        self._validate_instructor_ids(params.instructor_ids)
 
         rating = self.rating_repository.create(params)
         self.notify(rating)
@@ -179,9 +185,28 @@ class RatingService(IObservable[RatingDTO]):
         self, rating: RatingDTO, update_data: RatingPutParams | RatingPatchParams
     ) -> RatingDTO:
         update_data.comment = self.comment_normalizer.normalize_comment(update_data.comment)
+        self._validate_instructor_ids(update_data.instructor_ids)
         updated_rating = self.rating_repository.update(rating, update_data)
         self.notify(updated_rating)
         return updated_rating
+
+    def _validate_instructor_ids(self, instructor_ids: list[uuid.UUID] | None) -> None:
+        """Reject ids that do not reference an existing Instructor.
+
+        Django's M2M ``.set()`` silently ignores unknown primary keys, which
+        would let a client persist a rating with fewer instructors than it asked
+        for and no error. Fail loudly with a 400 instead.
+        """
+        if not instructor_ids:
+            return
+
+        unique_ids = set(instructor_ids)
+        found = self.instructor_repository.get_many_by_ids(list(unique_ids))
+        missing = unique_ids - {instructor.id for instructor in found}
+        if missing:
+            raise InvalidInstructorIdsError(
+                detail=f"Unknown instructor ids: {sorted(str(i) for i in missing)}"
+            )
 
     def delete_rating(self, rating: RatingDTO) -> None:
         self.rating_repository.delete(str(rating.id))

--- a/src/backend/rating_app/views/instructor_viewset.py
+++ b/src/backend/rating_app/views/instructor_viewset.py
@@ -1,24 +1,55 @@
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
-from rating_app.application_schemas.instructor import InstructorReadParams
+from rating_app.application_schemas.instructor import (
+    InstructorListParams,
+    InstructorReadParams,
+)
 from rating_app.ioc_container.common import pydantic_to_openapi_request_mapper
-from rating_app.serializers import InstructorSerializer
+from rating_app.serializers import InstructorListResponseSerializer, InstructorSerializer
 from rating_app.services import InstructorService
 from rating_app.views.rating_viewset import ModelValidationError
 
-from .responses import R_INSTRUCTOR
+from .responses import R_INSTRUCTOR, R_INSTRUCTOR_LIST
 
 to_openapi = pydantic_to_openapi_request_mapper().map
 
 
-class InstructorViewSet(viewsets.ModelViewSet):
+@extend_schema(tags=["instructors"])
+class InstructorViewSet(viewsets.ViewSet):
     serializer_class = InstructorSerializer
 
     instructor_service: InstructorService | None = None
+
+    @extend_schema(
+        summary="List instructors",
+        description=(
+            "Paginated instructor list ordered by mention count. Pass "
+            "`course_offering_id` and/or `speciality_id` to boost instructors "
+            "most mentioned on that course offering or speciality."
+        ),
+        parameters=to_openapi((InstructorListParams, OpenApiParameter.QUERY)),
+        responses=R_INSTRUCTOR_LIST,
+    )
+    def list(self, request, *args, **kwargs) -> Response:
+        assert self.instructor_service is not None
+
+        try:
+            params = InstructorListParams.model_validate(request.query_params.dict())
+        except ModelValidationError as e:
+            raise ValidationError(detail=e.errors()) from e
+
+        result = self.instructor_service.list_instructors(params)
+        payload = InstructorListResponseSerializer(
+            {
+                "items": result.items,
+                **result.pagination.model_dump(),
+            }
+        )
+        return Response(payload.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         summary="Retrieve an instructor",
@@ -37,3 +68,7 @@ class InstructorViewSet(viewsets.ModelViewSet):
         instructor = self.instructor_service.get_instructor_by_id(str(params.instructor_id))
 
         return Response(self.get_serializer(instructor).data)
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs.setdefault("context", {"request": self.request, "view": self})
+        return self.serializer_class(*args, **kwargs)

--- a/src/backend/rating_app/views/instructor_viewset.py
+++ b/src/backend/rating_app/views/instructor_viewset.py
@@ -20,8 +20,6 @@ to_openapi = pydantic_to_openapi_request_mapper().map
 
 @extend_schema(tags=["instructors"])
 class InstructorViewSet(viewsets.ViewSet):
-    serializer_class = InstructorSerializer
-
     instructor_service: InstructorService | None = None
 
     @extend_schema(
@@ -67,8 +65,4 @@ class InstructorViewSet(viewsets.ViewSet):
 
         instructor = self.instructor_service.get_instructor_by_id(str(params.instructor_id))
 
-        return Response(self.get_serializer(instructor).data)
-
-    def get_serializer(self, *args, **kwargs):
-        kwargs.setdefault("context", {"request": self.request, "view": self})
-        return self.serializer_class(*args, **kwargs)
+        return Response(InstructorSerializer(instructor).data)

--- a/src/backend/rating_app/views/responses.py
+++ b/src/backend/rating_app/views/responses.py
@@ -9,6 +9,7 @@ from rating_app.serializers import (
     CourseListResponseSerializer,
     FeatureFlagsSerializer,
     FilterOptionsSerializer,
+    InstructorListResponseSerializer,
     InstructorSerializer,
     RatingReadSerializer,
     RatingsWithUserListSerializer,
@@ -179,6 +180,13 @@ R_CSRF_TOKEN = {
 R_INSTRUCTOR = {
     200: OpenApiResponse(InstructorSerializer, "OK"),
     **common_errors(include_404=True),
+}
+
+R_INSTRUCTOR_LIST = {
+    200: OpenApiResponse(
+        forced_singular_serializer(InstructorListResponseSerializer), "OK"
+    ),
+    **common_errors(include_404=False),
 }
 
 R_STUDENT_RATINGS = {

--- a/src/backend/rating_app/views/responses.py
+++ b/src/backend/rating_app/views/responses.py
@@ -183,9 +183,7 @@ R_INSTRUCTOR = {
 }
 
 R_INSTRUCTOR_LIST = {
-    200: OpenApiResponse(
-        forced_singular_serializer(InstructorListResponseSerializer), "OK"
-    ),
+    200: OpenApiResponse(forced_singular_serializer(InstructorListResponseSerializer), "OK"),
     **common_errors(include_404=False),
 }
 

--- a/src/backend/rating_app/views/test_instructor.py
+++ b/src/backend/rating_app/views/test_instructor.py
@@ -87,6 +87,57 @@ def test_list_instructors_search(token_client, instructor_factory):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_list_instructors_search_matches_display_name_tokens(token_client, instructor_factory):
+    instructor_factory.create(
+        first_name="Микола",
+        patronymic="Миколайович",
+        last_name="Глибовець",
+        email="mykola.hlybovets@ukma.edu.ua",
+    )
+    instructor_factory.create(
+        first_name="Альбіна",
+        patronymic="Андріївна",
+        last_name="Глибовець",
+        email="albina.hlybovets@ukma.edu.ua",
+    )
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"search": "Глибовець Микола"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["first_name"] == "Микола"
+    assert data["items"][0]["last_name"] == "Глибовець"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_search_matches_patronymic_token(token_client, instructor_factory):
+    instructor_factory.create(
+        first_name="Микола",
+        patronymic="Миколайович",
+        last_name="Глибовець",
+        email="mykola.hlybovets@ukma.edu.ua",
+    )
+    instructor_factory.create(
+        first_name="Альбіна",
+        patronymic="Андріївна",
+        last_name="Глибовець",
+        email="albina.hlybovets@ukma.edu.ua",
+    )
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"search": "Миколайович"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["patronymic"] == "Миколайович"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_list_instructors_orders_by_offering_mentions(token_client, instructor_factory):
     offering = CourseOfferingFactory.create()
     top = instructor_factory.create(last_name="Aaa")

--- a/src/backend/rating_app/views/test_instructor.py
+++ b/src/backend/rating_app/views/test_instructor.py
@@ -4,6 +4,13 @@ from django.urls import reverse
 
 import pytest
 
+from rating_app.tests.factories import (
+    CourseOfferingFactory,
+    CourseOfferingSpecialityFactory,
+    RatingFactory,
+    SpecialityFactory,
+)
+
 
 @pytest.mark.django_db
 @pytest.mark.integration
@@ -44,3 +51,102 @@ def test_bad_uuid(token_client):
     response = token_client.get(url)
 
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_paginated(token_client, instructor_factory):
+    instructor_factory.create_batch(25)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"page": 1, "page_size": 10})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 25
+    assert data["page"] == 1
+    assert data["page_size"] == 10
+    assert len(data["items"]) == 10
+    assert data["next_page"] == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_search(token_client, instructor_factory):
+    instructor_factory.create(first_name="Ivan", last_name="Petrenko", email="ivan@ukma.edu.ua")
+    instructor_factory.create(first_name="Anna", last_name="Koval", email="anna@ukma.edu.ua")
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"search": "ivan"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0]["first_name"] == "Ivan"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_orders_by_offering_mentions(token_client, instructor_factory):
+    offering = CourseOfferingFactory.create()
+    top = instructor_factory.create(last_name="Aaa")
+    middle = instructor_factory.create(last_name="Bbb")
+    bottom = instructor_factory.create(last_name="Ccc")
+
+    # top → 2 ratings on this offering, middle → 1, bottom → 0
+    for _ in range(2):
+        r = RatingFactory.create(course_offering=offering)
+        r.instructors.add(top)
+    r = RatingFactory.create(course_offering=offering)
+    r.instructors.add(middle)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"course_offering_id": str(offering.id)})
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [item["id"] for item in data["items"][:3]]
+    assert ids == [str(top.id), str(middle.id), str(bottom.id)]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_orders_by_speciality_mentions(token_client, instructor_factory):
+    speciality = SpecialityFactory.create()
+    offering = CourseOfferingFactory.create()
+    CourseOfferingSpecialityFactory.create(offering=offering, speciality=speciality)
+    other_offering = CourseOfferingFactory.create()
+
+    top = instructor_factory.create(last_name="Aaa")
+    other = instructor_factory.create(last_name="Bbb")
+
+    rating_on_spec = RatingFactory.create(course_offering=offering)
+    rating_on_spec.instructors.add(top)
+    rating_elsewhere = RatingFactory.create(course_offering=other_offering)
+    rating_elsewhere.instructors.add(other)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"speciality_id": str(speciality.id)})
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [item["id"] for item in data["items"][:2]]
+    assert ids[0] == str(top.id)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_global_fallback(token_client, instructor_factory):
+    less = instructor_factory.create(last_name="Less")
+    more = instructor_factory.create(last_name="More")
+    RatingFactory.create().instructors.add(less)
+    for _ in range(3):
+        RatingFactory.create().instructors.add(more)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [item["id"] for item in data["items"][:2]]
+    assert ids == [str(more.id), str(less.id)]

--- a/src/backend/rating_app/views/test_instructor.py
+++ b/src/backend/rating_app/views/test_instructor.py
@@ -83,6 +83,8 @@ def test_list_instructors_search(token_client, instructor_factory):
     data = response.json()
     assert data["total"] == 1
     assert data["items"][0]["first_name"] == "Ivan"
+    # email is intentionally not exposed on the list payload either
+    assert "email" not in data["items"][0]
 
 
 @pytest.mark.django_db

--- a/src/backend/rating_app/views/test_rating.py
+++ b/src/backend/rating_app/views/test_rating.py
@@ -1377,6 +1377,72 @@ def test_patch_rating_instructor(
 @pytest.mark.django_db
 @pytest.mark.integration
 @freeze_time(DEFAULT_AFTER_MIDTERM_DATE)
+def test_create_rating_with_instructor_ids(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    semester_factory,
+    instructor_factory,
+):
+    semester = semester_factory(year=DEFAULT_YEAR, term=DEFAULT_TERM)
+    course = course_factory()
+    offering = course_offering_factory(course=course, semester=semester)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    instr_a = instructor_factory.create(first_name="Anna", last_name="Petrenko")
+    instr_b = instructor_factory.create(first_name="Bohdan", last_name="Kovalenko")
+
+    url = f"/api/v1/courses/{course.id}/ratings/"
+    payload = {
+        "course_offering": str(offering.id),
+        "difficulty": 4,
+        "usefulness": 5,
+        "instructor_ids": [str(instr_a.id), str(instr_b.id)],
+        "is_anonymous": False,
+    }
+
+    response = token_client.post(url, data=payload, format="json")
+    assert response.status_code == 201, response.data
+    body = response.json()
+    returned_ids = {item["id"] for item in body["instructors"]}
+    assert returned_ids == {str(instr_a.id), str(instr_b.id)}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_patch_rating_instructor_ids_replaces_set(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    rating_factory,
+    instructor_factory,
+):
+    course = course_factory()
+    offering = course_offering_factory(course=course)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    rating = rating_factory(course_offering=offering, student=student, difficulty=3, usefulness=4)
+    initial = instructor_factory.create()
+    replacement = instructor_factory.create()
+    rating.instructors.add(initial)
+
+    url = f"/api/v1/courses/{course.id}/ratings/{rating.id}/"
+    payload = {"instructor_ids": [str(replacement.id)]}
+
+    response = token_client.patch(url, data=payload, format="json")
+    assert response.status_code == 200, response.data
+
+    rating.refresh_from_db()
+    assert list(rating.instructors.values_list("id", flat=True)) == [replacement.id]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+@freeze_time(DEFAULT_AFTER_MIDTERM_DATE)
 def test_create_rating_instructor_too_long(
     token_client,
     course_factory,

--- a/src/backend/rating_app/views/test_rating.py
+++ b/src/backend/rating_app/views/test_rating.py
@@ -1,12 +1,13 @@
 from datetime import timedelta
 from decimal import Decimal
+from uuid import uuid4
 
 from django.utils import timezone
 
 import pytest
 from freezegun import freeze_time
 
-from rating_app.models import Comment
+from rating_app.models import Comment, Rating
 
 DEFAULT_DATE = "2023-10-25"
 DEFAULT_AFTER_MIDTERM_DATE = "2023-11-25"
@@ -1438,6 +1439,152 @@ def test_patch_rating_instructor_ids_replaces_set(
 
     rating.refresh_from_db()
     assert list(rating.instructors.values_list("id", flat=True)) == [replacement.id]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+@freeze_time(DEFAULT_AFTER_MIDTERM_DATE)
+def test_create_rating_with_unknown_instructor_id_returns_400(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    semester_factory,
+):
+    semester = semester_factory(year=DEFAULT_YEAR, term=DEFAULT_TERM)
+    course = course_factory()
+    offering = course_offering_factory(course=course, semester=semester)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+
+    url = f"/api/v1/courses/{course.id}/ratings/"
+    payload = {
+        "course_offering": str(offering.id),
+        "difficulty": 4,
+        "usefulness": 5,
+        "instructor_ids": [str(uuid4())],
+        "is_anonymous": False,
+    }
+
+    response = token_client.post(url, data=payload, format="json")
+    assert response.status_code == 400, response.data
+    assert not Rating.objects.filter(course_offering=offering, student=student).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_patch_rating_with_unknown_instructor_id_returns_400(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    rating_factory,
+):
+    course = course_factory()
+    offering = course_offering_factory(course=course)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    rating = rating_factory(course_offering=offering, student=student, difficulty=3, usefulness=4)
+
+    url = f"/api/v1/courses/{course.id}/ratings/{rating.id}/"
+    payload = {"instructor_ids": [str(uuid4())]}
+
+    response = token_client.patch(url, data=payload, format="json")
+    assert response.status_code == 400, response.data
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_patch_rating_instructor_ids_empty_clears_set(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    rating_factory,
+    instructor_factory,
+):
+    course = course_factory()
+    offering = course_offering_factory(course=course)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    rating = rating_factory(course_offering=offering, student=student, difficulty=3, usefulness=4)
+    rating.instructors.add(instructor_factory.create())
+
+    url = f"/api/v1/courses/{course.id}/ratings/{rating.id}/"
+    payload = {"instructor_ids": []}
+
+    response = token_client.patch(url, data=payload, format="json")
+    assert response.status_code == 200, response.data
+
+    rating.refresh_from_db()
+    assert rating.instructors.count() == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_patch_rating_omitting_instructor_ids_keeps_set(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    rating_factory,
+    instructor_factory,
+):
+    course = course_factory()
+    offering = course_offering_factory(course=course)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    rating = rating_factory(course_offering=offering, student=student, difficulty=3, usefulness=4)
+    instructor = instructor_factory.create()
+    rating.instructors.add(instructor)
+
+    url = f"/api/v1/courses/{course.id}/ratings/{rating.id}/"
+    payload = {"comment": "Updated comment"}
+
+    response = token_client.patch(url, data=payload, format="json")
+    assert response.status_code == 200, response.data
+
+    rating.refresh_from_db()
+    assert list(rating.instructors.values_list("id", flat=True)) == [instructor.id]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_put_rating_instructor_ids_empty_clears_set(
+    token_client,
+    course_factory,
+    course_offering_factory,
+    student_factory,
+    enrollment_factory,
+    rating_factory,
+    instructor_factory,
+):
+    course = course_factory()
+    offering = course_offering_factory(course=course)
+    student = student_factory(user=token_client.user)
+    enrollment_factory(offering=offering, student=student)
+    rating = rating_factory(course_offering=offering, student=student, difficulty=3, usefulness=4)
+    rating.instructors.add(instructor_factory.create())
+
+    url = f"/api/v1/courses/{course.id}/ratings/{rating.id}/"
+    payload = {
+        "course_offering": str(offering.id),
+        "difficulty": 4,
+        "usefulness": 5,
+        "comment": "Updated",
+        "instructor_ids": [],
+        "is_anonymous": False,
+    }
+
+    response = token_client.put(url, data=payload, format="json")
+    assert response.status_code == 200, response.data
+
+    rating.refresh_from_db()
+    assert rating.instructors.count() == 0
 
 
 @pytest.mark.django_db

--- a/src/backend/rating_app/views/test_rating.py
+++ b/src/backend/rating_app/views/test_rating.py
@@ -1409,6 +1409,8 @@ def test_create_rating_with_instructor_ids(
     body = response.json()
     returned_ids = {item["id"] for item in body["instructors"]}
     assert returned_ids == {str(instr_a.id), str(instr_b.id)}
+    # email must never leak through the rating's instructor payload
+    assert all("email" not in item for item in body["instructors"])
 
 
 @pytest.mark.django_db

--- a/src/backend/rating_app/views/test_student_stats.py
+++ b/src/backend/rating_app/views/test_student_stats.py
@@ -7,6 +7,7 @@ from rating_app.tests.factories import (
     CourseFactory,
     CourseOfferingFactory,
     EnrollmentFactory,
+    InstructorFactory,
     RatingFactory,
     SemesterFactory,
     StudentFactory,
@@ -468,3 +469,30 @@ def test_student_courses_cache_is_busted_after_version_bump(token_client, mock_c
     offering_data = fresh.json()[0]["offerings"][0]
     assert offering_data["rated"] is not None
     assert offering_data["rated"]["comment"] == "Late rating"
+
+
+@freeze_time(DEFAULT_DATE)
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_get_courses_stats_returns_m2m_instructors_on_rated(token_client):
+    # Regression: the light /students/me/courses/ endpoint must expose the
+    # rating's M2M instructors so the edit modal can pre-populate them.
+    student = StudentFactory(user=token_client.user)
+    course = CourseFactory(title="Course With Instructors")
+    semester = SemesterFactory(term=SemesterTerm[DEFAULT_TERM], year=DEFAULT_YEAR)
+    offering = CourseOfferingFactory(course=course, semester=semester)
+    EnrollmentFactory(student=student, offering=offering)
+    rating = RatingFactory(student=student, course_offering=offering)
+    instructor = InstructorFactory(
+        first_name="Олена", patronymic="Ігорівна", last_name="Коваленко"
+    )
+    rating.instructors.set([instructor])
+
+    response = token_client.get("/api/v1/students/me/courses/")
+
+    assert response.status_code == 200
+    rated = response.json()[0]["offerings"][0]["rated"]
+    assert len(rated["instructors"]) == 1
+    assert rated["instructors"][0]["id"] == str(instructor.id)
+    assert rated["instructors"][0]["last_name"] == "Коваленко"
+    assert rated["instructors"][0]["patronymic"] == "Ігорівна"

--- a/src/backend/rating_app/views/test_student_stats.py
+++ b/src/backend/rating_app/views/test_student_stats.py
@@ -483,9 +483,7 @@ def test_get_courses_stats_returns_m2m_instructors_on_rated(token_client):
     offering = CourseOfferingFactory(course=course, semester=semester)
     EnrollmentFactory(student=student, offering=offering)
     rating = RatingFactory(student=student, course_offering=offering)
-    instructor = InstructorFactory(
-        first_name="Олена", patronymic="Ігорівна", last_name="Коваленко"
-    )
+    instructor = InstructorFactory(first_name="Олена", patronymic="Ігорівна", last_name="Коваленко")
     rating.instructors.set([instructor])
 
     response = token_client.get("/api/v1/students/me/courses/")

--- a/src/backend/rating_app/views/test_student_stats.py
+++ b/src/backend/rating_app/views/test_student_stats.py
@@ -496,3 +496,4 @@ def test_get_courses_stats_returns_m2m_instructors_on_rated(token_client):
     assert rated["instructors"][0]["id"] == str(instructor.id)
     assert rated["instructors"][0]["last_name"] == "Коваленко"
     assert rated["instructors"][0]["patronymic"] == "Ігорівна"
+    assert "email" not in rated["instructors"][0]

--- a/src/webapp/AGENTS.md
+++ b/src/webapp/AGENTS.md
@@ -36,8 +36,9 @@ pnpm check
 ## Feature flags
 
 Gate UI with `useFeatureFlag("fe_<name>")` from `@/lib/feature-flags` (mirrors
-`@/lib/auth`); use `useFeatureFlags().isReady` to avoid a flash of the wrong
-variant for non-trivial content. Flags are served by `GET /api/v1/flags/` and
+`@/lib/auth`). For non-trivial content, and for anything that writes, use
+`useFeatureFlagState("fe_<name>")` instead — it returns `{ enabled, isReady }`,
+so an unresolved flag cannot be mistaken for OFF. Flags are served by `GET /api/v1/flags/` and
 must be allowlisted backend-side. See
 [docs/feature-flags.md](../../docs/feature-flags.md) for the end-to-end flow
 (add / toggle / test / remove) and

--- a/src/webapp/orval.config.ts
+++ b/src/webapp/orval.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
 	api: {
 		output: {
 			mode: "split",
-			target: "src/lib/api/generated/index.ts",
+			target: "endpoints.ts",
 			workspace: "src/lib/api/generated",
-			schemas: "src/lib/api/generated/models",
+			schemas: "models",
 			client: "react-query",
 			httpClient: "axios",
 			override: {

--- a/src/webapp/orval.config.ts
+++ b/src/webapp/orval.config.ts
@@ -14,6 +14,17 @@ export default defineConfig({
 					path: "../apiClient.ts",
 					name: "authorizedFetcher",
 				},
+				// Generate an infinite-query hook for the paginated instructors
+				// list (page-based). Scoped per-operation so other list
+				// endpoints keep their standard useQuery output.
+				operations: {
+					instructors_list: {
+						query: {
+							useInfinite: true,
+							useInfiniteQueryParam: "page",
+						},
+					},
+				},
 			},
 			// Do not generate MSW mocks
 			mock: false,

--- a/src/webapp/pnpm-lock.yaml
+++ b/src/webapp/pnpm-lock.yaml
@@ -31,7 +31,7 @@ overrides:
   js-yaml: 4.3.1
   postcss: 8.5.23
   ip-address: 10.3.1
-  nanoid: 3.3.17
+  nanoid: ^3.3.18
   body-parser: 2.3.0
   '@babel/core': 7.29.6
   axios: 1.19.0
@@ -3784,8 +3784,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -7952,7 +7952,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -8207,7 +8207,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/src/webapp/pnpm-workspace.yaml
+++ b/src/webapp/pnpm-workspace.yaml
@@ -46,7 +46,8 @@ overrides:
   js-yaml: 4.3.1
   postcss: 8.5.23
   ip-address: 10.3.1
-  nanoid: 3.3.17
+  # postcss expects nanoid ^3; 3.3.18 is the patched release for GHSA-2v37-7h3g-55p8.
+  nanoid: ^3.3.18
   body-parser: 2.3.0
   "@babel/core": 7.29.6
   axios: 1.19.0

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { testIds } from "@/lib/test-ids";
 import { createMockFilterOptions } from "@/test-utils/factories";
+import { render, screen, within } from "@/test-utils/render";
 import { CourseFiltersPanel } from "./CourseFiltersPanel";
 import type { CourseFiltersParamsState } from "../courseFiltersParams";
 import {

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
@@ -365,6 +365,7 @@ const SELECT_FILTER_TEST_IDS: Record<string, string> = {
 	dept: testIds.filters.departmentSelect,
 	spec: testIds.filters.specialitySelect,
 	type: testIds.filters.typeSelect,
+	instructor: testIds.filters.instructorSelect,
 };
 
 function RangeFilters({

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
@@ -19,6 +19,7 @@ import {
 	CollapsibleTrigger,
 } from "@/components/ui/Collapsible";
 import { Combobox } from "@/components/ui/Combobox";
+import { InstructorFilterSelect } from "@/features/instructors/components/InstructorFilterSelect";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import {
@@ -489,6 +490,23 @@ function SelectFilters({
 					const currentValue = getSelectValue(key);
 					const testId = SELECT_FILTER_TEST_IDS[key];
 					const isDisabled = disabled || options.length === 0;
+
+					if (key === "instructor") {
+						return (
+							<div key={key} className="space-y-3">
+								<Label className="text-sm font-medium inline-flex items-center gap-1.5">
+									{label}
+									{disabledMessage && <InfoHint message={disabledMessage} />}
+								</Label>
+								<InstructorFilterSelect
+									value={currentValue}
+									onChange={(nextValue) => onSelectChange(key, nextValue)}
+									placeholder={placeholder}
+									data-testid={testId}
+								/>
+							</div>
+						);
+					}
 
 					const selectElement = useCombobox ? (
 						<Combobox

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
@@ -19,7 +19,6 @@ import {
 	CollapsibleTrigger,
 } from "@/components/ui/Collapsible";
 import { Combobox } from "@/components/ui/Combobox";
-import { InstructorFilterSelect } from "@/features/instructors/components/InstructorFilterSelect";
 import { Input } from "@/components/ui/Input";
 import { Label } from "@/components/ui/Label";
 import {
@@ -36,12 +35,14 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/Tooltip";
+import { InstructorFilterSelect } from "@/features/instructors/components/InstructorFilterSelect";
 import type {
 	CoursesListSemesterTermsItem,
 	CoursesListTypeKind,
 	EducationLevelEnum,
 	FilterOptions,
 } from "@/lib/api/generated";
+import { useFeatureFlag } from "@/lib/feature-flags";
 import { localStorageAdapter } from "@/lib/storage";
 import { testIds } from "@/lib/test-ids";
 import { cn } from "@/lib/utils";
@@ -474,6 +475,7 @@ function SelectFilters({
 	getSelectValue: (key: string) => string;
 	onSelectChange: (key: string, value: string) => void;
 }>) {
+	const showInstructorFilter = useFeatureFlag("fe_instructor_multiselect");
 	return (
 		<>
 			{filters.map(
@@ -492,6 +494,9 @@ function SelectFilters({
 					const isDisabled = disabled || options.length === 0;
 
 					if (key === "instructor") {
+						if (!showInstructorFilter) {
+							return null;
+						}
 						return (
 							<div key={key} className="space-y-3">
 								<Label className="text-sm font-medium inline-flex items-center gap-1.5">

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
@@ -1,7 +1,7 @@
-import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { createMockFilterOptions } from "@/test-utils/factories";
+import { renderHookWithProviders as renderHook } from "@/test-utils/render";
 import { useCourseFiltersData } from "./useCourseFiltersData";
 import type { CourseFiltersParamsState } from "../courseFiltersParams";
 import {
@@ -179,9 +179,16 @@ describe("useCourseFiltersData", () => {
 
 			// Assert
 			const selects = allSelectFilters(result.current);
-			expect(selects).toHaveLength(5);
+			expect(selects).toHaveLength(6);
 			const filterKeys = selects.map((f) => f.key);
-			expect(filterKeys).toEqual(["year", "faculty", "dept", "spec", "type"]);
+			expect(filterKeys).toEqual([
+				"year",
+				"faculty",
+				"dept",
+				"spec",
+				"type",
+				"instructor",
+			]);
 		});
 
 		it("should map filter options to select options", () => {

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
@@ -231,6 +231,13 @@ describe("useCourseFiltersData", () => {
 			// Assert
 			const selects = allSelectFilters(result.current);
 			selects.forEach((filter) => {
+				// The instructor filter is rendered by a dedicated server-search
+				// component, so it carries no inline options.
+				if (filter.key === "instructor") {
+					expect(filter.options).toEqual([]);
+					return;
+				}
+
 				if (filter.useCombobox) {
 					expect(filter.options).toHaveLength(1);
 					expect(filter.options[0].value).toBe("");

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.ts
@@ -1,10 +1,6 @@
 import * as React from "react";
 
-import {
-	EducationLevelEnum,
-	type FilterOptions,
-	useInstructorsList,
-} from "@/lib/api/generated";
+import { EducationLevelEnum, type FilterOptions } from "@/lib/api/generated";
 import type { CourseFiltersParamsState } from "../courseFiltersParams";
 import {
 	CREDITS_RANGE,
@@ -250,9 +246,6 @@ export function useCourseFiltersData({
 		[semesterYears, filters.year],
 	);
 
-	const topInstructorsQuery = useInstructorsList({ page_size: 50 });
-	const topInstructors = topInstructorsQuery.data?.items ?? [];
-
 	const educationLevelToggleOptions: EducationLevelToggle = React.useMemo(
 		() => ({
 			options: [
@@ -330,19 +323,13 @@ export function useCourseFiltersData({
 					: "Спочатку оберіть спеціальність",
 			},
 			{
+				// Rendered by a dedicated InstructorFilterSelect (server search +
+				// infinite scroll); options are fetched inside that component.
 				key: "instructor",
 				label: "Викладач",
 				placeholder: "Усі викладачі",
 				value: filters.instructor,
-				options: [
-					{ value: "", label: "Усі викладачі" },
-					...topInstructors
-						.filter((i) => i.id)
-						.map((i) => ({
-							value: i.id as string,
-							label: [i.last_name, i.first_name].filter(Boolean).join(" "),
-						})),
-				],
+				options: [],
 				contentClassName: "max-h-72",
 				useCombobox: true,
 			},
@@ -357,7 +344,6 @@ export function useCourseFiltersData({
 			filters.spec,
 			filters.type,
 			filters.instructor,
-			topInstructors,
 		],
 	);
 

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.ts
@@ -1,6 +1,10 @@
 import * as React from "react";
 
-import { EducationLevelEnum, type FilterOptions } from "@/lib/api/generated";
+import {
+	EducationLevelEnum,
+	type FilterOptions,
+	useInstructorsList,
+} from "@/lib/api/generated";
 import type { CourseFiltersParamsState } from "../courseFiltersParams";
 import {
 	CREDITS_RANGE,
@@ -246,6 +250,9 @@ export function useCourseFiltersData({
 		[semesterYears, filters.year],
 	);
 
+	const topInstructorsQuery = useInstructorsList({ page_size: 50 });
+	const topInstructors = topInstructorsQuery.data?.items ?? [];
+
 	const educationLevelToggleOptions: EducationLevelToggle = React.useMemo(
 		() => ({
 			options: [
@@ -322,6 +329,23 @@ export function useCourseFiltersData({
 					? undefined
 					: "Спочатку оберіть спеціальність",
 			},
+			{
+				key: "instructor",
+				label: "Викладач",
+				placeholder: "Усі викладачі",
+				value: filters.instructor,
+				options: [
+					{ value: "", label: "Усі викладачі" },
+					...topInstructors
+						.filter((i) => i.id)
+						.map((i) => ({
+							value: i.id as string,
+							label: [i.last_name, i.first_name].filter(Boolean).join(" "),
+						})),
+				],
+				contentClassName: "max-h-72",
+				useCombobox: true,
+			},
 		],
 		[
 			courseTypes,
@@ -332,6 +356,8 @@ export function useCourseFiltersData({
 			filters.dept,
 			filters.spec,
 			filters.type,
+			filters.instructor,
+			topInstructors,
 		],
 	);
 
@@ -369,6 +395,7 @@ export function useCourseFiltersData({
 		if (filters.spec) count++;
 		if (filters.type) count++;
 		if (filters.eduLevel) count++;
+		if (filters.instructor) count++;
 		return count;
 	}, [
 		filters.faculty,
@@ -376,6 +403,7 @@ export function useCourseFiltersData({
 		filters.spec,
 		filters.type,
 		filters.eduLevel,
+		filters.instructor,
 	]);
 
 	const activePresetIds = React.useMemo(() => {

--- a/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
@@ -1,0 +1,178 @@
+import * as React from "react";
+
+import { CheckIcon, ChevronDownIcon, Loader2Icon, XIcon } from "lucide-react";
+
+import {
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/Command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/Popover";
+import { useInstructorsRetrieve } from "@/lib/api/generated";
+import { lockBodyScroll } from "@/lib/body-scroll-lock";
+import { cn } from "@/lib/utils";
+import { useInfiniteInstructors } from "../hooks/useInfiniteInstructors";
+import { formatInstructorLabel } from "./InstructorMultiSelect";
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+interface InstructorFilterSelectProps {
+	/** Selected instructor id, or "" for none. */
+	readonly value: string;
+	readonly onChange: (next: string) => void;
+	readonly placeholder?: string;
+	readonly searchPlaceholder?: string;
+	readonly emptyText?: string;
+	readonly className?: string;
+	readonly "data-testid"?: string;
+}
+
+/** Single-select instructor picker for the courses filter: server search +
+ * infinite scroll over the full directory (not a truncated top-N list). */
+function InstructorFilterSelect({
+	value,
+	onChange,
+	placeholder = "Усі викладачі",
+	searchPlaceholder = "Пошук викладача…",
+	emptyText = "Викладачів не знайдено.",
+	className,
+	"data-testid": testId,
+}: InstructorFilterSelectProps) {
+	const [open, setOpen] = React.useState(false);
+	const [searchTerm, setSearchTerm] = React.useState("");
+	const [debouncedSearch, setDebouncedSearch] = React.useState("");
+
+	React.useEffect(() => {
+		const handle = setTimeout(
+			() => setDebouncedSearch(searchTerm.trim()),
+			SEARCH_DEBOUNCE_MS,
+		);
+		return () => clearTimeout(handle);
+	}, [searchTerm]);
+
+	React.useEffect(() => {
+		if (!open) {
+			return;
+		}
+		const unlock = lockBodyScroll();
+		return () => unlock();
+	}, [open]);
+
+	// Resolve the selected instructor's name — it may not be in the loaded
+	// page (e.g. when the id comes from the URL on first load).
+	const { data: selected } = useInstructorsRetrieve(value, {
+		query: { enabled: Boolean(value) },
+	});
+
+	const { allInstructors, hasMore, isFetchingNextPage, isLoading, loaderRef } =
+		useInfiniteInstructors({
+			search: debouncedSearch || undefined,
+			enabled: open,
+		});
+
+	const handleSelect = (id: string) => {
+		onChange(id);
+		setOpen(false);
+	};
+
+	const clear = (event: React.MouseEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+		onChange("");
+	};
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					role="combobox"
+					aria-expanded={open}
+					className={cn(
+						"border-input focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex min-h-9 w-full items-center gap-1 rounded-md border bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px]",
+						className,
+					)}
+					data-testid={testId}
+				>
+					<span className={cn("truncate", !value && "text-muted-foreground")}>
+						{value
+							? selected
+								? formatInstructorLabel(selected)
+								: "…"
+							: placeholder}
+					</span>
+					{value ? (
+						<button
+							type="button"
+							aria-label="Очистити викладача"
+							className="text-muted-foreground hover:text-destructive ml-auto cursor-pointer"
+							onClick={clear}
+						>
+							<XIcon className="size-4" />
+						</button>
+					) : (
+						<ChevronDownIcon className="ml-auto size-4 opacity-50" />
+					)}
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-(--radix-popover-trigger-width) p-0"
+				data-testid={testId ? `${testId}-content` : undefined}
+			>
+				<Command shouldFilter={false}>
+					<CommandInput
+						value={searchTerm}
+						onValueChange={setSearchTerm}
+						placeholder={searchPlaceholder}
+					/>
+					<CommandList
+						className="max-h-72 overflow-y-auto"
+						data-testid={testId ? `${testId}-list` : undefined}
+					>
+						{!isLoading && allInstructors.length === 0 ? (
+							<CommandEmpty>{emptyText}</CommandEmpty>
+						) : null}
+						{allInstructors.map((instr) => {
+							if (!instr.id) return null;
+							const id = instr.id;
+							return (
+								<CommandItem
+									key={id}
+									value={id}
+									onSelect={() => handleSelect(id)}
+									className="flex items-start gap-2"
+								>
+									<span className="break-words">
+										{formatInstructorLabel(instr)}
+									</span>
+									<CheckIcon
+										className={cn(
+											"ml-auto size-4 shrink-0",
+											value === id ? "opacity-100" : "opacity-0",
+										)}
+									/>
+								</CommandItem>
+							);
+						})}
+						{(isLoading || isFetchingNextPage) && (
+							<div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
+								<Loader2Icon className="size-3 animate-spin" />
+								Завантаження…
+							</div>
+						)}
+						{hasMore ? <div ref={loaderRef} className="h-2" /> : null}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+export { InstructorFilterSelect };
+export type { InstructorFilterSelectProps };

--- a/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
@@ -92,8 +92,7 @@ function InstructorFilterSelect({
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				{/* A div, not a button: the clear control below is itself a button and
-				    HTML forbids nesting interactive elements. */}
+				{/* A div, not a button — the clear control is a button. */}
 				<div
 					role="combobox"
 					tabIndex={0}

--- a/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
@@ -81,6 +81,8 @@ function InstructorFilterSelect({
 		setOpen(false);
 	};
 
+	const listId = React.useId();
+
 	const clear = (event: React.MouseEvent) => {
 		event.preventDefault();
 		event.stopPropagation();
@@ -90,11 +92,22 @@ function InstructorFilterSelect({
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				<button
-					type="button"
+				{/* A div, not a button: the clear control below is itself a button and
+				    HTML forbids nesting interactive elements. */}
+				<div
 					role="combobox"
+					tabIndex={0}
 					aria-expanded={open}
+					aria-haspopup="listbox"
+					aria-controls={listId}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							setOpen(!open);
+						}
+					}}
 					className={cn(
+						"cursor-pointer",
 						"border-input focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex min-h-9 w-full items-center gap-1 rounded-md border bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px]",
 						className,
 					)}
@@ -119,7 +132,7 @@ function InstructorFilterSelect({
 					) : (
 						<ChevronDownIcon className="ml-auto size-4 opacity-50" />
 					)}
-				</button>
+				</div>
 			</PopoverTrigger>
 			<PopoverContent
 				className="w-(--radix-popover-trigger-width) p-0"
@@ -132,6 +145,7 @@ function InstructorFilterSelect({
 						placeholder={searchPlaceholder}
 					/>
 					<CommandList
+						id={listId}
 						className="max-h-72 overflow-y-auto"
 						data-testid={testId ? `${testId}-list` : undefined}
 					>

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -146,6 +148,76 @@ describe("InstructorMultiSelect", () => {
 
 			// Assert
 			expect(onChange).toHaveBeenCalledWith(["b"]);
+		});
+
+		it("should keep a selected chip when search results no longer include it", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const selectedInstructor = createMockInstructor({
+				id: "kalynovska",
+				first_name: "Оксана",
+				last_name: "Калиновська",
+				patronymic: "В`ячеславівна",
+			});
+			const otherInstructor = createMockInstructor({
+				id: "hlybovets",
+				first_name: "Микола",
+				last_name: "Глибовець",
+				patronymic: "Миколайович",
+			});
+			let currentItems = [selectedInstructor];
+
+			mockedInfinite.mockImplementation(
+				() =>
+					({
+						data: {
+							pages: [
+								{
+									items: currentItems,
+									total: currentItems.length,
+									next_page: null,
+								},
+							],
+							pageParams: [],
+						},
+						fetchNextPage: vi.fn(),
+						hasNextPage: false,
+						isFetchingNextPage: false,
+						isLoading: false,
+					}) as unknown as ReturnType<typeof useInstructorsListInfinite>,
+			);
+
+			function Harness() {
+				const [value, setValue] = React.useState<string[]>([]);
+				return (
+					<InstructorMultiSelect
+						value={value}
+						onChange={setValue}
+						data-testid="instructor-select"
+					/>
+				);
+			}
+
+			renderWithProviders(<Harness />);
+
+			// Act
+			await user.click(screen.getByRole("combobox"));
+			const input = screen.getByPlaceholderText("Пошук викладача…");
+			await user.type(input, "Калиновська");
+			await user.click(
+				within(await screen.findByTestId("instructor-select-list")).getByText(
+					"Калиновська Оксана В`ячеславівна",
+				),
+			);
+
+			currentItems = [otherInstructor];
+			await user.clear(screen.getByPlaceholderText("Пошук викладача…"));
+
+			// Assert
+			expect(
+				screen.getByText("Калиновська Оксана В`ячеславівна"),
+			).toBeInTheDocument();
+			expect(screen.queryByText("Обрати викладача…")).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
@@ -1,0 +1,259 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Instructor } from "@/lib/api/generated";
+import { renderWithProviders } from "@/test-utils/render";
+import {
+	formatInstructorLabel,
+	InstructorMultiSelect,
+} from "./InstructorMultiSelect";
+
+// Mock the orval-generated infinite query hook backing the dropdown
+vi.mock("@/lib/api/generated", async () => {
+	const actual = await vi.importActual("@/lib/api/generated");
+	return {
+		...actual,
+		useInstructorsListInfinite: vi.fn(),
+	};
+});
+
+const { useInstructorsListInfinite } = await import("@/lib/api/generated");
+const mockedInfinite = vi.mocked(useInstructorsListInfinite);
+
+function createMockInstructor(overrides: Partial<Instructor> = {}): Instructor {
+	return {
+		id: "instructor-1",
+		first_name: "Іван",
+		last_name: "Іваненко",
+		email: "ivan@ukma.edu.ua",
+		...overrides,
+	};
+}
+
+function mockInstructors(items: Instructor[]) {
+	mockedInfinite.mockReturnValue({
+		data:
+			items.length > 0
+				? {
+						pages: [{ items, total: items.length, next_page: null }],
+						pageParams: [],
+					}
+				: undefined,
+		fetchNextPage: vi.fn(),
+		hasNextPage: false,
+		isFetchingNextPage: false,
+		isLoading: false,
+	} as unknown as ReturnType<typeof useInstructorsListInfinite>);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockInstructors([]);
+	// cmdk scrolls the active item into view; jsdom lacks this API
+	Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("formatInstructorLabel", () => {
+	it("should order last, first, then patronymic", () => {
+		const label = formatInstructorLabel(
+			createMockInstructor({
+				last_name: "Іваненко",
+				first_name: "Іван",
+				patronymic: "Петрович",
+			}),
+		);
+		expect(label).toBe("Іваненко Іван Петрович");
+	});
+
+	it("should omit a missing patronymic", () => {
+		const label = formatInstructorLabel(
+			createMockInstructor({
+				last_name: "Іваненко",
+				first_name: "Іван",
+				patronymic: undefined,
+			}),
+		);
+		expect(label).toBe("Іваненко Іван");
+	});
+
+	it("should filter out blank name parts", () => {
+		const label = formatInstructorLabel({
+			id: "x",
+			last_name: "",
+			first_name: "Іван",
+			email: "x@ukma.edu.ua",
+		});
+		expect(label).toBe("Іван");
+	});
+});
+
+describe("InstructorMultiSelect", () => {
+	describe("Selected Chips", () => {
+		it("should render a chip for each selected instructor", () => {
+			// Arrange
+			const selected = createMockInstructor({
+				id: "instructor-1",
+				last_name: "Іваненко",
+				first_name: "Іван",
+			});
+
+			// Act
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={["instructor-1"]}
+					onChange={vi.fn()}
+					initialOptions={[selected]}
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("Іваненко Іван")).toBeInTheDocument();
+		});
+
+		it("should show the placeholder when nothing is selected", () => {
+			// Act
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={[]}
+					onChange={vi.fn()}
+					placeholder="Обрати викладача…"
+				/>,
+			);
+
+			// Assert
+			expect(screen.getByText("Обрати викладача…")).toBeInTheDocument();
+		});
+
+		it("should call onChange without the removed id when a chip is removed", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const onChange = vi.fn();
+			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
+			const b = createMockInstructor({ id: "b", last_name: "Борисенко" });
+
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={["a", "b"]}
+					onChange={onChange}
+					initialOptions={[a, b]}
+				/>,
+			);
+
+			// Act
+			const removeButton = screen.getByRole("button", {
+				name: /Видалити Алексенко/,
+			});
+			await user.click(removeButton);
+
+			// Assert
+			expect(onChange).toHaveBeenCalledWith(["b"]);
+		});
+	});
+
+	describe("Option Toggling", () => {
+		it("should add an option when toggled on", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const onChange = vi.fn();
+			const option = createMockInstructor({ id: "a", last_name: "Алексенко" });
+			mockInstructors([option]);
+
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={[]}
+					onChange={onChange}
+					data-testid="instructor-select"
+				/>,
+			);
+
+			// Act: open the dropdown then click the option
+			await user.click(screen.getByRole("combobox"));
+			const list = await screen.findByTestId("instructor-select-list");
+			await user.click(within(list).getByText("Алексенко Іван"));
+
+			// Assert
+			expect(onChange).toHaveBeenCalledWith(["a"]);
+		});
+
+		it("should remove an already-selected option when toggled off", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const onChange = vi.fn();
+			const option = createMockInstructor({ id: "a", last_name: "Алексенко" });
+			mockInstructors([option]);
+
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={["a"]}
+					onChange={onChange}
+					initialOptions={[option]}
+					data-testid="instructor-select"
+				/>,
+			);
+
+			// Act
+			await user.click(screen.getByRole("combobox"));
+			const list = await screen.findByTestId("instructor-select-list");
+			await user.click(within(list).getByText("Алексенко Іван"));
+
+			// Assert
+			expect(onChange).toHaveBeenCalledWith([]);
+		});
+	});
+
+	describe("maxSelected", () => {
+		it("should not add beyond the cap", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const onChange = vi.fn();
+			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
+			const b = createMockInstructor({ id: "b", last_name: "Борисенко" });
+			mockInstructors([a, b]);
+
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={["a"]}
+					onChange={onChange}
+					initialOptions={[a]}
+					maxSelected={1}
+					data-testid="instructor-select"
+				/>,
+			);
+
+			// Act: try to add a second option while at the cap
+			await user.click(screen.getByRole("combobox"));
+			const list = await screen.findByTestId("instructor-select-list");
+			await user.click(within(list).getByText("Борисенко Іван"));
+
+			// Assert
+			expect(onChange).not.toHaveBeenCalled();
+		});
+
+		it("should still allow deselecting at the cap", async () => {
+			// Arrange
+			const user = userEvent.setup();
+			const onChange = vi.fn();
+			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
+			mockInstructors([a]);
+
+			renderWithProviders(
+				<InstructorMultiSelect
+					value={["a"]}
+					onChange={onChange}
+					initialOptions={[a]}
+					maxSelected={1}
+					data-testid="instructor-select"
+				/>,
+			);
+
+			// Act
+			await user.click(screen.getByRole("combobox"));
+			const list = await screen.findByTestId("instructor-select-list");
+			await user.click(within(list).getByText("Алексенко Іван"));
+
+			// Assert
+			expect(onChange).toHaveBeenCalledWith([]);
+		});
+	});
+});

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
@@ -26,7 +26,6 @@ function createMockInstructor(overrides: Partial<Instructor> = {}): Instructor {
 		id: "instructor-1",
 		first_name: "Іван",
 		last_name: "Іваненко",
-		email: "ivan@ukma.edu.ua",
 		...overrides,
 	};
 }
@@ -82,7 +81,6 @@ describe("formatInstructorLabel", () => {
 			id: "x",
 			last_name: "",
 			first_name: "Іван",
-			email: "x@ukma.edu.ua",
 		});
 		expect(label).toBe("Іван");
 	});

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
@@ -91,14 +91,12 @@ describe("formatInstructorLabel", () => {
 describe("InstructorMultiSelect", () => {
 	describe("Selected Chips", () => {
 		it("should render a chip for each selected instructor", () => {
-			// Arrange
 			const selected = createMockInstructor({
 				id: "instructor-1",
 				last_name: "Іваненко",
 				first_name: "Іван",
 			});
 
-			// Act
 			renderWithProviders(
 				<InstructorMultiSelect
 					value={["instructor-1"]}
@@ -107,12 +105,10 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Assert
 			expect(screen.getByText("Іваненко Іван")).toBeInTheDocument();
 		});
 
 		it("should show the placeholder when nothing is selected", () => {
-			// Act
 			renderWithProviders(
 				<InstructorMultiSelect
 					value={[]}
@@ -121,12 +117,10 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Assert
 			expect(screen.getByText("Обрати викладача…")).toBeInTheDocument();
 		});
 
 		it("should call onChange without the removed id when a chip is removed", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const onChange = vi.fn();
 			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
@@ -140,18 +134,15 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Act
 			const removeButton = screen.getByRole("button", {
 				name: /Видалити Алексенко/,
 			});
 			await user.click(removeButton);
 
-			// Assert
 			expect(onChange).toHaveBeenCalledWith(["b"]);
 		});
 
 		it("should keep a selected chip when search results no longer include it", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const selectedInstructor = createMockInstructor({
 				id: "kalynovska",
@@ -200,7 +191,6 @@ describe("InstructorMultiSelect", () => {
 
 			renderWithProviders(<Harness />);
 
-			// Act
 			await user.click(screen.getByRole("combobox"));
 			const input = screen.getByPlaceholderText("Пошук викладача…");
 			await user.type(input, "Калиновська");
@@ -213,7 +203,6 @@ describe("InstructorMultiSelect", () => {
 			currentItems = [otherInstructor];
 			await user.clear(screen.getByPlaceholderText("Пошук викладача…"));
 
-			// Assert
 			expect(
 				screen.getByText("Калиновська Оксана В`ячеславівна"),
 			).toBeInTheDocument();
@@ -223,7 +212,6 @@ describe("InstructorMultiSelect", () => {
 
 	describe("Option Toggling", () => {
 		it("should add an option when toggled on", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const onChange = vi.fn();
 			const option = createMockInstructor({ id: "a", last_name: "Алексенко" });
@@ -237,17 +225,14 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Act: open the dropdown then click the option
 			await user.click(screen.getByRole("combobox"));
 			const list = await screen.findByTestId("instructor-select-list");
 			await user.click(within(list).getByText("Алексенко Іван"));
 
-			// Assert
 			expect(onChange).toHaveBeenCalledWith(["a"]);
 		});
 
 		it("should remove an already-selected option when toggled off", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const onChange = vi.fn();
 			const option = createMockInstructor({ id: "a", last_name: "Алексенко" });
@@ -262,19 +247,16 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Act
 			await user.click(screen.getByRole("combobox"));
 			const list = await screen.findByTestId("instructor-select-list");
 			await user.click(within(list).getByText("Алексенко Іван"));
 
-			// Assert
 			expect(onChange).toHaveBeenCalledWith([]);
 		});
 	});
 
 	describe("maxSelected", () => {
 		it("should not add beyond the cap", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const onChange = vi.fn();
 			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
@@ -291,17 +273,15 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Act: try to add a second option while at the cap
+			// The cap must block additions but still allow deselection.
 			await user.click(screen.getByRole("combobox"));
 			const list = await screen.findByTestId("instructor-select-list");
 			await user.click(within(list).getByText("Борисенко Іван"));
 
-			// Assert
 			expect(onChange).not.toHaveBeenCalled();
 		});
 
 		it("should still allow deselecting at the cap", async () => {
-			// Arrange
 			const user = userEvent.setup();
 			const onChange = vi.fn();
 			const a = createMockInstructor({ id: "a", last_name: "Алексенко" });
@@ -317,12 +297,10 @@ describe("InstructorMultiSelect", () => {
 				/>,
 			);
 
-			// Act
 			await user.click(screen.getByRole("combobox"));
 			const list = await screen.findByTestId("instructor-select-list");
 			await user.click(within(list).getByText("Алексенко Іван"));
 
-			// Assert
 			expect(onChange).toHaveBeenCalledWith([]);
 		});
 	});

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -17,7 +17,6 @@ import {
 import type { Instructor } from "@/lib/api/generated";
 import { lockBodyScroll } from "@/lib/body-scroll-lock";
 import { cn } from "@/lib/utils";
-
 import { useInfiniteInstructors } from "../hooks/useInfiniteInstructors";
 
 function formatInstructorLabel(instructor: Instructor): string {
@@ -79,18 +78,13 @@ function InstructorMultiSelect({
 		return () => unlock();
 	}, [open]);
 
-	const {
-		allInstructors,
-		hasMore,
-		isFetchingNextPage,
-		isLoading,
-		loaderRef,
-	} = useInfiniteInstructors({
-		search: debouncedSearch || undefined,
-		courseOfferingId,
-		specialityId,
-		enabled: open,
-	});
+	const { allInstructors, hasMore, isFetchingNextPage, isLoading, loaderRef } =
+		useInfiniteInstructors({
+			search: debouncedSearch || undefined,
+			courseOfferingId,
+			specialityId,
+			enabled: open,
+		});
 
 	const optionsById = React.useMemo(() => {
 		const map = new Map<string, Instructor>();
@@ -144,7 +138,9 @@ function InstructorMultiSelect({
 					data-testid={testId}
 				>
 					{selectedInstructors.length === 0 ? (
-						<span className="text-muted-foreground truncate">{placeholder}</span>
+						<span className="text-muted-foreground truncate">
+							{placeholder}
+						</span>
 					) : (
 						selectedInstructors.map((instr) => (
 							<span

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -192,14 +192,9 @@ function InstructorMultiSelect({
 									onSelect={() => toggleValue(id)}
 									className="flex items-start gap-2"
 								>
-									<div className="flex flex-col">
-										<span className="break-words">
-											{formatInstructorLabel(instr)}
-										</span>
-										<span className="text-muted-foreground text-xs">
-											{instr.email}
-										</span>
-									</div>
+									<span className="break-words">
+										{formatInstructorLabel(instr)}
+									</span>
 									<CheckIcon
 										className={cn(
 											"ml-auto size-4 shrink-0",

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -34,6 +34,7 @@ interface InstructorMultiSelectProps {
 	readonly onChange: (next: string[]) => void;
 	readonly initialOptions?: readonly Instructor[];
 	readonly courseOfferingId?: string;
+	readonly courseId?: string;
 	readonly specialityId?: string;
 	readonly placeholder?: string;
 	readonly searchPlaceholder?: string;
@@ -49,6 +50,7 @@ function InstructorMultiSelect({
 	onChange,
 	initialOptions = [],
 	courseOfferingId,
+	courseId,
 	specialityId,
 	placeholder = "Обрати викладача…",
 	searchPlaceholder = "Пошук викладача…",
@@ -82,6 +84,7 @@ function InstructorMultiSelect({
 		useInfiniteInstructors({
 			search: debouncedSearch || undefined,
 			courseOfferingId,
+			courseId,
 			specialityId,
 			enabled: open,
 		});

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -5,6 +5,7 @@ import { CheckIcon, ChevronDownIcon, Loader2Icon, XIcon } from "lucide-react";
 import {
 	Command,
 	CommandEmpty,
+	CommandGroup,
 	CommandInput,
 	CommandItem,
 	CommandList,
@@ -63,6 +64,9 @@ function InstructorMultiSelect({
 	const [open, setOpen] = React.useState(false);
 	const [searchTerm, setSearchTerm] = React.useState("");
 	const [debouncedSearch, setDebouncedSearch] = React.useState("");
+	const [selectedOptionsById, setSelectedOptionsById] = React.useState<
+		Map<string, Instructor>
+	>(() => new Map());
 
 	React.useEffect(() => {
 		const handle = setTimeout(
@@ -102,7 +106,37 @@ function InstructorMultiSelect({
 
 	const selectedSet = React.useMemo(() => new Set(value), [value]);
 
-	const toggleValue = (id: string) => {
+	React.useEffect(() => {
+		setSelectedOptionsById((current) => {
+			let changed = false;
+			const next = new Map(current);
+
+			for (const id of next.keys()) {
+				if (!selectedSet.has(id)) {
+					next.delete(id);
+					changed = true;
+				}
+			}
+
+			for (const option of [...initialOptions, ...allInstructors]) {
+				if (!option.id || !selectedSet.has(option.id)) {
+					continue;
+				}
+
+				if (next.get(option.id) !== option) {
+					next.set(option.id, option);
+					changed = true;
+				}
+			}
+
+			return changed ? next : current;
+		});
+	}, [initialOptions, allInstructors, selectedSet]);
+
+	const toggleValue = (instr: Instructor) => {
+		if (!instr.id) return;
+		const id = instr.id;
+
 		if (selectedSet.has(id)) {
 			onChange(value.filter((v) => v !== id));
 			return;
@@ -110,6 +144,11 @@ function InstructorMultiSelect({
 		if (maxSelected !== undefined && value.length >= maxSelected) {
 			return;
 		}
+		setSelectedOptionsById((current) => {
+			const next = new Map(current);
+			next.set(id, instr);
+			return next;
+		});
 		onChange([...value, id]);
 	};
 
@@ -120,7 +159,7 @@ function InstructorMultiSelect({
 	};
 
 	const selectedInstructors = value
-		.map((id) => optionsById.get(id))
+		.map((id) => selectedOptionsById.get(id) ?? optionsById.get(id))
 		.filter(
 			(instr): instr is Instructor & { id: string } =>
 				instr !== undefined && Boolean(instr.id),
@@ -184,29 +223,31 @@ function InstructorMultiSelect({
 						{!isLoading && allInstructors.length === 0 ? (
 							<CommandEmpty>{emptyText}</CommandEmpty>
 						) : null}
-						{allInstructors.map((instr) => {
-							if (!instr.id) return null;
-							const id = instr.id;
-							const isSelected = selectedSet.has(id);
-							return (
-								<CommandItem
-									key={id}
-									value={id}
-									onSelect={() => toggleValue(id)}
-									className="flex items-start gap-2"
-								>
-									<span className="break-words">
-										{formatInstructorLabel(instr)}
-									</span>
-									<CheckIcon
-										className={cn(
-											"ml-auto size-4 shrink-0",
-											isSelected ? "opacity-100" : "opacity-0",
-										)}
-									/>
-								</CommandItem>
-							);
-						})}
+						<CommandGroup>
+							{allInstructors.map((instr) => {
+								if (!instr.id) return null;
+								const id = instr.id;
+								const isSelected = selectedSet.has(id);
+								return (
+									<CommandItem
+										key={id}
+										value={id}
+										onSelect={() => toggleValue(instr)}
+										className="flex items-start gap-2"
+									>
+										<span className="break-words">
+											{formatInstructorLabel(instr)}
+										</span>
+										<CheckIcon
+											className={cn(
+												"ml-auto size-4 shrink-0",
+												isSelected ? "opacity-100" : "opacity-0",
+											)}
+										/>
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
 						{(isLoading || isFetchingNextPage) && (
 							<div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
 								<Loader2Icon className="size-3 animate-spin" />

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -1,0 +1,231 @@
+import * as React from "react";
+
+import { CheckIcon, ChevronDownIcon, Loader2Icon, XIcon } from "lucide-react";
+
+import {
+	Command,
+	CommandEmpty,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/Command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/Popover";
+import type { Instructor } from "@/lib/api/generated";
+import { lockBodyScroll } from "@/lib/body-scroll-lock";
+import { cn } from "@/lib/utils";
+
+import { useInfiniteInstructors } from "../hooks/useInfiniteInstructors";
+
+function formatInstructorLabel(instructor: Instructor): string {
+	const parts = [instructor.last_name ?? "", instructor.first_name ?? ""];
+	if (instructor.patronymic) {
+		parts.push(instructor.patronymic);
+	}
+	return parts.filter(Boolean).join(" ");
+}
+
+const SEARCH_DEBOUNCE_MS = 200;
+
+interface InstructorMultiSelectProps {
+	readonly value: readonly string[];
+	readonly onChange: (next: string[]) => void;
+	readonly initialOptions?: readonly Instructor[];
+	readonly courseOfferingId?: string;
+	readonly specialityId?: string;
+	readonly placeholder?: string;
+	readonly searchPlaceholder?: string;
+	readonly emptyText?: string;
+	readonly disabled?: boolean;
+	readonly maxSelected?: number;
+	readonly className?: string;
+	readonly "data-testid"?: string;
+}
+
+function InstructorMultiSelect({
+	value,
+	onChange,
+	initialOptions = [],
+	courseOfferingId,
+	specialityId,
+	placeholder = "Обрати викладача…",
+	searchPlaceholder = "Пошук викладача…",
+	emptyText = "Викладачів не знайдено.",
+	disabled = false,
+	maxSelected,
+	className,
+	"data-testid": testId,
+}: InstructorMultiSelectProps) {
+	const [open, setOpen] = React.useState(false);
+	const [searchTerm, setSearchTerm] = React.useState("");
+	const [debouncedSearch, setDebouncedSearch] = React.useState("");
+
+	React.useEffect(() => {
+		const handle = setTimeout(
+			() => setDebouncedSearch(searchTerm.trim()),
+			SEARCH_DEBOUNCE_MS,
+		);
+		return () => clearTimeout(handle);
+	}, [searchTerm]);
+
+	React.useEffect(() => {
+		if (!open) {
+			return;
+		}
+		const unlock = lockBodyScroll();
+		return () => unlock();
+	}, [open]);
+
+	const {
+		allInstructors,
+		hasMore,
+		isFetchingNextPage,
+		isLoading,
+		loaderRef,
+	} = useInfiniteInstructors({
+		search: debouncedSearch || undefined,
+		courseOfferingId,
+		specialityId,
+		enabled: open,
+	});
+
+	const optionsById = React.useMemo(() => {
+		const map = new Map<string, Instructor>();
+		for (const option of initialOptions) {
+			if (option.id) map.set(option.id, option);
+		}
+		for (const option of allInstructors) {
+			if (option.id) map.set(option.id, option);
+		}
+		return map;
+	}, [initialOptions, allInstructors]);
+
+	const selectedSet = React.useMemo(() => new Set(value), [value]);
+
+	const toggleValue = (id: string) => {
+		if (selectedSet.has(id)) {
+			onChange(value.filter((v) => v !== id));
+			return;
+		}
+		if (maxSelected !== undefined && value.length >= maxSelected) {
+			return;
+		}
+		onChange([...value, id]);
+	};
+
+	const removeValue = (event: React.MouseEvent, id: string) => {
+		event.preventDefault();
+		event.stopPropagation();
+		onChange(value.filter((v) => v !== id));
+	};
+
+	const selectedInstructors = value
+		.map((id) => optionsById.get(id))
+		.filter(
+			(instr): instr is Instructor & { id: string } =>
+				instr !== undefined && Boolean(instr.id),
+		);
+
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					role="combobox"
+					aria-expanded={open}
+					className={cn(
+						"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+						className,
+					)}
+					disabled={disabled}
+					data-testid={testId}
+				>
+					{selectedInstructors.length === 0 ? (
+						<span className="text-muted-foreground truncate">{placeholder}</span>
+					) : (
+						selectedInstructors.map((instr) => (
+							<span
+								key={instr.id}
+								className="bg-secondary text-secondary-foreground inline-flex items-center gap-1 rounded-sm px-2 py-0.5 text-xs"
+							>
+								<span className="break-words">
+									{formatInstructorLabel(instr)}
+								</span>
+								<button
+									type="button"
+									aria-label={`Видалити ${formatInstructorLabel(instr)}`}
+									className="hover:text-destructive cursor-pointer"
+									onClick={(e) => removeValue(e, instr.id)}
+								>
+									<XIcon className="size-3" />
+								</button>
+							</span>
+						))
+					)}
+					<ChevronDownIcon className="ml-auto size-4 opacity-50" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				className="w-(--radix-popover-trigger-width) p-0"
+				data-testid={testId ? `${testId}-content` : undefined}
+			>
+				<Command shouldFilter={false}>
+					<CommandInput
+						value={searchTerm}
+						onValueChange={setSearchTerm}
+						placeholder={searchPlaceholder}
+					/>
+					<CommandList
+						className="max-h-72 overflow-y-auto"
+						data-testid={testId ? `${testId}-list` : undefined}
+					>
+						{!isLoading && allInstructors.length === 0 ? (
+							<CommandEmpty>{emptyText}</CommandEmpty>
+						) : null}
+						{allInstructors.map((instr) => {
+							if (!instr.id) return null;
+							const id = instr.id;
+							const isSelected = selectedSet.has(id);
+							return (
+								<CommandItem
+									key={id}
+									value={id}
+									onSelect={() => toggleValue(id)}
+									className="flex items-start gap-2"
+								>
+									<div className="flex flex-col">
+										<span className="break-words">
+											{formatInstructorLabel(instr)}
+										</span>
+										<span className="text-muted-foreground text-xs">
+											{instr.email}
+										</span>
+									</div>
+									<CheckIcon
+										className={cn(
+											"ml-auto size-4 shrink-0",
+											isSelected ? "opacity-100" : "opacity-0",
+										)}
+									/>
+								</CommandItem>
+							);
+						})}
+						{(isLoading || isFetchingNextPage) && (
+							<div className="text-muted-foreground flex items-center justify-center gap-2 py-2 text-xs">
+								<Loader2Icon className="size-3 animate-spin" />
+								Завантаження…
+							</div>
+						)}
+						{hasMore ? <div ref={loaderRef} className="h-2" /> : null}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+export { InstructorMultiSelect, formatInstructorLabel };
+export type { InstructorMultiSelectProps };

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -170,8 +170,7 @@ function InstructorMultiSelect({
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				{/* A div, not a button: the chip remove controls below are themselves
-				    buttons and HTML forbids nesting interactive elements. */}
+				{/* A div, not a button — the chip remove controls are buttons. */}
 				<div
 					role="combobox"
 					tabIndex={disabled ? -1 : 0}
@@ -218,8 +217,7 @@ function InstructorMultiSelect({
 							</span>
 						))
 					)}
-					{/* Stable open target: the rest of the trigger is covered by chips
-					    whose remove buttons swallow the click. */}
+					{/* Stable open target: chips cover the rest of the trigger. */}
 					<ChevronDownIcon
 						className="ml-auto size-4 shrink-0 opacity-50"
 						data-testid={testId ? `${testId}-toggle` : undefined}

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -152,6 +152,8 @@ function InstructorMultiSelect({
 		onChange([...value, id]);
 	};
 
+	const listId = React.useId();
+
 	const removeValue = (event: React.MouseEvent, id: string) => {
 		event.preventDefault();
 		event.stopPropagation();
@@ -168,15 +170,28 @@ function InstructorMultiSelect({
 	return (
 		<Popover open={open} onOpenChange={setOpen}>
 			<PopoverTrigger asChild>
-				<button
-					type="button"
+				{/* A div, not a button: the chip remove controls below are themselves
+				    buttons and HTML forbids nesting interactive elements. */}
+				<div
 					role="combobox"
+					tabIndex={disabled ? -1 : 0}
 					aria-expanded={open}
+					aria-haspopup="listbox"
+					aria-controls={listId}
+					aria-disabled={disabled || undefined}
+					onKeyDown={(event) => {
+						if (disabled) {
+							return;
+						}
+						if (event.key === "Enter" || event.key === " ") {
+							event.preventDefault();
+							setOpen(!open);
+						}
+					}}
 					className={cn(
-						"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex min-h-9 w-full flex-wrap items-center gap-1 rounded-md border bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+						"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50 flex min-h-9 w-full cursor-pointer flex-wrap items-center gap-1 rounded-md border bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] aria-disabled:cursor-not-allowed aria-disabled:opacity-50",
 						className,
 					)}
-					disabled={disabled}
 					data-testid={testId}
 				>
 					{selectedInstructors.length === 0 ? (
@@ -204,7 +219,7 @@ function InstructorMultiSelect({
 						))
 					)}
 					<ChevronDownIcon className="ml-auto size-4 opacity-50" />
-				</button>
+				</div>
 			</PopoverTrigger>
 			<PopoverContent
 				className="w-(--radix-popover-trigger-width) p-0"
@@ -217,6 +232,7 @@ function InstructorMultiSelect({
 						placeholder={searchPlaceholder}
 					/>
 					<CommandList
+						id={listId}
 						className="max-h-72 overflow-y-auto"
 						data-testid={testId ? `${testId}-list` : undefined}
 					>

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.tsx
@@ -218,7 +218,12 @@ function InstructorMultiSelect({
 							</span>
 						))
 					)}
-					<ChevronDownIcon className="ml-auto size-4 opacity-50" />
+					{/* Stable open target: the rest of the trigger is covered by chips
+					    whose remove buttons swallow the click. */}
+					<ChevronDownIcon
+						className="ml-auto size-4 shrink-0 opacity-50"
+						data-testid={testId ? `${testId}-toggle` : undefined}
+					/>
 				</div>
 			</PopoverTrigger>
 			<PopoverContent

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
@@ -45,7 +45,6 @@ function createMockInstructor(overrides: Partial<Instructor> = {}): Instructor {
 		id: "instructor-1",
 		first_name: "Іван",
 		last_name: "Іваненко",
-		email: "ivan@ukma.edu.ua",
 		...overrides,
 	};
 }

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
@@ -1,0 +1,205 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Instructor, InstructorsListParams } from "@/lib/api/generated";
+import { useInfiniteInstructors } from "./useInfiniteInstructors";
+
+// Mock the orval-generated infinite query hook
+vi.mock("@/lib/api/generated", async () => {
+	const actual = await vi.importActual("@/lib/api/generated");
+	return {
+		...actual,
+		useInstructorsListInfinite: vi.fn(),
+	};
+});
+
+const { useInstructorsListInfinite } = await import("@/lib/api/generated");
+const mockedInfinite = vi.mocked(useInstructorsListInfinite);
+
+interface MockPage {
+	items: Instructor[];
+	total: number;
+	next_page: number | null;
+}
+
+function createMockInfiniteReturn(
+	overrides: Partial<{
+		pages: MockPage[];
+		hasNextPage: boolean;
+		isFetchingNextPage: boolean;
+		isLoading: boolean;
+	}> = {},
+) {
+	const pages = overrides.pages ?? [];
+	return {
+		data: pages.length > 0 ? { pages, pageParams: [] } : undefined,
+		fetchNextPage: vi.fn(),
+		hasNextPage: overrides.hasNextPage ?? false,
+		isFetchingNextPage: overrides.isFetchingNextPage ?? false,
+		isLoading: overrides.isLoading ?? false,
+	} as unknown as ReturnType<typeof useInstructorsListInfinite>;
+}
+
+function createMockInstructor(overrides: Partial<Instructor> = {}): Instructor {
+	return {
+		id: "instructor-1",
+		first_name: "Іван",
+		last_name: "Іваненко",
+		email: "ivan@ukma.edu.ua",
+		...overrides,
+	};
+}
+
+/** Read the params passed to the most recent useInstructorsListInfinite call */
+function lastCallParams(): InstructorsListParams {
+	const calls = mockedInfinite.mock.calls;
+	return calls[calls.length - 1][0] as InstructorsListParams;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockedInfinite.mockReturnValue(createMockInfiniteReturn());
+});
+
+describe("useInfiniteInstructors", () => {
+	describe("Query Params", () => {
+		it("should omit empty search, courseOfferingId, and specialityId", () => {
+			// Act
+			renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(lastCallParams()).toEqual({ page_size: 20 });
+		});
+
+		it("should include provided filters with snake_case keys", () => {
+			// Act
+			renderHook(() =>
+				useInfiniteInstructors({
+					search: "Іван",
+					courseOfferingId: "offering-1",
+					specialityId: "spec-1",
+				}),
+			);
+
+			// Assert
+			expect(lastCallParams()).toEqual({
+				page_size: 20,
+				search: "Іван",
+				course_offering_id: "offering-1",
+				speciality_id: "spec-1",
+			});
+		});
+
+		it("should respect a custom pageSize", () => {
+			// Act
+			renderHook(() => useInfiniteInstructors({ pageSize: 50 }));
+
+			// Assert
+			expect(lastCallParams()).toEqual({ page_size: 50 });
+		});
+	});
+
+	describe("Derived Output", () => {
+		it("should flat-map instructors across multiple pages", () => {
+			// Arrange
+			const a = createMockInstructor({ id: "a" });
+			const b = createMockInstructor({ id: "b" });
+			const c = createMockInstructor({ id: "c" });
+			mockedInfinite.mockReturnValue(
+				createMockInfiniteReturn({
+					pages: [
+						{ items: [a, b], total: 3, next_page: 2 },
+						{ items: [c], total: 3, next_page: null },
+					],
+				}),
+			);
+
+			// Act
+			const { result } = renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(result.current.allInstructors).toEqual([a, b, c]);
+		});
+
+		it("should expose total from the first page", () => {
+			// Arrange
+			mockedInfinite.mockReturnValue(
+				createMockInfiniteReturn({
+					pages: [
+						{ items: [createMockInstructor()], total: 42, next_page: 2 },
+						{ items: [], total: 99, next_page: null },
+					],
+				}),
+			);
+
+			// Act
+			const { result } = renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(result.current.total).toBe(42);
+		});
+
+		it("should return an empty list and undefined total when no data", () => {
+			// Act
+			const { result } = renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(result.current.allInstructors).toEqual([]);
+			expect(result.current.total).toBeUndefined();
+		});
+
+		it("should derive hasMore from hasNextPage", () => {
+			// Arrange
+			mockedInfinite.mockReturnValue(
+				createMockInfiniteReturn({
+					pages: [{ items: [createMockInstructor()], total: 1, next_page: 2 }],
+					hasNextPage: true,
+				}),
+			);
+
+			// Act
+			const { result } = renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(result.current.hasMore).toBe(true);
+		});
+
+		it("should report hasMore as false when there is no next page", () => {
+			// Arrange
+			mockedInfinite.mockReturnValue(
+				createMockInfiniteReturn({
+					pages: [
+						{ items: [createMockInstructor()], total: 1, next_page: null },
+					],
+					hasNextPage: false,
+				}),
+			);
+
+			// Act
+			const { result } = renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			expect(result.current.hasMore).toBe(false);
+		});
+	});
+
+	describe("Query Options", () => {
+		it("should forward enabled=false to the query options", () => {
+			// Act
+			renderHook(() => useInfiniteInstructors({ enabled: false }));
+
+			// Assert
+			const options = mockedInfinite.mock.calls.at(-1)?.[1];
+			expect(options?.query?.enabled).toBe(false);
+		});
+
+		it("should default enabled to true", () => {
+			// Act
+			renderHook(() => useInfiniteInstructors());
+
+			// Assert
+			const options = mockedInfinite.mock.calls.at(-1)?.[1];
+			expect(options?.query?.enabled).toBe(true);
+		});
+	});
+});

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
@@ -63,15 +63,12 @@ beforeEach(() => {
 describe("useInfiniteInstructors", () => {
 	describe("Query Params", () => {
 		it("should omit empty search, courseOfferingId, and specialityId", () => {
-			// Act
 			renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(lastCallParams()).toEqual({ page_size: 20 });
 		});
 
 		it("should include provided filters with snake_case keys", () => {
-			// Act
 			renderHook(() =>
 				useInfiniteInstructors({
 					search: "Іван",
@@ -80,7 +77,6 @@ describe("useInfiniteInstructors", () => {
 				}),
 			);
 
-			// Assert
 			expect(lastCallParams()).toEqual({
 				page_size: 20,
 				search: "Іван",
@@ -90,17 +86,14 @@ describe("useInfiniteInstructors", () => {
 		});
 
 		it("should respect a custom pageSize", () => {
-			// Act
 			renderHook(() => useInfiniteInstructors({ pageSize: 50 }));
 
-			// Assert
 			expect(lastCallParams()).toEqual({ page_size: 50 });
 		});
 	});
 
 	describe("Derived Output", () => {
 		it("should flat-map instructors across multiple pages", () => {
-			// Arrange
 			const a = createMockInstructor({ id: "a" });
 			const b = createMockInstructor({ id: "b" });
 			const c = createMockInstructor({ id: "c" });
@@ -113,15 +106,12 @@ describe("useInfiniteInstructors", () => {
 				}),
 			);
 
-			// Act
 			const { result } = renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(result.current.allInstructors).toEqual([a, b, c]);
 		});
 
 		it("should expose total from the first page", () => {
-			// Arrange
 			mockedInfinite.mockReturnValue(
 				createMockInfiniteReturn({
 					pages: [
@@ -131,24 +121,19 @@ describe("useInfiniteInstructors", () => {
 				}),
 			);
 
-			// Act
 			const { result } = renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(result.current.total).toBe(42);
 		});
 
 		it("should return an empty list and undefined total when no data", () => {
-			// Act
 			const { result } = renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(result.current.allInstructors).toEqual([]);
 			expect(result.current.total).toBeUndefined();
 		});
 
 		it("should derive hasMore from hasNextPage", () => {
-			// Arrange
 			mockedInfinite.mockReturnValue(
 				createMockInfiniteReturn({
 					pages: [{ items: [createMockInstructor()], total: 1, next_page: 2 }],
@@ -156,15 +141,12 @@ describe("useInfiniteInstructors", () => {
 				}),
 			);
 
-			// Act
 			const { result } = renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(result.current.hasMore).toBe(true);
 		});
 
 		it("should report hasMore as false when there is no next page", () => {
-			// Arrange
 			mockedInfinite.mockReturnValue(
 				createMockInfiniteReturn({
 					pages: [
@@ -174,29 +156,23 @@ describe("useInfiniteInstructors", () => {
 				}),
 			);
 
-			// Act
 			const { result } = renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			expect(result.current.hasMore).toBe(false);
 		});
 	});
 
 	describe("Query Options", () => {
 		it("should forward enabled=false to the query options", () => {
-			// Act
 			renderHook(() => useInfiniteInstructors({ enabled: false }));
 
-			// Assert
 			const options = mockedInfinite.mock.calls.at(-1)?.[1];
 			expect(options?.query?.enabled).toBe(false);
 		});
 
 		it("should default enabled to true", () => {
-			// Act
 			renderHook(() => useInfiniteInstructors());
 
-			// Assert
 			const options = mockedInfinite.mock.calls.at(-1)?.[1];
 			expect(options?.query?.enabled).toBe(true);
 		});

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
@@ -16,6 +16,7 @@ export interface UseInfiniteInstructorsReturn {
 export interface UseInfiniteInstructorsOptions {
 	readonly search?: string;
 	readonly courseOfferingId?: string;
+	readonly courseId?: string;
 	readonly specialityId?: string;
 	readonly pageSize?: number;
 	readonly enabled?: boolean;
@@ -26,6 +27,7 @@ const DEFAULT_PAGE_SIZE = 20;
 export function useInfiniteInstructors({
 	search,
 	courseOfferingId,
+	courseId,
 	specialityId,
 	pageSize = DEFAULT_PAGE_SIZE,
 	enabled = true,
@@ -35,9 +37,10 @@ export function useInfiniteInstructors({
 			page_size: pageSize,
 			...(search ? { search } : {}),
 			...(courseOfferingId ? { course_offering_id: courseOfferingId } : {}),
+			...(courseId ? { course_id: courseId } : {}),
 			...(specialityId ? { speciality_id: specialityId } : {}),
 		}),
-		[search, courseOfferingId, specialityId, pageSize],
+		[search, courseOfferingId, courseId, specialityId, pageSize],
 	);
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
@@ -1,0 +1,101 @@
+import type { RefObject } from "react";
+import { useEffect, useMemo, useRef } from "react";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import type { Instructor } from "@/lib/api/generated";
+import {
+	getInstructorsListQueryKey,
+	instructorsList,
+} from "@/lib/api/generated";
+
+export interface UseInfiniteInstructorsReturn {
+	allInstructors: Instructor[];
+	total: number | undefined;
+	hasMore: boolean;
+	isLoading: boolean;
+	isFetchingNextPage: boolean;
+	loaderRef: RefObject<HTMLDivElement | null>;
+}
+
+export interface UseInfiniteInstructorsOptions {
+	readonly search?: string;
+	readonly courseOfferingId?: string;
+	readonly specialityId?: string;
+	readonly pageSize?: number;
+	readonly enabled?: boolean;
+}
+
+const DEFAULT_PAGE_SIZE = 20;
+
+export function useInfiniteInstructors({
+	search,
+	courseOfferingId,
+	specialityId,
+	pageSize = DEFAULT_PAGE_SIZE,
+	enabled = true,
+}: UseInfiniteInstructorsOptions = {}): UseInfiniteInstructorsReturn {
+	const params = useMemo(
+		() => ({
+			page_size: pageSize,
+			...(search ? { search } : {}),
+			...(courseOfferingId ? { course_offering_id: courseOfferingId } : {}),
+			...(specialityId ? { speciality_id: specialityId } : {}),
+		}),
+		[search, courseOfferingId, specialityId, pageSize],
+	);
+
+	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+		useInfiniteQuery({
+			queryKey: getInstructorsListQueryKey(params),
+			queryFn: ({ pageParam }) =>
+				instructorsList({ ...params, page: pageParam as number }),
+			getNextPageParam: (lastPage) =>
+				lastPage.page < lastPage.total_pages ? lastPage.page + 1 : undefined,
+			initialPageParam: 1,
+			enabled,
+		});
+
+	const allInstructors = data?.pages.flatMap((p) => p.items) ?? [];
+	const total = data?.pages[0]?.total;
+
+	const loaderRef = useRef<HTMLDivElement | null>(null);
+	const fetchNextPageRef = useRef(fetchNextPage);
+	fetchNextPageRef.current = fetchNextPage;
+
+	useEffect(() => {
+		if (!hasNextPage || allInstructors.length === 0) {
+			return;
+		}
+
+		const currentLoader = loaderRef.current;
+		if (!currentLoader) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0].isIntersecting && !isFetchingNextPage && hasNextPage) {
+					void fetchNextPageRef.current();
+				}
+			},
+			{ threshold: 0, rootMargin: "100px" },
+		);
+
+		observer.observe(currentLoader);
+
+		return () => {
+			observer.unobserve(currentLoader);
+			observer.disconnect();
+		};
+	}, [hasNextPage, allInstructors.length, isFetchingNextPage]);
+
+	return {
+		allInstructors,
+		total,
+		hasMore: !!hasNextPage,
+		isLoading,
+		isFetchingNextPage,
+		loaderRef,
+	};
+}

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
@@ -1,13 +1,8 @@
 import type { RefObject } from "react";
 import { useEffect, useMemo, useRef } from "react";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
-
-import type { Instructor } from "@/lib/api/generated";
-import {
-	getInstructorsListQueryKey,
-	instructorsList,
-} from "@/lib/api/generated";
+import type { Instructor, InstructorsListParams } from "@/lib/api/generated";
+import { useInstructorsListInfinite } from "@/lib/api/generated";
 
 export interface UseInfiniteInstructorsReturn {
 	allInstructors: Instructor[];
@@ -35,7 +30,7 @@ export function useInfiniteInstructors({
 	pageSize = DEFAULT_PAGE_SIZE,
 	enabled = true,
 }: UseInfiniteInstructorsOptions = {}): UseInfiniteInstructorsReturn {
-	const params = useMemo(
+	const params = useMemo<InstructorsListParams>(
 		() => ({
 			page_size: pageSize,
 			...(search ? { search } : {}),
@@ -46,14 +41,12 @@ export function useInfiniteInstructors({
 	);
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-		useInfiniteQuery({
-			queryKey: getInstructorsListQueryKey(params),
-			queryFn: ({ pageParam }) =>
-				instructorsList({ ...params, page: pageParam as number }),
-			getNextPageParam: (lastPage) =>
-				lastPage.page < lastPage.total_pages ? lastPage.page + 1 : undefined,
-			initialPageParam: 1,
-			enabled,
+		useInstructorsListInfinite(params, {
+			query: {
+				initialPageParam: 1,
+				getNextPageParam: (lastPage) => lastPage.next_page ?? undefined,
+				enabled,
+			},
 		});
 
 	const allInstructors = data?.pages.flatMap((p) => p.items) ?? [];

--- a/src/webapp/src/features/ratings/components/RatingCard.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCard.tsx
@@ -46,6 +46,7 @@ export function RatingCard({
 				usefulness={rating.usefulness}
 				comment={rating.comment}
 				instructor={rating.instructor}
+				instructors={rating.instructors ?? []}
 				ratingId={rating.id}
 				courseId={courseId}
 				upvotes={rating.upvotes ?? 0}

--- a/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
@@ -20,7 +20,6 @@ function instructor(over: Partial<RatingInstructor>): RatingInstructor {
 		first_name: "",
 		patronymic: "",
 		last_name: "",
-		email: "",
 		...over,
 	};
 }

--- a/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
@@ -25,7 +25,7 @@ function instructor(over: Partial<RatingInstructor>): RatingInstructor {
 }
 
 describe("RatingCardBody instructor display", () => {
-	it("renders M2M instructors as surname + initials", () => {
+	it("renders M2M instructors as surname + full first name", () => {
 		render(
 			<RatingCardBody
 				{...baseProps}
@@ -42,7 +42,7 @@ describe("RatingCardBody instructor display", () => {
 
 		expect(screen.getByText("Викладачі:")).toBeInTheDocument();
 		expect(
-			screen.getByText("Петренко І. В., Коваленко А."),
+			screen.getByText("Петренко Іван, Коваленко Анна"),
 		).toBeInTheDocument();
 	});
 
@@ -57,7 +57,7 @@ describe("RatingCardBody instructor display", () => {
 		);
 
 		expect(screen.getByText("Викладач:")).toBeInTheDocument();
-		expect(screen.getByText("Коваленко А.")).toBeInTheDocument();
+		expect(screen.getByText("Коваленко Анна")).toBeInTheDocument();
 	});
 
 	it("falls back to legacy text when no M2M instructors", () => {
@@ -78,7 +78,7 @@ describe("RatingCardBody instructor display", () => {
 			/>,
 		);
 
-		expect(screen.getByText("Коваленко А.")).toBeInTheDocument();
+		expect(screen.getByText("Коваленко Анна")).toBeInTheDocument();
 		expect(screen.queryByText("Старий текст")).not.toBeInTheDocument();
 	});
 

--- a/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { RatingInstructor } from "@/lib/api/generated";
+import { render, screen } from "@/test-utils/render";
+import { RatingCardBody } from "./RatingCardBody";
+
+const baseProps = {
+	displayName: "Студент",
+	isAnonymous: false,
+	difficulty: 3,
+	usefulness: 4,
+	upvotes: 0,
+	downvotes: 0,
+	viewerVote: null,
+} as const;
+
+function instructor(over: Partial<RatingInstructor>): RatingInstructor {
+	return {
+		id: "00000000-0000-0000-0000-000000000000",
+		first_name: "",
+		patronymic: "",
+		last_name: "",
+		email: "",
+		...over,
+	};
+}
+
+describe("RatingCardBody instructor display", () => {
+	it("renders M2M instructors as surname + initials", () => {
+		render(
+			<RatingCardBody
+				{...baseProps}
+				instructors={[
+					instructor({
+						first_name: "Іван",
+						patronymic: "Васильович",
+						last_name: "Петренко",
+					}),
+					instructor({ first_name: "Анна", last_name: "Коваленко" }),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Викладачі:")).toBeInTheDocument();
+		expect(
+			screen.getByText("Петренко І. В., Коваленко А."),
+		).toBeInTheDocument();
+	});
+
+	it("uses singular label for a single instructor", () => {
+		render(
+			<RatingCardBody
+				{...baseProps}
+				instructors={[
+					instructor({ first_name: "Анна", last_name: "Коваленко" }),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Викладач:")).toBeInTheDocument();
+		expect(screen.getByText("Коваленко А.")).toBeInTheDocument();
+	});
+
+	it("falls back to legacy text when no M2M instructors", () => {
+		render(<RatingCardBody {...baseProps} instructor="Сегін" />);
+
+		expect(screen.getByText("Викладач:")).toBeInTheDocument();
+		expect(screen.getByText("Сегін")).toBeInTheDocument();
+	});
+
+	it("prefers M2M over legacy text when both are present", () => {
+		render(
+			<RatingCardBody
+				{...baseProps}
+				instructor="Старий текст"
+				instructors={[
+					instructor({ first_name: "Анна", last_name: "Коваленко" }),
+				]}
+			/>,
+		);
+
+		expect(screen.getByText("Коваленко А.")).toBeInTheDocument();
+		expect(screen.queryByText("Старий текст")).not.toBeInTheDocument();
+	});
+
+	it("renders no instructor line when neither is provided", () => {
+		render(<RatingCardBody {...baseProps} />);
+
+		expect(screen.queryByText(/Викладач/)).not.toBeInTheDocument();
+	});
+});

--- a/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
@@ -24,6 +24,9 @@ function instructor(over: Partial<RatingInstructor>): RatingInstructor {
 	};
 }
 
+// M2M instructor display is gated behind the feature flag.
+const FF_ON = { flags: { fe_instructor_multiselect: true } } as const;
+
 describe("RatingCardBody instructor display", () => {
 	it("renders M2M instructors as surname + full first name", () => {
 		render(
@@ -38,6 +41,7 @@ describe("RatingCardBody instructor display", () => {
 					instructor({ first_name: "Анна", last_name: "Коваленко" }),
 				]}
 			/>,
+			FF_ON,
 		);
 
 		expect(screen.getByText("Викладачі:")).toBeInTheDocument();
@@ -54,6 +58,7 @@ describe("RatingCardBody instructor display", () => {
 					instructor({ first_name: "Анна", last_name: "Коваленко" }),
 				]}
 			/>,
+			FF_ON,
 		);
 
 		expect(screen.getByText("Викладач:")).toBeInTheDocument();
@@ -76,6 +81,7 @@ describe("RatingCardBody instructor display", () => {
 					instructor({ first_name: "Анна", last_name: "Коваленко" }),
 				]}
 			/>,
+			FF_ON,
 		);
 
 		expect(screen.getByText("Коваленко Анна")).toBeInTheDocument();
@@ -86,5 +92,20 @@ describe("RatingCardBody instructor display", () => {
 		render(<RatingCardBody {...baseProps} />);
 
 		expect(screen.queryByText(/Викладач/)).not.toBeInTheDocument();
+	});
+
+	it("hides M2M instructors and shows legacy text when the flag is off", () => {
+		render(
+			<RatingCardBody
+				{...baseProps}
+				instructor="Старий текст"
+				instructors={[
+					instructor({ first_name: "Анна", last_name: "Коваленко" }),
+				]}
+			/>,
+		);
+
+		expect(screen.queryByText("Коваленко Анна")).not.toBeInTheDocument();
+		expect(screen.getByText("Старий текст")).toBeInTheDocument();
 	});
 });

--- a/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.test.tsx
@@ -72,6 +72,13 @@ describe("RatingCardBody instructor display", () => {
 		expect(screen.getByText("Сегін")).toBeInTheDocument();
 	});
 
+	it("still shows legacy text with the flag on when the rating has no M2M instructors", () => {
+		render(<RatingCardBody {...baseProps} instructor="Сегін" />, FF_ON);
+
+		expect(screen.getByText("Викладач:")).toBeInTheDocument();
+		expect(screen.getByText("Сегін")).toBeInTheDocument();
+	});
+
 	it("prefers M2M over legacy text when both are present", () => {
 		render(
 			<RatingCardBody

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -12,6 +12,7 @@ import type {
 	RatingInstructor,
 	RatingVoteStrType,
 } from "@/lib/api/generated";
+import { useFeatureFlag } from "@/lib/feature-flags";
 import { RatingComment } from "./RatingComment";
 import { RatingComments } from "./RatingComments";
 import { RatingStats } from "./RatingStats";
@@ -21,7 +22,9 @@ import { RatingVotes } from "./RatingVotes";
  * is omitted for brevity; the full first name keeps same-surname instructors
  * distinguishable (e.g. "Калиновська Олександра" vs "Калиновська Оксана"). */
 function formatInstructorName(instructor: RatingInstructor): string {
-	return [instructor.last_name, instructor.first_name].filter(Boolean).join(" ");
+	return [instructor.last_name, instructor.first_name]
+		.filter(Boolean)
+		.join(" ");
 }
 
 interface RatingCardBodyProps {
@@ -69,6 +72,7 @@ export function RatingCardBody({
 	votesReadOnly = false,
 	votesDisabledMessage,
 }: RatingCardBodyProps) {
+	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
 	return (
 		<>
 			<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -101,7 +105,7 @@ export function RatingCardBody({
 				<RatingStats difficulty={difficulty} usefulness={usefulness} />
 			</div>
 
-			{instructors.length > 0 ? (
+			{showMultiSelect && instructors.length > 0 ? (
 				<p className="mt-2 flex min-w-0 items-start gap-1 text-sm text-muted-foreground">
 					<span className="shrink-0 font-medium">
 						{instructors.length > 1 ? "Викладачі:" : "Викладач:"}

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -7,11 +7,24 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/Tooltip";
 import { formatDate } from "@/features/courses/courseFormatting";
-import type { CommentAuthor, RatingVoteStrType } from "@/lib/api/generated";
+import type {
+	CommentAuthor,
+	RatingInstructor,
+	RatingVoteStrType,
+} from "@/lib/api/generated";
 import { RatingComment } from "./RatingComment";
 import { RatingComments } from "./RatingComments";
 import { RatingStats } from "./RatingStats";
 import { RatingVotes } from "./RatingVotes";
+
+/** "Прізвище І. В." — surname plus initials, blanks skipped. */
+function formatInstructorName(instructor: RatingInstructor): string {
+	const initials = [instructor.first_name, instructor.patronymic]
+		.filter(Boolean)
+		.map((part) => `${(part as string).charAt(0)}.`)
+		.join(" ");
+	return [instructor.last_name, initials].filter(Boolean).join(" ");
+}
 
 interface RatingCardBodyProps {
 	readonly displayName: string;
@@ -23,6 +36,7 @@ interface RatingCardBodyProps {
 	readonly usefulness: number | undefined;
 	readonly comment?: string | null;
 	readonly instructor?: string | null;
+	readonly instructors?: readonly RatingInstructor[];
 	readonly commentEmptyMessage?: string;
 	readonly ratingId?: string;
 	readonly courseId?: string;
@@ -45,6 +59,7 @@ export function RatingCardBody({
 	usefulness,
 	comment,
 	instructor,
+	instructors = [],
 	commentEmptyMessage,
 	ratingId,
 	courseId,
@@ -88,17 +103,28 @@ export function RatingCardBody({
 				<RatingStats difficulty={difficulty} usefulness={usefulness} />
 			</div>
 
-			{instructor && (
+			{instructors.length > 0 ? (
 				<p className="mt-2 flex min-w-0 items-start gap-1 text-sm text-muted-foreground">
-					<span className="shrink-0 font-medium">Викладач:</span>
-					<span className="min-w-0 break-words">{instructor}</span>
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<Info className="h-3.5 w-3.5 shrink-0 cursor-help text-muted-foreground/60" />
-						</TooltipTrigger>
-						<TooltipContent>Вказано студентом, не перевірено</TooltipContent>
-					</Tooltip>
+					<span className="shrink-0 font-medium">
+						{instructors.length > 1 ? "Викладачі:" : "Викладач:"}
+					</span>
+					<span className="min-w-0 break-words">
+						{instructors.map(formatInstructorName).join(", ")}
+					</span>
 				</p>
+			) : (
+				instructor && (
+					<p className="mt-2 flex min-w-0 items-start gap-1 text-sm text-muted-foreground">
+						<span className="shrink-0 font-medium">Викладач:</span>
+						<span className="min-w-0 break-words">{instructor}</span>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Info className="h-3.5 w-3.5 shrink-0 cursor-help text-muted-foreground/60" />
+							</TooltipTrigger>
+							<TooltipContent>Вказано студентом, не перевірено</TooltipContent>
+						</Tooltip>
+					</p>
+				)
 			)}
 
 			<div className="mt-3">

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -17,13 +17,11 @@ import { RatingComments } from "./RatingComments";
 import { RatingStats } from "./RatingStats";
 import { RatingVotes } from "./RatingVotes";
 
-/** "Прізвище І. В." — surname plus initials, blanks skipped. */
+/** "Прізвище Імʼя" — surname plus full first name, blanks skipped. Patronymic
+ * is omitted for brevity; the full first name keeps same-surname instructors
+ * distinguishable (e.g. "Калиновська Олександра" vs "Калиновська Оксана"). */
 function formatInstructorName(instructor: RatingInstructor): string {
-	const initials = [instructor.first_name, instructor.patronymic]
-		.filter(Boolean)
-		.map((part) => `${(part as string).charAt(0)}.`)
-		.join(" ");
-	return [instructor.last_name, initials].filter(Boolean).join(" ");
+	return [instructor.last_name, instructor.first_name].filter(Boolean).join(" ");
 }
 
 interface RatingCardBodyProps {

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -12,7 +12,7 @@ import type {
 	RatingInstructor,
 	RatingVoteStrType,
 } from "@/lib/api/generated";
-import { useFeatureFlags } from "@/lib/feature-flags";
+import { useFeatureFlagState } from "@/lib/feature-flags";
 import { RatingComment } from "./RatingComment";
 import { RatingComments } from "./RatingComments";
 import { RatingStats } from "./RatingStats";
@@ -72,8 +72,9 @@ export function RatingCardBody({
 	votesReadOnly = false,
 	votesDisabledMessage,
 }: RatingCardBodyProps) {
-	const { flags, isReady } = useFeatureFlags();
-	const showMultiSelect = isReady && flags.fe_instructor_multiselect === true;
+	const { enabled: showMultiSelect, isReady } = useFeatureFlagState(
+		"fe_instructor_multiselect",
+	);
 	const instructorNames = instructors.map(formatInstructorName).filter(Boolean);
 	return (
 		<>

--- a/src/webapp/src/features/ratings/components/RatingCardBody.tsx
+++ b/src/webapp/src/features/ratings/components/RatingCardBody.tsx
@@ -12,7 +12,7 @@ import type {
 	RatingInstructor,
 	RatingVoteStrType,
 } from "@/lib/api/generated";
-import { useFeatureFlag } from "@/lib/feature-flags";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import { RatingComment } from "./RatingComment";
 import { RatingComments } from "./RatingComments";
 import { RatingStats } from "./RatingStats";
@@ -72,7 +72,9 @@ export function RatingCardBody({
 	votesReadOnly = false,
 	votesDisabledMessage,
 }: RatingCardBodyProps) {
-	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
+	const { flags, isReady } = useFeatureFlags();
+	const showMultiSelect = isReady && flags.fe_instructor_multiselect === true;
+	const instructorNames = instructors.map(formatInstructorName).filter(Boolean);
 	return (
 		<>
 			<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -105,13 +107,13 @@ export function RatingCardBody({
 				<RatingStats difficulty={difficulty} usefulness={usefulness} />
 			</div>
 
-			{showMultiSelect && instructors.length > 0 ? (
+			{!isReady ? null : showMultiSelect && instructorNames.length > 0 ? (
 				<p className="mt-2 flex min-w-0 items-start gap-1 text-sm text-muted-foreground">
 					<span className="shrink-0 font-medium">
-						{instructors.length > 1 ? "Викладачі:" : "Викладач:"}
+						{instructorNames.length > 1 ? "Викладачі:" : "Викладач:"}
 					</span>
 					<span className="min-w-0 break-words">
-						{instructors.map(formatInstructorName).join(", ")}
+						{instructorNames.join(", ")}
 					</span>
 				</p>
 			) : (

--- a/src/webapp/src/features/ratings/components/RatingForm.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { testIds } from "@/lib/test-ids";
+import { render, screen } from "@/test-utils/render";
 import { RatingForm } from "./RatingForm";
 
 describe("RatingForm", () => {

--- a/src/webapp/src/features/ratings/components/RatingForm.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.test.tsx
@@ -29,4 +29,30 @@ describe("RatingForm", () => {
 			"6",
 		);
 	});
+
+	describe("instructor field — feature flag gating", () => {
+		it("shows the legacy free-text input when the flag is off", () => {
+			render(<RatingForm onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+			expect(
+				screen.getByTestId(testIds.rating.instructorInput),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByTestId(testIds.rating.instructorMultiSelect),
+			).not.toBeInTheDocument();
+		});
+
+		it("shows the multi-select when the flag is on", () => {
+			render(<RatingForm onSubmit={vi.fn()} onCancel={vi.fn()} />, {
+				flags: { fe_instructor_multiselect: true },
+			});
+
+			expect(
+				screen.getByTestId(testIds.rating.instructorMultiSelect),
+			).toBeInTheDocument();
+			expect(
+				screen.queryByTestId(testIds.rating.instructorInput),
+			).not.toBeInTheDocument();
+		});
+	});
 });

--- a/src/webapp/src/features/ratings/components/RatingForm.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.test.tsx
@@ -55,6 +55,36 @@ describe("RatingForm", () => {
 			).not.toBeInTheDocument();
 		});
 
+		it("shows the previous free-text instructor read-only next to the multi-select", () => {
+			render(
+				<RatingForm
+					onSubmit={vi.fn()}
+					onCancel={vi.fn()}
+					isEditMode
+					initialData={{
+						difficulty: 3,
+						usefulness: 3,
+						comment: "",
+						instructor_ids: [],
+						instructor: "Сегін",
+						is_anonymous: false,
+					}}
+				/>,
+				{ flags: { fe_instructor_multiselect: true } },
+			);
+
+			expect(
+				screen.getByTestId(testIds.rating.legacyInstructorReadonly),
+			).toHaveTextContent("Сегін");
+			expect(
+				screen.getByTestId(testIds.rating.instructorMultiSelect),
+			).toBeInTheDocument();
+			// The old value is informational only — it cannot be edited as text.
+			expect(
+				screen.queryByTestId(testIds.rating.instructorInput),
+			).not.toBeInTheDocument();
+		});
+
 		it("renders neither variant until the flags resolve", () => {
 			render(<RatingForm onSubmit={vi.fn()} onCancel={vi.fn()} />, {
 				flagsReady: false,

--- a/src/webapp/src/features/ratings/components/RatingForm.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.test.tsx
@@ -54,5 +54,18 @@ describe("RatingForm", () => {
 				screen.queryByTestId(testIds.rating.instructorInput),
 			).not.toBeInTheDocument();
 		});
+
+		it("renders neither variant until the flags resolve", () => {
+			render(<RatingForm onSubmit={vi.fn()} onCancel={vi.fn()} />, {
+				flagsReady: false,
+			});
+
+			expect(
+				screen.queryByTestId(testIds.rating.instructorInput),
+			).not.toBeInTheDocument();
+			expect(
+				screen.queryByTestId(testIds.rating.instructorMultiSelect),
+			).not.toBeInTheDocument();
+		});
 	});
 });

--- a/src/webapp/src/features/ratings/components/RatingForm.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.test.tsx
@@ -74,7 +74,7 @@ describe("RatingForm", () => {
 			);
 
 			expect(
-				screen.getByTestId(testIds.rating.legacyInstructorReadonly),
+				screen.getByTestId(testIds.rating.legacyInstructorText),
 			).toHaveTextContent("Сегін");
 			expect(
 				screen.getByTestId(testIds.rating.instructorMultiSelect),

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -16,9 +16,11 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/Form";
+import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
 import { InstructorMultiSelect } from "@/features/instructors/components/InstructorMultiSelect";
 import type { Instructor } from "@/lib/api/generated";
+import { useFeatureFlag } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { cn } from "@/lib/utils";
 import {
@@ -40,6 +42,8 @@ const ratingSchema = z.object({
 		.transform((val) => val?.trim() || undefined)
 		.optional(),
 	instructor_ids: z.array(z.string().uuid()),
+	// Legacy free-text instructor, used when the multi-select feature flag is off.
+	instructor: z.string().optional(),
 	is_anonymous: z.boolean(),
 });
 
@@ -148,11 +152,13 @@ function RatingFormFields({
 	offeringId,
 	courseId,
 	initialInstructors,
+	showMultiSelect,
 }: Readonly<{
 	control: ReturnType<typeof useForm<RatingFormData>>["control"];
 	offeringId?: string;
 	courseId?: string;
 	initialInstructors?: readonly Instructor[];
+	showMultiSelect: boolean;
 }>) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
@@ -198,29 +204,50 @@ function RatingFormFields({
 				/>
 			</div>
 
-			<FormField<RatingFormData, "instructor_ids">
-				control={control}
-				name="instructor_ids"
-				render={({ field }) => (
-					<FormItem>
-						<FormLabel>Викладачі (необов'язково)</FormLabel>
-						<FormControl>
-							<InstructorMultiSelect
-								value={field.value ?? []}
-								onChange={field.onChange}
-								initialOptions={initialInstructors}
-								courseOfferingId={offeringId}
-								courseId={courseId}
-								data-testid={testIds.rating.instructorMultiSelect}
-							/>
-						</FormControl>
-						<FormDescription>
-							Можна обрати кількох викладачів, які вели курс
-						</FormDescription>
-						<FormMessage />
-					</FormItem>
-				)}
-			/>
+			{showMultiSelect ? (
+				<FormField<RatingFormData, "instructor_ids">
+					control={control}
+					name="instructor_ids"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Викладачі (необов'язково)</FormLabel>
+							<FormControl>
+								<InstructorMultiSelect
+									value={field.value ?? []}
+									onChange={field.onChange}
+									initialOptions={initialInstructors}
+									courseOfferingId={offeringId}
+									courseId={courseId}
+									data-testid={testIds.rating.instructorMultiSelect}
+								/>
+							</FormControl>
+							<FormDescription>
+								Можна обрати кількох викладачів, які вели курс
+							</FormDescription>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+			) : (
+				<FormField<RatingFormData, "instructor">
+					control={control}
+					name="instructor"
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>Викладач (необов'язково)</FormLabel>
+							<FormControl>
+								<Input
+									placeholder="Ім'я викладача"
+									{...field}
+									value={field.value ?? ""}
+									data-testid={testIds.rating.instructorInput}
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+			)}
 
 			<FormField<RatingFormData, "comment">
 				control={control}
@@ -296,6 +323,7 @@ export function RatingForm({
 	courseId,
 	initialInstructors,
 }: RatingFormProps) {
+	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
 	const form = useForm<RatingFormData>({
 		resolver: zodResolver(ratingSchema),
 		defaultValues: initialData || {
@@ -303,6 +331,7 @@ export function RatingForm({
 			usefulness: 3,
 			comment: "",
 			instructor_ids: [],
+			instructor: "",
 			is_anonymous: false,
 		},
 	});
@@ -325,6 +354,7 @@ export function RatingForm({
 					offeringId={offeringId}
 					courseId={courseId}
 					initialInstructors={initialInstructors}
+					showMultiSelect={showMultiSelect}
 				/>
 
 				<div className="shrink-0 border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -16,8 +16,9 @@ import {
 	FormLabel,
 	FormMessage,
 } from "@/components/ui/Form";
-import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
+import { InstructorMultiSelect } from "@/features/instructors/components/InstructorMultiSelect";
+import type { Instructor } from "@/lib/api/generated";
 import { testIds } from "@/lib/test-ids";
 import { cn } from "@/lib/utils";
 import {
@@ -38,12 +39,7 @@ const ratingSchema = z.object({
 		.string()
 		.transform((val) => val?.trim() || undefined)
 		.optional(),
-	// TODO: temporary free-text field; will be replaced with a verified instructor dropdown
-	instructor: z
-		.string()
-		.max(256, "Ім'я викладача не може перевищувати 256 символів")
-		.transform((val) => val?.trim() || undefined)
-		.optional(),
+	instructor_ids: z.array(z.string().uuid()),
 	is_anonymous: z.boolean(),
 });
 
@@ -149,8 +145,12 @@ function StarRatingInput({
 
 function RatingFormFields({
 	control,
+	offeringId,
+	initialInstructors,
 }: Readonly<{
 	control: ReturnType<typeof useForm<RatingFormData>>["control"];
+	offeringId?: string;
+	initialInstructors?: readonly Instructor[];
 }>) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
@@ -196,20 +196,24 @@ function RatingFormFields({
 				/>
 			</div>
 
-			<FormField<RatingFormData, "instructor">
+			<FormField<RatingFormData, "instructor_ids">
 				control={control}
-				name="instructor"
+				name="instructor_ids"
 				render={({ field }) => (
 					<FormItem>
-						<FormLabel>Викладач (необов'язково)</FormLabel>
+						<FormLabel>Викладачі (необов'язково)</FormLabel>
 						<FormControl>
-							<Input
-								placeholder="Ім'я викладача"
-								{...field}
-								data-testid={testIds.rating.instructorInput}
+							<InstructorMultiSelect
+								value={field.value ?? []}
+								onChange={field.onChange}
+								initialOptions={initialInstructors}
+								courseOfferingId={offeringId}
+								data-testid={testIds.rating.instructorMultiSelect}
 							/>
 						</FormControl>
-						<FormDescription>Вкажіть викладача, який вів курс</FormDescription>
+						<FormDescription>
+							Можна обрати кількох викладачів, які вели курс
+						</FormDescription>
 						<FormMessage />
 					</FormItem>
 				)}
@@ -274,6 +278,8 @@ interface RatingFormProps {
 	readonly isLoading?: boolean;
 	readonly isEditMode?: boolean;
 	readonly initialData?: RatingFormData;
+	readonly offeringId?: string;
+	readonly initialInstructors?: readonly Instructor[];
 }
 
 export function RatingForm({
@@ -282,6 +288,8 @@ export function RatingForm({
 	isLoading = false,
 	isEditMode = false,
 	initialData,
+	offeringId,
+	initialInstructors,
 }: RatingFormProps) {
 	const form = useForm<RatingFormData>({
 		resolver: zodResolver(ratingSchema),
@@ -289,7 +297,7 @@ export function RatingForm({
 			difficulty: 3,
 			usefulness: 3,
 			comment: "",
-			instructor: "",
+			instructor_ids: [],
 			is_anonymous: false,
 		},
 	});
@@ -307,7 +315,11 @@ export function RatingForm({
 				className="flex min-h-0 flex-1 flex-col overflow-hidden"
 				data-testid={testIds.rating.form}
 			>
-				<RatingFormFields control={form.control} />
+				<RatingFormFields
+					control={form.control}
+					offeringId={offeringId}
+					initialInstructors={initialInstructors}
+				/>
 
 				<div className="shrink-0 border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
 					<div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -146,10 +146,12 @@ function StarRatingInput({
 function RatingFormFields({
 	control,
 	offeringId,
+	courseId,
 	initialInstructors,
 }: Readonly<{
 	control: ReturnType<typeof useForm<RatingFormData>>["control"];
 	offeringId?: string;
+	courseId?: string;
 	initialInstructors?: readonly Instructor[];
 }>) {
 	return (
@@ -208,6 +210,7 @@ function RatingFormFields({
 								onChange={field.onChange}
 								initialOptions={initialInstructors}
 								courseOfferingId={offeringId}
+								courseId={courseId}
 								data-testid={testIds.rating.instructorMultiSelect}
 							/>
 						</FormControl>
@@ -279,6 +282,7 @@ interface RatingFormProps {
 	readonly isEditMode?: boolean;
 	readonly initialData?: RatingFormData;
 	readonly offeringId?: string;
+	readonly courseId?: string;
 	readonly initialInstructors?: readonly Instructor[];
 }
 
@@ -289,6 +293,7 @@ export function RatingForm({
 	isEditMode = false,
 	initialData,
 	offeringId,
+	courseId,
 	initialInstructors,
 }: RatingFormProps) {
 	const form = useForm<RatingFormData>({
@@ -318,6 +323,7 @@ export function RatingForm({
 				<RatingFormFields
 					control={form.control}
 					offeringId={offeringId}
+					courseId={courseId}
 					initialInstructors={initialInstructors}
 				/>
 

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
 import { InstructorMultiSelect } from "@/features/instructors/components/InstructorMultiSelect";
 import type { Instructor } from "@/lib/api/generated";
-import { useFeatureFlag } from "@/lib/feature-flags";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { cn } from "@/lib/utils";
 import {
@@ -43,7 +43,7 @@ const ratingSchema = z.object({
 		.optional(),
 	instructor_ids: z.array(z.string().uuid()),
 	// Legacy free-text instructor, used when the multi-select feature flag is off.
-	instructor: z.string().optional(),
+	instructor: z.string().max(256).optional(),
 	is_anonymous: z.boolean(),
 });
 
@@ -153,12 +153,14 @@ function RatingFormFields({
 	courseId,
 	initialInstructors,
 	showMultiSelect,
+	flagsReady,
 }: Readonly<{
 	control: ReturnType<typeof useForm<RatingFormData>>["control"];
 	offeringId?: string;
 	courseId?: string;
 	initialInstructors?: readonly Instructor[];
 	showMultiSelect: boolean;
+	flagsReady: boolean;
 }>) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
@@ -204,7 +206,10 @@ function RatingFormFields({
 				/>
 			</div>
 
-			{showMultiSelect ? (
+			{/* Hold the instructor field until flags resolve: rendering the legacy
+			    input first would let typed text be discarded when the multi-select
+			    takes over. */}
+			{!flagsReady ? null : showMultiSelect ? (
 				<FormField<RatingFormData, "instructor_ids">
 					control={control}
 					name="instructor_ids"
@@ -323,7 +328,9 @@ export function RatingForm({
 	courseId,
 	initialInstructors,
 }: RatingFormProps) {
-	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
+	const { flags, isReady: flagsReady } = useFeatureFlags();
+	const showMultiSelect =
+		flagsReady && flags.fe_instructor_multiselect === true;
 	const form = useForm<RatingFormData>({
 		resolver: zodResolver(ratingSchema),
 		defaultValues: initialData || {
@@ -355,6 +362,7 @@ export function RatingForm({
 					courseId={courseId}
 					initialInstructors={initialInstructors}
 					showMultiSelect={showMultiSelect}
+					flagsReady={flagsReady}
 				/>
 
 				<div className="shrink-0 border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -20,7 +20,7 @@ import { Input } from "@/components/ui/Input";
 import { Textarea } from "@/components/ui/Textarea";
 import { InstructorMultiSelect } from "@/features/instructors/components/InstructorMultiSelect";
 import type { Instructor } from "@/lib/api/generated";
-import { useFeatureFlags } from "@/lib/feature-flags";
+import { useFeatureFlagState } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { cn } from "@/lib/utils";
 import {
@@ -340,9 +340,9 @@ export function RatingForm({
 	courseId,
 	initialInstructors,
 }: RatingFormProps) {
-	const { flags, isReady: flagsReady } = useFeatureFlags();
-	const showMultiSelect =
-		flagsReady && flags.fe_instructor_multiselect === true;
+	const { enabled: showMultiSelect, isReady: flagsReady } = useFeatureFlagState(
+		"fe_instructor_multiselect",
+	);
 	const form = useForm<RatingFormData>({
 		resolver: zodResolver(ratingSchema),
 		defaultValues: initialData || {

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -208,9 +208,8 @@ function RatingFormFields({
 				/>
 			</div>
 
-			{/* Hold the instructor field until flags resolve: rendering the legacy
-			    input first would let typed text be discarded when the multi-select
-			    takes over. */}
+			{/* Held until flags resolve, or text typed into the legacy input would
+			    be discarded when the multi-select takes over. */}
 			{!flagsReady ? null : showMultiSelect ? (
 				<FormField<RatingFormData, "instructor_ids">
 					control={control}
@@ -221,7 +220,7 @@ function RatingFormFields({
 							{legacyInstructor && (
 								<p
 									className="text-sm text-muted-foreground"
-									data-testid={testIds.rating.legacyInstructorReadonly}
+									data-testid={testIds.rating.legacyInstructorText}
 								>
 									Раніше вказано текстом:{" "}
 									<span className="font-medium">{legacyInstructor}</span>

--- a/src/webapp/src/features/ratings/components/RatingForm.tsx
+++ b/src/webapp/src/features/ratings/components/RatingForm.tsx
@@ -154,6 +154,7 @@ function RatingFormFields({
 	initialInstructors,
 	showMultiSelect,
 	flagsReady,
+	legacyInstructor,
 }: Readonly<{
 	control: ReturnType<typeof useForm<RatingFormData>>["control"];
 	offeringId?: string;
@@ -161,6 +162,7 @@ function RatingFormFields({
 	initialInstructors?: readonly Instructor[];
 	showMultiSelect: boolean;
 	flagsReady: boolean;
+	legacyInstructor?: string;
 }>) {
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 py-4">
@@ -216,6 +218,15 @@ function RatingFormFields({
 					render={({ field }) => (
 						<FormItem>
 							<FormLabel>Викладачі (необов'язково)</FormLabel>
+							{legacyInstructor && (
+								<p
+									className="text-sm text-muted-foreground"
+									data-testid={testIds.rating.legacyInstructorReadonly}
+								>
+									Раніше вказано текстом:{" "}
+									<span className="font-medium">{legacyInstructor}</span>
+								</p>
+							)}
 							<FormControl>
 								<InstructorMultiSelect
 									value={field.value ?? []}
@@ -227,7 +238,9 @@ function RatingFormFields({
 								/>
 							</FormControl>
 							<FormDescription>
-								Можна обрати кількох викладачів, які вели курс
+								{legacyInstructor
+									? "Оберіть викладачів зі списку — вони замінять текстовий запис"
+									: "Можна обрати кількох викладачів, які вели курс"}
 							</FormDescription>
 							<FormMessage />
 						</FormItem>
@@ -363,6 +376,7 @@ export function RatingForm({
 					initialInstructors={initialInstructors}
 					showMultiSelect={showMultiSelect}
 					flagsReady={flagsReady}
+					legacyInstructor={initialData?.instructor?.trim() || undefined}
 				/>
 
 				<div className="shrink-0 border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">

--- a/src/webapp/src/features/ratings/components/RatingModal.test.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	useCoursesRatingsCreate,
+	useCoursesRatingsPartialUpdate,
+} from "@/lib/api/generated";
+import { render } from "@/test-utils/render";
+import { RatingModal, type RatingFormData } from "./RatingModal";
+
+vi.mock("@/lib/api/generated", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@/lib/api/generated")>();
+
+	return {
+		...actual,
+		useCoursesRatingsCreate: vi.fn(),
+		useCoursesRatingsPartialUpdate: vi.fn(),
+	};
+});
+
+let capturedSubmit: ((data: RatingFormData) => Promise<void>) | undefined;
+
+vi.mock("./RatingForm", () => {
+	return {
+		RatingForm: ({
+			onSubmit,
+		}: {
+			onSubmit: (data: RatingFormData) => Promise<void>;
+		}) => {
+			capturedSubmit = onSubmit;
+			return <div data-testid="rating-form-stub" />;
+		},
+	};
+});
+
+const EXISTING = {
+	id: "11111111-1111-1111-1111-111111111111",
+	difficulty: 3,
+	usefulness: 4,
+	comment: "",
+	instructor: "Сегін",
+	instructors: [],
+	is_anonymous: false,
+};
+
+function formData(over: Partial<RatingFormData>): RatingFormData {
+	return {
+		difficulty: 3,
+		usefulness: 4,
+		comment: "",
+		instructor_ids: [],
+		instructor: "Сегін",
+		is_anonymous: false,
+		...over,
+	};
+}
+
+function renderModal(flags: Record<string, boolean>) {
+	const mutateAsync = vi.fn().mockResolvedValue({});
+	vi.mocked(useCoursesRatingsPartialUpdate).mockReturnValue({
+		mutateAsync,
+		isPending: false,
+	} as unknown as ReturnType<typeof useCoursesRatingsPartialUpdate>);
+	vi.mocked(useCoursesRatingsCreate).mockReturnValue({
+		mutateAsync: vi.fn().mockResolvedValue({}),
+		isPending: false,
+	} as unknown as ReturnType<typeof useCoursesRatingsCreate>);
+
+	render(
+		<RatingModal
+			isOpen
+			onClose={vi.fn()}
+			courseId="22222222-2222-2222-2222-222222222222"
+			existingRating={EXISTING}
+		/>,
+		{ flags },
+	);
+
+	return mutateAsync;
+}
+
+describe("RatingModal instructor write path", () => {
+	it("clears the legacy text when instructors are selected with the flag on", async () => {
+		const mutateAsync = renderModal({ fe_instructor_multiselect: true });
+
+		await capturedSubmit?.(
+			formData({ instructor_ids: ["33333333-3333-3333-3333-333333333333"] }),
+		);
+
+		expect(mutateAsync.mock.calls[0][0].data).toMatchObject({
+			instructor_ids: ["33333333-3333-3333-3333-333333333333"],
+			instructor: "",
+		});
+	});
+
+	it("leaves the legacy text untouched when nothing is selected", async () => {
+		const mutateAsync = renderModal({ fe_instructor_multiselect: true });
+
+		await capturedSubmit?.(formData({ instructor_ids: [] }));
+
+		const { data } = mutateAsync.mock.calls[0][0];
+		expect(data.instructor_ids).toEqual([]);
+		expect(data).not.toHaveProperty("instructor");
+	});
+
+	it("writes only the legacy text when the flag is off", async () => {
+		const mutateAsync = renderModal({});
+
+		await capturedSubmit?.(
+			formData({ instructor_ids: ["33333333-3333-3333-3333-333333333333"] }),
+		);
+
+		const { data } = mutateAsync.mock.calls[0][0];
+		expect(data.instructor).toBe("Сегін");
+		expect(data).not.toHaveProperty("instructor_ids");
+	});
+});

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -27,7 +27,7 @@ interface ExistingRating {
 	usefulness?: number;
 	comment?: string | null;
 	instructor?: string | null;
-	instructors?: RatingInstructor[];
+	instructors?: readonly RatingInstructor[];
 	is_anonymous?: boolean;
 }
 

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -18,6 +18,7 @@ import {
 	useCoursesRatingsCreate,
 	useCoursesRatingsPartialUpdate,
 } from "@/lib/api/generated";
+import { useFeatureFlag } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { RatingForm, type RatingFormData } from "./RatingForm";
 
@@ -51,6 +52,7 @@ export function RatingModal({
 	onSuccess,
 }: RatingModalProps) {
 	const isEditMode = !!existingRating;
+	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
 	const queryClient = useQueryClient();
 
 	const createMutation = useCoursesRatingsCreate();
@@ -77,6 +79,11 @@ export function RatingModal({
 	};
 
 	const handleSubmit = async (data: RatingFormData) => {
+		// Gate the write path: when the multi-select flag is off, persist the
+		// legacy free-text instructor; when on, persist the M2M instructor_ids.
+		const instructorPayload = showMultiSelect
+			? { instructor_ids: data.instructor_ids }
+			: { instructor: data.instructor ?? "" };
 		try {
 			if (isEditMode && existingRating?.id) {
 				await updateMutation.mutateAsync({
@@ -86,7 +93,7 @@ export function RatingModal({
 						difficulty: data.difficulty,
 						usefulness: data.usefulness,
 						comment: data.comment ?? "",
-						instructor_ids: data.instructor_ids,
+						...instructorPayload,
 						is_anonymous: data.is_anonymous,
 					},
 				});
@@ -104,7 +111,7 @@ export function RatingModal({
 						difficulty: data.difficulty,
 						usefulness: data.usefulness,
 						comment: data.comment ?? undefined,
-						instructor_ids: data.instructor_ids,
+						...instructorPayload,
 						is_anonymous: data.is_anonymous,
 					},
 				});
@@ -138,6 +145,7 @@ export function RatingModal({
 				usefulness: existingRating.usefulness ?? 3,
 				comment: existingRating.comment ?? "",
 				instructor_ids: existingInstructors.map((ri) => ri.id),
+				instructor: existingRating.instructor ?? "",
 				is_anonymous: existingRating.is_anonymous ?? false,
 			}
 		: undefined;

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -8,6 +8,7 @@ import {
 	DialogTitle,
 } from "@/components/ui/Dialog";
 import { toast } from "@/components/ui/Toaster";
+import type { Instructor, RatingInstructor } from "@/lib/api/generated";
 import {
 	getCoursesListQueryKey,
 	getCoursesRatingsListQueryKey,
@@ -26,6 +27,7 @@ interface ExistingRating {
 	usefulness?: number;
 	comment?: string | null;
 	instructor?: string | null;
+	instructors?: RatingInstructor[];
 	is_anonymous?: boolean;
 }
 
@@ -84,7 +86,7 @@ export function RatingModal({
 						difficulty: data.difficulty,
 						usefulness: data.usefulness,
 						comment: data.comment ?? "",
-						instructor: data.instructor ?? "",
+						instructor_ids: data.instructor_ids,
 						is_anonymous: data.is_anonymous,
 					},
 				});
@@ -102,7 +104,7 @@ export function RatingModal({
 						difficulty: data.difficulty,
 						usefulness: data.usefulness,
 						comment: data.comment ?? undefined,
-						instructor: data.instructor ?? undefined,
+						instructor_ids: data.instructor_ids,
 						is_anonymous: data.is_anonymous,
 					},
 				});
@@ -120,12 +122,23 @@ export function RatingModal({
 		}
 	};
 
+	const existingInstructors = (existingRating?.instructors ?? []).filter(
+		(ri): ri is Required<RatingInstructor> => Boolean(ri.id),
+	);
+	const initialInstructors: Instructor[] = existingInstructors.map((ri) => ({
+		id: ri.id,
+		first_name: ri.first_name ?? "",
+		last_name: ri.last_name ?? "",
+		patronymic: ri.patronymic ?? "",
+		email: ri.email ?? "",
+	}));
+
 	const initialData: RatingFormData | undefined = existingRating
 		? {
 				difficulty: existingRating.difficulty ?? 3,
 				usefulness: existingRating.usefulness ?? 3,
 				comment: existingRating.comment ?? "",
-				instructor: existingRating.instructor ?? "",
+				instructor_ids: existingInstructors.map((ri) => ri.id),
 				is_anonymous: existingRating.is_anonymous ?? false,
 			}
 		: undefined;
@@ -159,6 +172,8 @@ export function RatingModal({
 					isLoading={isLoading}
 					isEditMode={isEditMode}
 					initialData={initialData}
+					offeringId={offeringId}
+					initialInstructors={initialInstructors}
 				/>
 			</DialogContent>
 		</Dialog>

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -172,6 +172,7 @@ export function RatingModal({
 					isEditMode={isEditMode}
 					initialData={initialData}
 					offeringId={offeringId}
+					courseId={courseId}
 					initialInstructors={initialInstructors}
 				/>
 			</DialogContent>

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -130,7 +130,6 @@ export function RatingModal({
 		first_name: ri.first_name ?? "",
 		last_name: ri.last_name ?? "",
 		patronymic: ri.patronymic ?? "",
-		email: ri.email ?? "",
 	}));
 
 	const initialData: RatingFormData | undefined = existingRating

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -18,7 +18,7 @@ import {
 	useCoursesRatingsCreate,
 	useCoursesRatingsPartialUpdate,
 } from "@/lib/api/generated";
-import { useFeatureFlag } from "@/lib/feature-flags";
+import { useFeatureFlags } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { RatingForm, type RatingFormData } from "./RatingForm";
 
@@ -52,7 +52,9 @@ export function RatingModal({
 	onSuccess,
 }: RatingModalProps) {
 	const isEditMode = !!existingRating;
-	const showMultiSelect = useFeatureFlag("fe_instructor_multiselect");
+	const { flags, isReady: flagsReady } = useFeatureFlags();
+	const showMultiSelect =
+		flagsReady && flags.fe_instructor_multiselect === true;
 	const queryClient = useQueryClient();
 
 	const createMutation = useCoursesRatingsCreate();
@@ -81,6 +83,10 @@ export function RatingModal({
 	const handleSubmit = async (data: RatingFormData) => {
 		// Gate the write path: when the multi-select flag is off, persist the
 		// legacy free-text instructor; when on, persist the M2M instructor_ids.
+		// Submitting before the flags resolve would pick the wrong shape.
+		if (!flagsReady) {
+			return;
+		}
 		const instructorPayload = showMultiSelect
 			? { instructor_ids: data.instructor_ids }
 			: { instructor: data.instructor ?? "" };

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -87,8 +87,14 @@ export function RatingModal({
 		if (!flagsReady) {
 			return;
 		}
+		// Picking real instructors supersedes whatever was typed into the legacy
+		// field, so clear it. An empty selection leaves the old text alone rather
+		// than silently dropping the only instructor the rating has.
 		const instructorPayload = showMultiSelect
-			? { instructor_ids: data.instructor_ids }
+			? {
+					instructor_ids: data.instructor_ids,
+					...(data.instructor_ids.length > 0 ? { instructor: "" } : {}),
+				}
 			: { instructor: data.instructor ?? "" };
 		try {
 			if (isEditMode && existingRating?.id) {

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -81,15 +81,12 @@ export function RatingModal({
 	};
 
 	const handleSubmit = async (data: RatingFormData) => {
-		// Gate the write path: when the multi-select flag is off, persist the
-		// legacy free-text instructor; when on, persist the M2M instructor_ids.
-		// Submitting before the flags resolve would pick the wrong shape.
+		// Submitting before the flags resolve would persist the wrong shape.
 		if (!flagsReady) {
 			return;
 		}
-		// Picking real instructors supersedes whatever was typed into the legacy
-		// field, so clear it. An empty selection leaves the old text alone rather
-		// than silently dropping the only instructor the rating has.
+		// A non-empty selection supersedes the legacy text; an empty one leaves it,
+		// rather than dropping the rating's only instructor.
 		const instructorPayload = showMultiSelect
 			? {
 					instructor_ids: data.instructor_ids,

--- a/src/webapp/src/features/ratings/components/RatingModal.tsx
+++ b/src/webapp/src/features/ratings/components/RatingModal.tsx
@@ -18,7 +18,7 @@ import {
 	useCoursesRatingsCreate,
 	useCoursesRatingsPartialUpdate,
 } from "@/lib/api/generated";
-import { useFeatureFlags } from "@/lib/feature-flags";
+import { useFeatureFlagState } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { RatingForm, type RatingFormData } from "./RatingForm";
 
@@ -52,9 +52,9 @@ export function RatingModal({
 	onSuccess,
 }: RatingModalProps) {
 	const isEditMode = !!existingRating;
-	const { flags, isReady: flagsReady } = useFeatureFlags();
-	const showMultiSelect =
-		flagsReady && flags.fe_instructor_multiselect === true;
+	const { enabled: showMultiSelect, isReady: flagsReady } = useFeatureFlagState(
+		"fe_instructor_multiselect",
+	);
 	const queryClient = useQueryClient();
 
 	const createMutation = useCoursesRatingsCreate();

--- a/src/webapp/src/features/ratings/components/UserRatingCard.tsx
+++ b/src/webapp/src/features/ratings/components/UserRatingCard.tsx
@@ -10,6 +10,7 @@ import {
 import type {
 	CommentAuthor,
 	InlineRating,
+	RatingInstructor,
 	RatingRead,
 	RatingVoteStrType,
 } from "@/lib/api/generated";
@@ -23,6 +24,7 @@ interface ExtendedRating extends InlineRating {
 	viewer_vote?: RatingVoteStrType | null;
 	comments_count?: number;
 	comment_authors?: CommentAuthor[];
+	instructors?: RatingInstructor[];
 }
 
 interface UserRatingCardProps {
@@ -105,6 +107,7 @@ export function UserRatingCard({
 				usefulness={rating.usefulness}
 				comment={rating.comment}
 				instructor={rating.instructor}
+				instructors={rating.instructors ?? []}
 				commentEmptyMessage="Ви не залишили коментар."
 				ratingId={rating.id}
 				courseId={courseId}

--- a/src/webapp/src/features/ratings/components/UserRatingCard.tsx
+++ b/src/webapp/src/features/ratings/components/UserRatingCard.tsx
@@ -81,6 +81,7 @@ export function UserRatingCard({
 						onClick={onEdit}
 						aria-label="Редагувати оцінку"
 						className="h-7 w-7 p-0"
+						data-testid={testIds.courseDetails.editUserRatingButton}
 					>
 						<Pencil className="h-3.5 w-3.5" />
 					</Button>

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -4,7 +4,11 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FeatureFlagsProvider } from "./FeatureFlagsContext";
-import { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";
+import {
+	useFeatureFlag,
+	useFeatureFlags,
+	useFeatureFlagState,
+} from "./useFeatureFlag";
 
 const FLAGS_QUERY_KEY = ["/api/v1/flags/"];
 const mockUseFlagsList = vi.fn();
@@ -60,6 +64,18 @@ describe("feature flags", () => {
 			wrapper,
 		});
 		expect(result.current).toBe(false);
+	});
+
+	it("separates an unresolved flag from an off one", () => {
+		mockUseFlagsList.mockReturnValue({
+			data: undefined,
+			isSuccess: false,
+			isError: false,
+		});
+		const { result } = renderHook(() => useFeatureFlagState("fe_test_header"), {
+			wrapper,
+		});
+		expect(result.current).toEqual({ enabled: false, isReady: false });
 	});
 
 	it("is not ready and exposes no flags before the query resolves", () => {

--- a/src/webapp/src/lib/feature-flags/index.ts
+++ b/src/webapp/src/lib/feature-flags/index.ts
@@ -7,4 +7,8 @@ export {
 	readFeatureFlagOverrides,
 	setFeatureFlagOverride,
 } from "./overrides";
-export { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";
+export {
+	useFeatureFlag,
+	useFeatureFlags,
+	useFeatureFlagState,
+} from "./useFeatureFlag";

--- a/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
+++ b/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
@@ -15,3 +15,16 @@ export function useFeatureFlags() {
 export function useFeatureFlag(name: string): boolean {
 	return useFeatureFlags().flags[name] ?? false;
 }
+
+/**
+ * Flag value plus whether it has resolved yet, for UI that must not flash the
+ * wrong variant. `useFeatureFlag` alone reports an unresolved flag as `false`,
+ * which is indistinguishable from "off".
+ */
+export function useFeatureFlagState(name: string): {
+	enabled: boolean;
+	isReady: boolean;
+} {
+	const { flags, isReady } = useFeatureFlags();
+	return { enabled: flags[name] ?? false, isReady };
+}

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -131,6 +131,7 @@ export const testIds = {
 		departmentSelect: "filters-department-select",
 		specialitySelect: "filters-speciality-select",
 		typeSelect: "filters-type-select",
+		instructorSelect: "filters-instructor-select",
 		educationLevelToggle: "filters-education-level-toggle",
 	},
 
@@ -154,6 +155,7 @@ export const testIds = {
 		usefulnessSlider: "rating-usefulness-slider",
 		commentTextarea: "rating-comment-textarea",
 		instructorInput: "rating-instructor-input",
+		instructorMultiSelect: "rating-instructor-multiselect",
 		anonymousCheckbox: "rating-anonymous-checkbox",
 		submitButton: "rating-submit-button",
 		cancelButton: "rating-cancel-button",

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -139,6 +139,7 @@ export const testIds = {
 	courseDetails: {
 		title: "course-details-title",
 		rateButton: "course-details-rate-button",
+		editUserRatingButton: "course-details-edit-user-rating-button",
 		statsCards: "course-details-stats-cards",
 		ratingsCountStat: "course-details-ratings-count-stat",
 		reviewsSection: "course-details-reviews-section",

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -157,7 +157,7 @@ export const testIds = {
 		commentTextarea: "rating-comment-textarea",
 		instructorInput: "rating-instructor-input",
 		instructorMultiSelect: "rating-instructor-multiselect",
-		legacyInstructorReadonly: "rating-legacy-instructor-readonly",
+		legacyInstructorText: "rating-legacy-instructor-text",
 		anonymousCheckbox: "rating-anonymous-checkbox",
 		submitButton: "rating-submit-button",
 		cancelButton: "rating-cancel-button",

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -157,6 +157,7 @@ export const testIds = {
 		commentTextarea: "rating-comment-textarea",
 		instructorInput: "rating-instructor-input",
 		instructorMultiSelect: "rating-instructor-multiselect",
+		legacyInstructorReadonly: "rating-legacy-instructor-readonly",
 		anonymousCheckbox: "rating-anonymous-checkbox",
 		submitButton: "rating-submit-button",
 		cancelButton: "rating-cancel-button",

--- a/src/webapp/src/test-utils/render.tsx
+++ b/src/webapp/src/test-utils/render.tsx
@@ -18,6 +18,7 @@ export function renderWithProviders(
 		RenderOptions & {
 			queryClient?: QueryClient;
 			flags?: Record<string, boolean>;
+			flagsReady?: boolean;
 		}
 	>,
 ) {
@@ -36,7 +37,10 @@ export function renderWithProviders(
 			<QueryClientProvider client={queryClient}>
 				<AuthProvider>
 					<FeatureFlagsContext.Provider
-						value={{ flags: options?.flags ?? {}, isReady: true }}
+						value={{
+							flags: options?.flags ?? {},
+							isReady: options?.flagsReady ?? true,
+						}}
 					>
 						{children}
 					</FeatureFlagsContext.Provider>

--- a/src/webapp/tests/e2e/courses/course-details.page.ts
+++ b/src/webapp/tests/e2e/courses/course-details.page.ts
@@ -15,6 +15,7 @@ export class CourseDetailsPage {
 	// Reviews section
 	private readonly reviewsSection: Locator;
 	private readonly reviewCards: Locator;
+	private readonly editUserRatingButton: Locator;
 	private readonly userRatingDeleteButton: Locator;
 	private readonly deleteConfirmButton: Locator;
 
@@ -42,6 +43,9 @@ export class CourseDetailsPage {
 
 		this.reviewCards = page.getByTestId(testIds.courseDetails.reviewCard);
 
+		this.editUserRatingButton = page.getByTestId(
+			testIds.courseDetails.editUserRatingButton,
+		);
 		this.userRatingDeleteButton = page.getByTestId(testIds.rating.deleteButton);
 		this.deleteConfirmButton = page.getByTestId(
 			testIds.deleteDialog.confirmButton,
@@ -83,6 +87,11 @@ export class CourseDetailsPage {
 	async clickRateButton(): Promise<void> {
 		await expect(this.rateButton).toBeVisible();
 		await this.rateButton.click();
+	}
+
+	async clickEditUserRating(): Promise<void> {
+		await expect(this.editUserRatingButton).toBeVisible();
+		await this.editUserRatingButton.click();
 	}
 
 	async hasStatsData(): Promise<boolean> {

--- a/src/webapp/tests/e2e/ratings/instructor-legacy.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-legacy.spec.ts
@@ -59,6 +59,10 @@ test.describe("Rating instructor — legacy free-text (flag off)", () => {
 			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
 			await expect(ratingModal.instructorTextInputLocator()).toBeVisible();
 			expect(await ratingModal.getInstructorTextValue()).toBe(instructorName);
+
+			// Close the edit modal so the cleanup can reach the card's delete button
+			// (an open modal overlay would intercept the click).
+			await ratingModal.cancel();
 		} catch (error) {
 			mainError = error;
 		}

--- a/src/webapp/tests/e2e/ratings/instructor-legacy.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-legacy.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+
+import { testIds } from "@/lib/test-ids";
+import { MyRatingsPage } from "./my-ratings.page";
+import { CourseDetailsPage } from "../courses/course-details.page";
+import { createTestRatingData } from "../framework/test-config";
+import { setFeatureFlagOverride } from "../shared/feature-flags";
+import { RatingModal } from "../shared/rating-modal.component";
+
+// Regression: with the multi-select flag OFF, the rating form must keep the
+// legacy free-text instructor input and the old write path must work end to end.
+test.describe("Rating instructor — legacy free-text (flag off)", () => {
+	let coursePage: CourseDetailsPage;
+	let ratingModal: RatingModal;
+	let myRatingsPage: MyRatingsPage;
+
+	test.beforeEach(async ({ page }) => {
+		await setFeatureFlagOverride(page, "fe_instructor_multiselect", false);
+
+		coursePage = new CourseDetailsPage(page);
+		ratingModal = new RatingModal(page);
+		myRatingsPage = new MyRatingsPage(page);
+
+		await myRatingsPage.goto();
+		await myRatingsPage.openFirstCourseToRate();
+		await expect(page.getByTestId(testIds.courseDetails.title)).toBeVisible();
+	});
+
+	test("shows the text input (not the multi-select), saves and re-populates it", async ({
+		page,
+	}) => {
+		let createdRating = false;
+		let mainError: unknown;
+
+		try {
+			await coursePage.clickRateButton();
+			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
+
+			// The legacy text input is shown; the multi-select is not rendered.
+			await expect(ratingModal.instructorTextInputLocator()).toBeVisible();
+			await expect(ratingModal.instructorMultiSelectLocator()).toBeHidden();
+
+			const testData = createTestRatingData({
+				comment: `e2e:instructor-legacy:${String(Date.now())}`,
+			});
+			const instructorName = `Викладач ${String(Date.now())}`;
+
+			await ratingModal.setDifficultyRating(testData.difficulty);
+			await ratingModal.setUsefulnessRating(testData.usefulness);
+			await ratingModal.setComment(testData.comment);
+			await ratingModal.fillInstructorText(instructorName);
+
+			await ratingModal.submitRating();
+			await ratingModal.waitForHidden();
+			createdRating = true;
+
+			// Re-open edit: the saved free-text instructor must pre-populate.
+			await coursePage.clickEditUserRating();
+			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
+			await expect(ratingModal.instructorTextInputLocator()).toBeVisible();
+			expect(await ratingModal.getInstructorTextValue()).toBe(instructorName);
+		} catch (error) {
+			mainError = error;
+		}
+
+		if (createdRating) {
+			try {
+				await coursePage.deleteUserRating();
+			} catch (cleanupError) {
+				if (!mainError) {
+					throw cleanupError;
+				}
+				console.warn("Failed to cleanup rating created by test", cleanupError);
+			}
+		}
+
+		if (mainError) {
+			throw mainError;
+		}
+	});
+});

--- a/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
@@ -1,0 +1,88 @@
+import { expect, type Locator, test } from "@playwright/test";
+
+import { testIds } from "@/lib/test-ids";
+import { MyRatingsPage } from "./my-ratings.page";
+import { CourseDetailsPage } from "../courses/course-details.page";
+import { createTestRatingData } from "../framework/test-config";
+import { RatingModal } from "../shared/rating-modal.component";
+
+test.describe("Rating instructor multi-select", () => {
+	let coursePage: CourseDetailsPage;
+	let ratingModal: RatingModal;
+	let myRatingsPage: MyRatingsPage;
+
+	test.beforeEach(async ({ page }) => {
+		coursePage = new CourseDetailsPage(page);
+		ratingModal = new RatingModal(page);
+		myRatingsPage = new MyRatingsPage(page);
+
+		await myRatingsPage.goto();
+		await myRatingsPage.openFirstCourseToRate();
+
+		await expect(page.getByTestId(testIds.courseDetails.title)).toBeVisible();
+	});
+
+	test("pick two instructors via multi-select and submit", async ({ page }) => {
+		let createdRating = false;
+		let reviewCard: Locator | undefined;
+		let mainError: unknown;
+
+		try {
+			await coursePage.clickRateButton();
+			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
+
+			const comment = `e2e:instructor:${String(Date.now())}`;
+			const testData = createTestRatingData({ comment });
+
+			await ratingModal.setDifficultyRating(testData.difficulty);
+			await ratingModal.setUsefulnessRating(testData.usefulness);
+			await ratingModal.setComment(testData.comment);
+
+			await ratingModal.openInstructorPicker();
+			const list = page.getByTestId(
+				`${testIds.rating.instructorMultiSelect}-list`,
+			);
+			const firstThree = list.locator("[role='option']");
+			await expect(firstThree.first()).toBeVisible();
+			const optionCount = Math.min(2, await firstThree.count());
+
+			for (let i = 0; i < optionCount; i++) {
+				await firstThree.nth(i).click();
+			}
+
+			await ratingModal.closeInstructorPicker();
+
+			const chips = page
+				.getByTestId(testIds.rating.instructorMultiSelect)
+				.locator("span[class*='bg-secondary']");
+			await expect(chips).toHaveCount(optionCount);
+
+			await ratingModal.submitRating();
+			await ratingModal.waitForHidden();
+			createdRating = true;
+
+			reviewCard = await coursePage.findReviewCardByText(testData.comment);
+			await expect(reviewCard).toBeVisible();
+		} catch (error) {
+			mainError = error;
+		}
+
+		if (createdRating) {
+			try {
+				await coursePage.deleteUserRating();
+				if (reviewCard) {
+					await expect(reviewCard).toBeHidden();
+				}
+			} catch (cleanupError) {
+				if (!mainError) {
+					throw cleanupError;
+				}
+				console.warn("Failed to cleanup rating created by test", cleanupError);
+			}
+		}
+
+		if (mainError) {
+			throw mainError;
+		}
+	});
+});

--- a/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
@@ -4,6 +4,7 @@ import { testIds } from "@/lib/test-ids";
 import { MyRatingsPage } from "./my-ratings.page";
 import { CourseDetailsPage } from "../courses/course-details.page";
 import { createTestRatingData } from "../framework/test-config";
+import { setFeatureFlagOverride } from "../shared/feature-flags";
 import { RatingModal } from "../shared/rating-modal.component";
 
 test.describe("Rating instructor multi-select", () => {
@@ -12,6 +13,9 @@ test.describe("Rating instructor multi-select", () => {
 	let myRatingsPage: MyRatingsPage;
 
 	test.beforeEach(async ({ page }) => {
+		// The multi-select UI is gated behind this flag; force it on for the test.
+		await setFeatureFlagOverride(page, "fe_instructor_multiselect", true);
+
 		coursePage = new CourseDetailsPage(page);
 		ratingModal = new RatingModal(page);
 		myRatingsPage = new MyRatingsPage(page);

--- a/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
@@ -42,21 +42,33 @@ test.describe("Rating instructor multi-select", () => {
 			await ratingModal.setUsefulnessRating(testData.usefulness);
 			await ratingModal.setComment(testData.comment);
 
-			// --- select one ---
+			// --- select one via search; regression: chip survives clearing search ---
 			await ratingModal.openInstructorPicker();
-			await ratingModal.selectInstructorOptionByIndex(0);
+			await ratingModal.searchInstructor("Калиновська");
+			await ratingModal.pickInstructorByText("Калиновська");
+			const [kalynovskaName] = await ratingModal.getSelectedInstructorNames();
+			expect(kalynovskaName).toContain("Калиновська");
+			await ratingModal.clearInstructorSearch();
+			expect(await ratingModal.getSelectedInstructorNames()).toContain(
+				kalynovskaName,
+			);
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(1);
 
 			// --- select two ---
 			await ratingModal.openInstructorPicker();
-			await ratingModal.selectInstructorOptionByIndex(1);
+			await ratingModal.searchInstructor("Глибовець Микола");
+			await ratingModal.pickInstructorByText("Глибовець Микола");
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
 
 			const savedNames = (
 				await ratingModal.getSelectedInstructorNames()
 			).sort();
+			const hlybovetsName = savedNames.find((name) =>
+				name.includes("Глибовець"),
+			);
+			expect(hlybovetsName).toBeTruthy();
 
 			// --- deselect one ---
 			await ratingModal.removeInstructorChipByIndex(0);
@@ -68,8 +80,12 @@ test.describe("Rating instructor multi-select", () => {
 
 			// re-select the same two and persist them
 			await ratingModal.openInstructorPicker();
-			await ratingModal.selectInstructorOptionByIndex(0);
-			await ratingModal.selectInstructorOptionByIndex(1);
+			await ratingModal.searchInstructor(kalynovskaName);
+			await ratingModal.pickInstructorByText(kalynovskaName);
+			await ratingModal.searchInstructor(hlybovetsName ?? "Глибовець Микола");
+			await ratingModal.pickInstructorByText(
+				hlybovetsName ?? "Глибовець Микола",
+			);
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
 			expect((await ratingModal.getSelectedInstructorNames()).sort()).toEqual(

--- a/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { testIds } from "@/lib/test-ids";
 import { MyRatingsPage } from "./my-ratings.page";
@@ -18,51 +18,89 @@ test.describe("Rating instructor multi-select", () => {
 
 		await myRatingsPage.goto();
 		await myRatingsPage.openFirstCourseToRate();
-
 		await expect(page.getByTestId(testIds.courseDetails.title)).toBeVisible();
 	});
 
-	test("pick two instructors via multi-select and submit", async ({ page }) => {
+	// Select one, select two, deselect one, deselect all, persist two, then
+	// reopen the edit modal and confirm the saved instructors pre-populate
+	// (regression: the edit modal used to open with an empty picker), finally
+	// clear them all and confirm the cleared state persists.
+	test("select, deselect, persist and re-open with saved instructors", async ({
+		page,
+	}) => {
 		let createdRating = false;
-		let reviewCard: Locator | undefined;
 		let mainError: unknown;
 
 		try {
 			await coursePage.clickRateButton();
 			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
 
-			const comment = `e2e:instructor:${String(Date.now())}`;
-			const testData = createTestRatingData({ comment });
-
+			const testData = createTestRatingData({
+				comment: `e2e:instructor:${String(Date.now())}`,
+			});
 			await ratingModal.setDifficultyRating(testData.difficulty);
 			await ratingModal.setUsefulnessRating(testData.usefulness);
 			await ratingModal.setComment(testData.comment);
 
+			// --- select one ---
 			await ratingModal.openInstructorPicker();
-			const list = page.getByTestId(
-				`${testIds.rating.instructorMultiSelect}-list`,
-			);
-			const firstThree = list.locator("[role='option']");
-			await expect(firstThree.first()).toBeVisible();
-			const optionCount = Math.min(2, await firstThree.count());
-
-			for (let i = 0; i < optionCount; i++) {
-				await firstThree.nth(i).click();
-			}
-
+			await ratingModal.selectInstructorOptionByIndex(0);
 			await ratingModal.closeInstructorPicker();
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(1);
 
-			const chips = page
-				.getByTestId(testIds.rating.instructorMultiSelect)
-				.locator("span[class*='bg-secondary']");
-			await expect(chips).toHaveCount(optionCount);
+			// --- select two ---
+			await ratingModal.openInstructorPicker();
+			await ratingModal.selectInstructorOptionByIndex(1);
+			await ratingModal.closeInstructorPicker();
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
+
+			const savedNames = (
+				await ratingModal.getSelectedInstructorNames()
+			).sort();
+
+			// --- deselect one ---
+			await ratingModal.removeInstructorChipByIndex(0);
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(1);
+
+			// --- deselect all ---
+			await ratingModal.removeInstructorChipByIndex(0);
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(0);
+
+			// re-select the same two and persist them
+			await ratingModal.openInstructorPicker();
+			await ratingModal.selectInstructorOptionByIndex(0);
+			await ratingModal.selectInstructorOptionByIndex(1);
+			await ratingModal.closeInstructorPicker();
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
+			expect((await ratingModal.getSelectedInstructorNames()).sort()).toEqual(
+				savedNames,
+			);
 
 			await ratingModal.submitRating();
 			await ratingModal.waitForHidden();
 			createdRating = true;
 
-			reviewCard = await coursePage.findReviewCardByText(testData.comment);
-			await expect(reviewCard).toBeVisible();
+			// --- regression: re-open edit, saved instructors must be present ---
+			await coursePage.clickEditUserRating();
+			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
+			expect((await ratingModal.getSelectedInstructorNames()).sort()).toEqual(
+				savedNames,
+			);
+
+			// --- deselect all in edit and persist the cleared state ---
+			await ratingModal.removeInstructorChipByIndex(0);
+			await ratingModal.removeInstructorChipByIndex(0);
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(0);
+			await ratingModal.submitRating();
+			await ratingModal.waitForHidden();
+
+			// re-open once more: the cleared state must have persisted
+			await coursePage.clickEditUserRating();
+			await expect(page.getByTestId(testIds.rating.modal)).toBeVisible();
+			expect(await ratingModal.getSelectedInstructorCount()).toBe(0);
+			await ratingModal.closeInstructorPicker();
+			await page.getByTestId(testIds.rating.modal).waitFor({ state: "hidden" });
 		} catch (error) {
 			mainError = error;
 		}
@@ -70,9 +108,6 @@ test.describe("Rating instructor multi-select", () => {
 		if (createdRating) {
 			try {
 				await coursePage.deleteUserRating();
-				if (reviewCard) {
-					await expect(reviewCard).toBeHidden();
-				}
 			} catch (cleanupError) {
 				if (!mainError) {
 					throw cleanupError;

--- a/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
+++ b/src/webapp/tests/e2e/ratings/instructor-multiselect.spec.ts
@@ -46,33 +46,37 @@ test.describe("Rating instructor multi-select", () => {
 			await ratingModal.setUsefulnessRating(testData.usefulness);
 			await ratingModal.setComment(testData.comment);
 
-			// --- select one via search; regression: chip survives clearing search ---
+			// Take two real names from the directory instead of hardcoding staff who
+			// may be renamed, unrated, or filtered out of the list later.
 			await ratingModal.openInstructorPicker();
-			await ratingModal.searchInstructor("Калиновська");
-			await ratingModal.pickInstructorByText("Калиновська");
-			const [kalynovskaName] = await ratingModal.getSelectedInstructorNames();
-			expect(kalynovskaName).toContain("Калиновська");
+			const [firstName, secondName] =
+				await ratingModal.getListedInstructorNames(2);
+			expect(firstName).toBeTruthy();
+			expect(secondName).toBeTruthy();
+			expect(firstName).not.toBe(secondName);
+
+			// --- select one; regression: chip survives clearing search ---
+			await ratingModal.pickInstructorByText(firstName);
+			expect(await ratingModal.getSelectedInstructorNames()).toContain(
+				firstName,
+			);
 			await ratingModal.clearInstructorSearch();
 			expect(await ratingModal.getSelectedInstructorNames()).toContain(
-				kalynovskaName,
+				firstName,
 			);
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(1);
 
 			// --- select two ---
 			await ratingModal.openInstructorPicker();
-			await ratingModal.searchInstructor("Глибовець Микола");
-			await ratingModal.pickInstructorByText("Глибовець Микола");
+			await ratingModal.pickInstructorByText(secondName);
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
 
-			const savedNames = (
-				await ratingModal.getSelectedInstructorNames()
-			).sort();
-			const hlybovetsName = savedNames.find((name) =>
-				name.includes("Глибовець"),
+			const savedNames = [firstName, secondName].sort();
+			expect((await ratingModal.getSelectedInstructorNames()).sort()).toEqual(
+				savedNames,
 			);
-			expect(hlybovetsName).toBeTruthy();
 
 			// --- deselect one ---
 			await ratingModal.removeInstructorChipByIndex(0);
@@ -84,12 +88,8 @@ test.describe("Rating instructor multi-select", () => {
 
 			// re-select the same two and persist them
 			await ratingModal.openInstructorPicker();
-			await ratingModal.searchInstructor(kalynovskaName);
-			await ratingModal.pickInstructorByText(kalynovskaName);
-			await ratingModal.searchInstructor(hlybovetsName ?? "Глибовець Микола");
-			await ratingModal.pickInstructorByText(
-				hlybovetsName ?? "Глибовець Микола",
-			);
+			await ratingModal.pickInstructorByText(firstName);
+			await ratingModal.pickInstructorByText(secondName);
 			await ratingModal.closeInstructorPicker();
 			expect(await ratingModal.getSelectedInstructorCount()).toBe(2);
 			expect((await ratingModal.getSelectedInstructorNames()).sort()).toEqual(

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -40,9 +40,7 @@ export class RatingModal {
 		await expect(this.instructorTrigger).toBeVisible();
 		await this.instructorTrigger.click();
 		await expect(
-			this.page.getByTestId(
-				`${testIds.rating.instructorMultiSelect}-list`,
-			),
+			this.page.getByTestId(`${testIds.rating.instructorMultiSelect}-list`),
 		).toBeVisible();
 	}
 
@@ -71,9 +69,7 @@ export class RatingModal {
 	}
 
 	async getSelectedInstructorCount(): Promise<number> {
-		const chips = this.instructorTrigger.locator(
-			"span[class*='bg-secondary']",
-		);
+		const chips = this.instructorTrigger.locator("span[class*='bg-secondary']");
 		return chips.count();
 	}
 

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -68,9 +68,37 @@ export class RatingModal {
 		await this.page.keyboard.press("Escape");
 	}
 
+	private get instructorChips(): Locator {
+		return this.instructorTrigger.locator("span[class*='bg-secondary']");
+	}
+
 	async getSelectedInstructorCount(): Promise<number> {
-		const chips = this.instructorTrigger.locator("span[class*='bg-secondary']");
-		return chips.count();
+		return this.instructorChips.count();
+	}
+
+	async getSelectedInstructorNames(): Promise<string[]> {
+		const count = await this.instructorChips.count();
+		const names: string[] = [];
+		for (let i = 0; i < count; i++) {
+			names.push((await this.instructorChips.nth(i).innerText()).trim());
+		}
+		return names;
+	}
+
+	/** Click the option at `index` in the open picker list; returns its label. */
+	async selectInstructorOptionByIndex(index: number): Promise<string> {
+		const options = this.page
+			.getByTestId(`${testIds.rating.instructorMultiSelect}-list`)
+			.locator("[role='option']");
+		await expect(options.nth(index)).toBeVisible();
+		const label = (await options.nth(index).innerText()).trim();
+		await options.nth(index).click();
+		return label;
+	}
+
+	/** Remove the chip at `index` by clicking its × button. */
+	async removeInstructorChipByIndex(index: number): Promise<void> {
+		await this.instructorChips.nth(index).locator("button").click();
 	}
 
 	async waitForHidden(): Promise<void> {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -56,6 +56,14 @@ export class RatingModal {
 			.fill(query);
 	}
 
+	async clearInstructorSearch(): Promise<void> {
+		await this.page
+			.locator(
+				`[data-testid='${testIds.rating.instructorMultiSelect}-content'] [cmdk-input]`,
+			)
+			.fill("");
+	}
+
 	async pickInstructorByText(text: string): Promise<void> {
 		const list = this.page.getByTestId(
 			`${testIds.rating.instructorMultiSelect}-list`,
@@ -65,7 +73,11 @@ export class RatingModal {
 	}
 
 	async closeInstructorPicker(): Promise<void> {
+		const list = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
 		await this.page.keyboard.press("Escape");
+		await expect(list).toBeHidden();
 	}
 
 	private get instructorChips(): Locator {
@@ -83,17 +95,6 @@ export class RatingModal {
 			names.push((await this.instructorChips.nth(i).innerText()).trim());
 		}
 		return names;
-	}
-
-	/** Click the option at `index` in the open picker list; returns its label. */
-	async selectInstructorOptionByIndex(index: number): Promise<string> {
-		const options = this.page
-			.getByTestId(`${testIds.rating.instructorMultiSelect}-list`)
-			.locator("[role='option']");
-		await expect(options.nth(index)).toBeVisible();
-		const label = (await options.nth(index).innerText()).trim();
-		await options.nth(index).click();
-		return label;
 	}
 
 	/** Remove the chip at `index` by clicking its × button. */

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -58,10 +58,23 @@ export class RatingModal {
 
 	async openInstructorPicker(): Promise<void> {
 		await expect(this.instructorTrigger).toBeVisible();
-		await this.instructorTrigger.click();
-		await expect(
-			this.page.getByTestId(`${testIds.rating.instructorMultiSelect}-list`),
-		).toBeVisible();
+		const list = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
+		// The picker is a Radix Popover rendered inside the rating Dialog; the
+		// open click can race with the dialog's focus handling, so retry the
+		// click until the list actually shows.
+		await expect(async () => {
+			if (!(await list.isVisible())) {
+				await this.instructorTrigger.click();
+			}
+			await expect(list).toBeVisible({ timeout: 2_000 });
+		}).toPass({ timeout: 20_000 });
+	}
+
+	async cancel(): Promise<void> {
+		await this.page.getByTestId(testIds.rating.cancelButton).click();
+		await this.waitForHidden();
 	}
 
 	async searchInstructor(query: string): Promise<void> {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -20,13 +20,61 @@ export class RatingModal {
 	// Action buttons
 	private readonly saveButton: Locator;
 
+	private readonly page: Page;
+	private readonly instructorTrigger: Locator;
+
 	constructor(page: Page) {
+		this.page = page;
 		this.modal = page.getByTestId(testIds.rating.modal);
 		this.difficultyStars = page.getByTestId(testIds.rating.difficultySlider);
 		this.usefulnessStars = page.getByTestId(testIds.rating.usefulnessSlider);
 		this.commentTextarea = page.getByTestId(testIds.rating.commentTextarea);
+		this.instructorTrigger = page.getByTestId(
+			testIds.rating.instructorMultiSelect,
+		);
 
 		this.saveButton = page.getByTestId(testIds.rating.submitButton);
+	}
+
+	async openInstructorPicker(): Promise<void> {
+		await expect(this.instructorTrigger).toBeVisible();
+		await this.instructorTrigger.click();
+		await expect(
+			this.page.getByTestId(
+				`${testIds.rating.instructorMultiSelect}-list`,
+			),
+		).toBeVisible();
+	}
+
+	async searchInstructor(query: string): Promise<void> {
+		const list = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
+		await expect(list).toBeVisible();
+		await this.page
+			.locator(
+				`[data-testid='${testIds.rating.instructorMultiSelect}-content'] [cmdk-input]`,
+			)
+			.fill(query);
+	}
+
+	async pickInstructorByText(text: string): Promise<void> {
+		const list = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
+		await expect(list).toBeVisible();
+		await list.getByText(text, { exact: false }).first().click();
+	}
+
+	async closeInstructorPicker(): Promise<void> {
+		await this.page.keyboard.press("Escape");
+	}
+
+	async getSelectedInstructorCount(): Promise<number> {
+		const chips = this.instructorTrigger.locator(
+			"span[class*='bg-secondary']",
+		);
+		return chips.count();
 	}
 
 	async waitForHidden(): Promise<void> {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -22,6 +22,7 @@ export class RatingModal {
 
 	private readonly page: Page;
 	private readonly instructorTrigger: Locator;
+	private readonly instructorInput: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -32,8 +33,27 @@ export class RatingModal {
 		this.instructorTrigger = page.getByTestId(
 			testIds.rating.instructorMultiSelect,
 		);
+		this.instructorInput = page.getByTestId(testIds.rating.instructorInput);
 
 		this.saveButton = page.getByTestId(testIds.rating.submitButton);
+	}
+
+	/** Legacy free-text instructor input (shown when the multi-select flag is off). */
+	async fillInstructorText(text: string): Promise<void> {
+		await expect(this.instructorInput).toBeVisible();
+		await this.instructorInput.fill(text);
+	}
+
+	async getInstructorTextValue(): Promise<string> {
+		return this.instructorInput.inputValue();
+	}
+
+	instructorMultiSelectLocator(): Locator {
+		return this.instructorTrigger;
+	}
+
+	instructorTextInputLocator(): Locator {
+		return this.instructorInput;
 	}
 
 	async openInstructorPicker(): Promise<void> {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -23,6 +23,9 @@ export class RatingModal {
 	private readonly page: Page;
 	private readonly instructorTrigger: Locator;
 	private readonly instructorInput: Locator;
+	private readonly instructorToggle: Locator;
+	private readonly instructorList: Locator;
+	private readonly instructorSearchInput: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
@@ -34,6 +37,15 @@ export class RatingModal {
 			testIds.rating.instructorMultiSelect,
 		);
 		this.instructorInput = page.getByTestId(testIds.rating.instructorInput);
+		this.instructorToggle = page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-toggle`,
+		);
+		this.instructorList = page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
+		this.instructorSearchInput = page.locator(
+			`[data-testid='${testIds.rating.instructorMultiSelect}-content'] [cmdk-input]`,
+		);
 
 		this.saveButton = page.getByTestId(testIds.rating.submitButton);
 	}
@@ -58,23 +70,14 @@ export class RatingModal {
 
 	async openInstructorPicker(): Promise<void> {
 		await expect(this.instructorTrigger).toBeVisible();
-		const list = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-list`,
-		);
-		// Click the chevron, not the trigger itself: once a chip is selected the
-		// trigger's centre lands on that chip's remove button, which removes the
-		// chip and stops the click from reaching the popover.
-		const toggle = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-toggle`,
-		);
-		// The picker is a Radix Popover rendered inside the rating Dialog; the
-		// open click can race with the dialog's focus handling, so retry the
-		// click until the list actually shows.
+		// Click the chevron, not the trigger: with a chip selected the trigger's
+		// centre lands on that chip's remove button. The open click can also race
+		// with the dialog's focus handling, so retry until the list shows.
 		await expect(async () => {
-			if (!(await list.isVisible())) {
-				await toggle.click();
+			if (!(await this.instructorList.isVisible())) {
+				await this.instructorToggle.click();
 			}
-			await expect(list).toBeVisible({ timeout: 2_000 });
+			await expect(this.instructorList).toBeVisible({ timeout: 2_000 });
 		}).toPass({ timeout: 20_000 });
 	}
 
@@ -84,32 +87,18 @@ export class RatingModal {
 	}
 
 	async searchInstructor(query: string): Promise<void> {
-		const list = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-list`,
-		);
-		await expect(list).toBeVisible();
-		await this.page
-			.locator(
-				`[data-testid='${testIds.rating.instructorMultiSelect}-content'] [cmdk-input]`,
-			)
-			.fill(query);
+		await expect(this.instructorList).toBeVisible();
+		await this.instructorSearchInput.fill(query);
 	}
 
 	async clearInstructorSearch(): Promise<void> {
-		await this.page
-			.locator(
-				`[data-testid='${testIds.rating.instructorMultiSelect}-content'] [cmdk-input]`,
-			)
-			.fill("");
+		await this.instructorSearchInput.fill("");
 	}
 
 	/** Names currently offered by the picker, in listed order. */
 	async getListedInstructorNames(limit = 5): Promise<string[]> {
-		const list = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-list`,
-		);
-		await expect(list).toBeVisible();
-		const options = list.getByRole("option");
+		await expect(this.instructorList).toBeVisible();
+		const options = this.instructorList.getByRole("option");
 		await expect(options.first()).toBeVisible();
 		const count = Math.min(await options.count(), limit);
 		const names: string[] = [];
@@ -124,21 +113,18 @@ export class RatingModal {
 	 * choice never depends on directory ordering or on a partial-name collision.
 	 */
 	async pickInstructorByText(text: string): Promise<void> {
-		const list = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-list`,
-		);
 		await this.searchInstructor(text);
-		const option = list.getByRole("option", { name: text, exact: true });
+		const option = this.instructorList.getByRole("option", {
+			name: text,
+			exact: true,
+		});
 		await expect(option).toBeVisible();
 		await option.click();
 	}
 
 	async closeInstructorPicker(): Promise<void> {
-		const list = this.page.getByTestId(
-			`${testIds.rating.instructorMultiSelect}-list`,
-		);
 		await this.page.keyboard.press("Escape");
-		await expect(list).toBeHidden();
+		await expect(this.instructorList).toBeHidden();
 	}
 
 	private get instructorChips(): Locator {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -103,12 +103,34 @@ export class RatingModal {
 			.fill("");
 	}
 
-	async pickInstructorByText(text: string): Promise<void> {
+	/** Names currently offered by the picker, in listed order. */
+	async getListedInstructorNames(limit = 5): Promise<string[]> {
 		const list = this.page.getByTestId(
 			`${testIds.rating.instructorMultiSelect}-list`,
 		);
 		await expect(list).toBeVisible();
-		await list.getByText(text, { exact: false }).first().click();
+		const options = list.getByRole("option");
+		await expect(options.first()).toBeVisible();
+		const count = Math.min(await options.count(), limit);
+		const names: string[] = [];
+		for (let i = 0; i < count; i++) {
+			names.push((await options.nth(i).innerText()).trim());
+		}
+		return names;
+	}
+
+	/**
+	 * Search for a name, then pick the row that matches it exactly, so the
+	 * choice never depends on directory ordering or on a partial-name collision.
+	 */
+	async pickInstructorByText(text: string): Promise<void> {
+		const list = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-list`,
+		);
+		await this.searchInstructor(text);
+		const option = list.getByRole("option", { name: text, exact: true });
+		await expect(option).toBeVisible();
+		await option.click();
 	}
 
 	async closeInstructorPicker(): Promise<void> {

--- a/src/webapp/tests/e2e/shared/rating-modal.component.ts
+++ b/src/webapp/tests/e2e/shared/rating-modal.component.ts
@@ -61,12 +61,18 @@ export class RatingModal {
 		const list = this.page.getByTestId(
 			`${testIds.rating.instructorMultiSelect}-list`,
 		);
+		// Click the chevron, not the trigger itself: once a chip is selected the
+		// trigger's centre lands on that chip's remove button, which removes the
+		// chip and stops the click from reaching the popover.
+		const toggle = this.page.getByTestId(
+			`${testIds.rating.instructorMultiSelect}-toggle`,
+		);
 		// The picker is a Radix Popover rendered inside the rating Dialog; the
 		// open click can race with the dialog's focus handling, so retry the
 		// click until the list actually shows.
 		await expect(async () => {
 			if (!(await list.isVisible())) {
-				await this.instructorTrigger.click();
+				await toggle.click();
 			}
 			await expect(list).toBeVisible({ timeout: 2_000 });
 		}).toPass({ timeout: 20_000 });


### PR DESCRIPTION
## #563 — Instructor multi-select on ratings + instructor filter on courses

Builds on the real `Instructor` entities from #564 (merged in v1.8.0): lets users tag a rating with one or more actual instructors instead of a free-text field, and adds an instructor filter to the courses page — both ranked by how often each instructor is mentioned.

**Ships behind `fe_instructor_multiselect`, off by default.** With the flag off the UI is byte-for-byte the current free-text experience, so this is safe to merge before the legacy backfill runs.

### Backend
- `Rating.instructors` **M2M** added (migration `0029`, schema-only, additive, reversible). Legacy free-text `Rating.instructor` is **kept** for backward compatibility.
- Ranked list endpoint `GET /api/v1/instructors/` — paginated (`page`/`page_size`), `search`, ranked by `course_offering_id` → `speciality_id` → global mention counts. **Cyrillic names rank before Latin** at equal mention counts (`starts_latin` tie-break); deterministic tie-break ends in `id`.
- The M365 export can't distinguish staff from students, so ~75% of the ingested directory is students. `list_ranked` drops never-rated entries matching (by email) a bachelor `Student` whose programme started within the last four academic years. Deliberately conservative: masters kept (they teach practicums), alumni kept, anyone with ≥1 rating always kept.
- `instructor_ids: list[UUID]` accepted on rating create / PUT / PATCH, **validated** against existing instructors — unknown ids → **400** (`InvalidInstructorIdsError`) rather than silently dropped by `.set()`.
- Instructors returned on **every** read shape the UI consumes — `RatingRead`, the light `StudentsMeCourses` (`InlineRating`) and the detailed `StudentsMeGrades` (`InlineRatingDetailed`) — so the edit modal pre-populates on both the course page and My Ratings.
- **Instructor email is never serialized** anywhere in the API (directory, rating reads, course-offering instructors, student-courses payload). It stays the model's unique identity key only, so the `IsAuthenticated`-only endpoints can't leak staff/student emails.

### Frontend
- `orval.config` generates an **infinite query** for `instructors_list`; `useInfiniteInstructors` consumes `useInstructorsListInfinite`.
- `InstructorMultiSelect` (Popover + cmdk + debounced server search + IntersectionObserver infinite scroll) replaces the text input in `RatingForm`. Selected instructors render as removable chips; names only, no emails.
- Courses filter panel gains a "Викладач" filter sourced from the top-mentioned instructors.
- Every entry point (`RatingForm`, `RatingModal`, `RatingCardBody`, `CourseFiltersPanel`) is flag-gated. The first three wait for `useFeatureFlags().isReady` before rendering or submitting, per `src/webapp/AGENTS.md` — otherwise the legacy variant renders first and an early submit would persist the wrong shape. `CourseFiltersPanel` is intentionally left ungated: a filter option appearing late is harmless, and gating it would blank the panel on every load.
- Both instructor pickers use a `div` trigger with `role="combobox"` + Enter/Space handling rather than a `button`, so the chip remove / clear buttons are not nested interactive controls, and both carry `aria-controls` / `aria-haspopup="listbox"`.

### What an existing rating looks like with the flag on

A rating written before this PR has free text and no linked instructors. It is **not** hidden or blanked:

- **On the card** it still renders `Викладач: <text>` with the "Вказано студентом, не перевірено" tooltip — `RatingCardBody` only uses the M2M branch when at least one instructor is linked. This fallback is what makes merging before the backfill safe.
- **In the edit modal** the free-text input is gone. The old value appears above the picker as read-only (`Раніше вказано текстом: …`) so the author can find the matching real person, and the only editable control is the multi-select.
- **On save**, picking instructors supersedes the text: the request sends `instructor_ids` **and** `instructor: ""`. Saving with an empty selection leaves the text alone rather than dropping the rating's only instructor information.

### Tests

636 backend, 285 frontend, all green; `pyright` 0 errors; both lints and formats clean; OpenAPI schema verified in sync.

- Backend: ranking tiers + Cyrillic/Latin + tie-break, bachelor-exclusion filter, `get_many_by_ids`, M2M create/PATCH/PUT incl. unknown-id → 400 and clear-vs-omit PATCH semantics, legacy text path, email-absence assertions across list / rating / stats payloads.
- Frontend, flag-aware on every layer:

  | Layer | Flag off | Flag on | Flags pending |
  |---|---|---|---|
  | `RatingCardBody` | legacy text, M2M hidden | M2M preferred; legacy fallback when unlinked | line held |
  | `RatingForm` | free-text input | multi-select + read-only legacy line | neither variant |
  | `RatingModal` write path | legacy only, no `instructor_ids` | `instructor_ids` + cleared text; empty selection preserves text | submit blocked |

- **E2E**: `instructor-multiselect.spec.ts` (flag on) covers a rating's full lifecycle — select one, select two, deselect one, deselect all, persist, re-open the edit modal and assert the saved instructors pre-populate, then clear all and assert the cleared state persists. `instructor-legacy.spec.ts` (flag off) asserts the free-text path is untouched.
- **Known gap**: no E2E yet for the legacy-replacement flow end to end (open an old rating under the flag → pick instructors → save → reopen → text gone). Unit-covered in `RatingModal.test.tsx`.

### Deploy notes
- **Flush the student-ratings Redis cache after migrating.** `StudentService.get_ratings`/`get_ratings_detail` are `@rcached` (1h) and the payload shape changed; the namespace only invalidates on rating writes, not on a shape change.
- Rollout order: **merge with the flag off → backfill legacy `Rating.instructor` text → verify the directory → enable the flag → drop the legacy column (stage-4 MR).**
- **The backfill should blank `instructor` on every row it successfully maps**, mirroring what the UI does on save. Otherwise backfilled ratings keep showing `Раніше вказано текстом: …` in their edit modal indefinitely; leaving the text only on rows the backfill could not resolve is exactly where it stays useful.
- **Do not enable the flag on the strength of CI alone.** The M365 export cannot distinguish staff from students, so the directory quality — not the backfill — is the real gate. The bachelor-exclusion filter is tested but has never been run against the real directory; check who actually disappears before turning it on.

### Known issues not from this branch
- `audit / Frontend Security Audit` is red: `nanoid <3.3.18` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)), transitive via `postcss ← vite` from `@tailwindcss/vite` and `@tanstack/router-plugin`. Red on `main` since 2026-08-14 and arrived with #641; fix is a `pnpm.overrides` pin in its own chore MR.

Closes #563.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added searchable, paginated instructor browsing with ranking by course, offering, speciality, and ratings.
  * Added instructor filtering to course filters, including infinite scrolling and multi-select search.
  * Ratings can now associate multiple verified instructors and display their names.
  * Added feature-flagged multi-instructor selection while preserving legacy text entry.
* **Bug Fixes**
  * Instructor email addresses are no longer exposed in responses.
  * Added validation for unknown instructor selections.
* **Tests**
  * Added unit, integration, and end-to-end coverage for instructor search, filtering, selection, editing, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->