### PR TITLE
fix(#609): disable nginx->gunicorn upstream keepalive to stop CLOSE_WAIT leak

### DIFF
--- a/infra/nginx/rateukma.conf.template
+++ b/infra/nginx/rateukma.conf.template
@@ -1,9 +1,8 @@
-# Upstream keepalive intentionally disabled: nginx -> gunicorn runs over the
-# local plaintext loopback, so connection pooling saves no measurable handshake
-# cost, while gthread leaks nginx-closed keepalive sockets into CLOSE_WAIT
-# (see nginx trac #2145, gunicorn #1976/#2297). Each request opens and closes
-# cleanly instead. Re-enable only if the backend moves off-host (and switch to
-# an async worker first).
+# nginx <-> gunicorn connection reuse is OFF on purpose. This hop is local and
+# plaintext, so reusing connections saves almost nothing; meanwhile gunicorn's
+# gthread worker leaks reused-then-idle sockets into CLOSE_WAIT until workers
+# stall (see issue #609, nginx trac #2145). "Connection: close" below makes
+# each request close cleanly, so nothing is left open to leak.
 upstream backend {
     server 127.0.0.1:8000;
 }
@@ -13,6 +12,11 @@ server {
 
     access_log /var/log/nginx/rateukma_access.log;
     error_log /var/log/nginx/rateukma_error.log;
+
+    # Browser <-> nginx connection reuse stays ON (this is the hop where it pays
+    # off: real network + TLS). 75s is the nginx default, set here explicitly so
+    # it's clear we only disabled reuse on the upstream hop above, not this one.
+    keepalive_timeout 75s;
 
     # Gzip compression
     gzip on;

--- a/infra/nginx/rateukma.conf.template
+++ b/infra/nginx/rateukma.conf.template
@@ -1,6 +1,11 @@
+# Upstream keepalive intentionally disabled: nginx -> gunicorn runs over the
+# local plaintext loopback, so connection pooling saves no measurable handshake
+# cost, while gthread leaks nginx-closed keepalive sockets into CLOSE_WAIT
+# (see nginx trac #2145, gunicorn #1976/#2297). Each request opens and closes
+# cleanly instead. Re-enable only if the backend moves off-host (and switch to
+# an async worker first).
 upstream backend {
     server 127.0.0.1:8000;
-    keepalive 16;
 }
 
 server {
@@ -20,7 +25,7 @@ server {
     location /api/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
-        proxy_set_header Connection "";
+        proxy_set_header Connection "close";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -30,7 +35,7 @@ server {
     location /admin/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
-        proxy_set_header Connection "";
+        proxy_set_header Connection "close";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -50,7 +55,7 @@ server {
     location /accounts/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
-        proxy_set_header Connection "";
+        proxy_set_header Connection "close";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -65,7 +70,7 @@ server {
     location /courses/ {
         proxy_pass http://backend;
         proxy_http_version 1.1;
-        proxy_set_header Connection "";
+        proxy_set_header Connection "close";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/backend/django-entrypoint.sh
+++ b/src/backend/django-entrypoint.sh
@@ -61,7 +61,9 @@ GUNICORN_ARGS=(
     --access-logfile -
     --max-requests "$MAX_REQUESTS"
     --max-requests-jitter "$((MAX_REQUESTS / 10))"
-    --keep-alive 65
+    # short keep-alive: nginx closes each upstream connection (Connection: close),
+    # so this only bounds direct/idle clients; 5s is the recommended 5-15s range
+    --keep-alive 5
 )
 
 # environment-specific settings


### PR DESCRIPTION
Closes #609.

## What

Stop reusing the **nginx → gunicorn** connection (it leaked sockets and saved us nothing).

- `infra/nginx/rateukma.conf.template`: drop `keepalive 16;` from `upstream`, set `Connection "close"` on proxied locations, and set `keepalive_timeout 75s` explicitly so it's clear the browser↔nginx reuse stays ON.
- `src/backend/django-entrypoint.sh`: `--keep-alive 65 → 5`.

## Why (short version)

A request crosses two connections: **browser↔nginx** (over the internet + HTTPS — reuse is worth it) and **nginx↔gunicorn** (same machine, plaintext — reuse saves ~nothing). We had reuse on for the second one, and gunicorn's `gthread` worker has a bug where reused-then-idle connections never get closed — they pile up as `CLOSE_WAIT` until workers stall. Found **905 leaked sockets**, ~500 each on 2 of 5 workers → the random hangs.

Turning off reuse on that hop kills the leak (nginx [trac #2145](https://trac.nginx.org/nginx/ticket/2145): leak is gone with reuse off) and costs nothing because the hop is local/plaintext. Browser-side reuse is untouched. Full diagnosis + commands in #609.

## Risk

Low. `scripts/ci/deploy.sh` renders the template, runs `nginx -t`, and reloads with automatic rollback if the config is invalid.

## Verify

Before fix (live): 905 sockets in `CLOSE_WAIT`, direct curl hangs to timeout.
After restart (mitigation already applied): 0 `CLOSE_WAIT`, curl 6–185ms.

After this deploys, confirm the count stays near zero over time:
```bash
sudo docker exec rate_ukma_django_backend_release sh -c \
  'awk "NR>1{print \$4}" /proc/net/tcp /proc/net/tcp6 | sort | uniq -c | sort -rn'
# look at the "08" (CLOSE_WAIT) row — should stay small
```

## Follow-ups (tracked in #609)

- Evaluate `uvicorn` ASGI worker (~36% faster, no leak).
- Raise container fd limit (currently 1024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
