### PR TITLE
fix(#609): bind published container ports to loopback

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "127.0.0.1:${POSTGRES_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     profiles:
@@ -26,7 +26,7 @@ services:
     container_name: "${COMPOSE_PROJECT_NAME}_redis"
     restart: unless-stopped
     ports:
-      - "${REDIS_PORT:-6379}:6379"
+      - "127.0.0.1:${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/data
     networks:
@@ -62,7 +62,7 @@ services:
       - ${STATIC_ROOT}:/static
       - ${MEDIA_ROOT}:/media
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     networks:
       - backend
       - frontend
@@ -95,7 +95,7 @@ services:
       - ${STATIC_ROOT}:/static
       - ${MEDIA_ROOT}:/media
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     profiles:
       - prod
 
@@ -110,7 +110,7 @@ services:
       - ./webapp:/app
       - /app/node_modules
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     networks:
       - frontend
     env_file:


### PR DESCRIPTION
## Problem

Postgres (`5432`), Redis (`6379`) and the backend (`8000`) were published with docker's short port syntax (`"HOST:CONTAINER"`), which binds `0.0.0.0` — all interfaces, including the public one. With `ufw` inactive (and docker's iptables DNAT bypassing the host firewall anyway), all three were reachable from the open internet.

Verified on staging from an external machine: `:8000`, `:5432`, `:6379` all accept connections (control port `:9999` → refused). Redis had **no password** (`requirepass` empty, `PING`→`PONG`); Postgres required scram auth.

## Impact (this is the recurring #609 stall)

The `#610` nginx fix only addressed the nginx→gunicorn hop (~14% of the leak). The dominant driver was invisible to it: **86% of leaked CLOSE_WAIT sockets came from public-internet scanners hitting `:8000` directly, bypassing nginx**. The `gthread` workers never reaped those abandoned half-closed connections → CLOSE_WAIT accumulates (478/554 from public IPs on staging) → workers wedge → real users get 30s stalls (`connection-error?reason=server`).

## Fix

Bind every published port to `127.0.0.1`. Real paths are unaffected:
- backend reaches Postgres/Redis over the `backend` docker network by service name;
- nginx proxies to `127.0.0.1:8000` (confirmed in the live/staging nginx upstream);
- dev tooling still reaches everything via localhost.

Public reachability is removed.

## Follow-ups (not in this PR)
- Switch gunicorn `--worker-class gthread` → `sync` to kill the remaining gthread reap bug (the 14%).
- Set a Redis password as defense in depth.

## Test plan
Deployed to staging from this branch; verify `:5432/:6379/:8000` no longer reachable externally and the site serves normally through nginx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service port bindings to be accessible locally only, enhancing security by restricting remote network access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->