### PR TITLE
feat(#583): sort homepage courses by review freshness

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -91,6 +91,15 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
+        name: last_review_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for most recent review timestamp (asc/desc); courses
+          without reviews appear last in both directions
+      - in: query
         name: name
         schema:
           type: string
@@ -110,6 +119,14 @@ paths:
         schema:
           type: integer
         description: Minimum ratings count (0+)
+      - in: query
+        name: ratings_count_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for review count (asc/desc)
       - in: query
         name: semester_terms
         schema:
@@ -947,6 +964,15 @@ paths:
           format: uuid
         description: Filter by instructor UUID
       - in: query
+        name: last_review_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for most recent review timestamp (asc/desc); courses
+          without reviews appear last in both directions
+      - in: query
         name: name
         schema:
           type: string
@@ -966,6 +992,14 @@ paths:
         schema:
           type: integer
         description: Minimum ratings count (0+)
+      - in: query
+        name: ratings_count_order
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+        description: Sort order for review count (asc/desc)
       - in: query
         name: semester_terms
         schema:

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -120,14 +120,6 @@ paths:
           type: integer
         description: Minimum ratings count (0+)
       - in: query
-        name: ratings_count_order
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        description: Sort order for review count (asc/desc)
-      - in: query
         name: semester_terms
         schema:
           type: array
@@ -992,14 +984,6 @@ paths:
         schema:
           type: integer
         description: Minimum ratings count (0+)
-      - in: query
-        name: ratings_count_order
-        schema:
-          type: string
-          enum:
-          - asc
-          - desc
-        description: Sort order for review count (asc/desc)
       - in: query
         name: semester_terms
         schema:

--- a/src/backend/rating_app/application_schemas/course.py
+++ b/src/backend/rating_app/application_schemas/course.py
@@ -99,6 +99,14 @@ class CourseFilterCriteria(BaseModel):
     avg_usefulness_order: AvgOrder | None = Field(
         default=None, description="Sort order for usefulness (asc/desc)"
     )
+    ratings_count_order: AvgOrder | None = Field(
+        default=None, description="Sort order for review count (asc/desc)"
+    )
+    last_review_order: AvgOrder | None = Field(
+        default=None,
+        description="Sort order for most recent review timestamp (asc/desc); "
+        "courses without reviews appear last in both directions",
+    )
     page: int | None = Field(default=1, ge=1, description="Page number")
     page_size: int | None = Field(default=None, ge=1, description="Items per page")
 
@@ -131,7 +139,13 @@ class CourseFilterCriteria(BaseModel):
             return [value.upper()]
         return value
 
-    @field_validator("avg_difficulty_order", "avg_usefulness_order", mode="before")
+    @field_validator(
+        "avg_difficulty_order",
+        "avg_usefulness_order",
+        "ratings_count_order",
+        "last_review_order",
+        mode="before",
+    )
     @classmethod
     def normalize_sort_order(cls, value):
         if isinstance(value, str):

--- a/src/backend/rating_app/application_schemas/course.py
+++ b/src/backend/rating_app/application_schemas/course.py
@@ -99,9 +99,6 @@ class CourseFilterCriteria(BaseModel):
     avg_usefulness_order: AvgOrder | None = Field(
         default=None, description="Sort order for usefulness (asc/desc)"
     )
-    ratings_count_order: AvgOrder | None = Field(
-        default=None, description="Sort order for review count (asc/desc)"
-    )
     last_review_order: AvgOrder | None = Field(
         default=None,
         description="Sort order for most recent review timestamp (asc/desc); "
@@ -142,7 +139,6 @@ class CourseFilterCriteria(BaseModel):
     @field_validator(
         "avg_difficulty_order",
         "avg_usefulness_order",
-        "ratings_count_order",
         "last_review_order",
         mode="before",
     )

--- a/src/backend/rating_app/repositories/course_repository.py
+++ b/src/backend/rating_app/repositories/course_repository.py
@@ -7,6 +7,7 @@ from django.db.models import (
     Exists,
     F,
     IntegerField,
+    Max,
     OuterRef,
     Prefetch,
     Q,
@@ -418,6 +419,9 @@ class CourseRepository(
     def _apply_sorting(
         self, courses: QuerySet[Course], filters: CourseFilterCriteriaInternal
     ) -> QuerySet[Course]:
+        if filters.last_review_order is not None:
+            courses = courses.annotate(last_review=Max("offerings__ratings__created_at"))
+
         order_by_fields = self._build_order_by_fields(filters)
 
         courses = courses.annotate(
@@ -446,6 +450,18 @@ class CourseRepository(
                 order_by_fields.append(field.asc())
             else:
                 order_by_fields.append(field.desc())
+        if filters.ratings_count_order:
+            field = F("ratings_count")
+            if filters.ratings_count_order == "asc":
+                order_by_fields.append(field.asc())
+            else:
+                order_by_fields.append(field.desc())
+        if filters.last_review_order:
+            field = F("last_review")
+            if filters.last_review_order == "asc":
+                order_by_fields.append(field.asc(nulls_last=True))
+            else:
+                order_by_fields.append(field.desc(nulls_last=True))
         return order_by_fields
 
     def _map_to_domain_models(self, models: list[Course]) -> list[CourseDTO]:

--- a/src/backend/rating_app/repositories/course_repository.py
+++ b/src/backend/rating_app/repositories/course_repository.py
@@ -450,12 +450,6 @@ class CourseRepository(
                 order_by_fields.append(field.asc())
             else:
                 order_by_fields.append(field.desc())
-        if filters.ratings_count_order:
-            field = F("ratings_count")
-            if filters.ratings_count_order == "asc":
-                order_by_fields.append(field.asc())
-            else:
-                order_by_fields.append(field.desc())
         if filters.last_review_order:
             field = F("last_review")
             if filters.last_review_order == "asc":

--- a/src/backend/rating_app/views/test_course.py
+++ b/src/backend/rating_app/views/test_course.py
@@ -667,50 +667,6 @@ def test_sorting_preserves_order_with_various_ratings(token_client, course_facto
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_sorting_by_ratings_count(token_client, course_factory):
-    course_many = course_factory.create()
-    course_many.ratings_count = 12
-    course_many.save()
-
-    course_few = course_factory.create()
-    course_few.ratings_count = 2
-    course_few.save()
-
-    course_mid = course_factory.create()
-    course_mid.ratings_count = 5
-    course_mid.save()
-
-    course_none = course_factory.create()
-    course_none.ratings_count = 0
-    course_none.save()
-
-    response_desc = token_client.get(
-        "/api/v1/courses/?ratings_count_order=desc&page_size=10"
-    )
-    assert response_desc.status_code == 200
-    items_desc = response_desc.json()["items"]
-    assert [item["id"] for item in items_desc[:4]] == [
-        str(course_many.id),
-        str(course_mid.id),
-        str(course_few.id),
-        str(course_none.id),
-    ]
-
-    response_asc = token_client.get(
-        "/api/v1/courses/?ratings_count_order=asc&page_size=10"
-    )
-    assert response_asc.status_code == 200
-    items_asc = response_asc.json()["items"]
-    assert [item["id"] for item in items_asc[:4]] == [
-        str(course_few.id),
-        str(course_mid.id),
-        str(course_many.id),
-        str(course_none.id),
-    ]
-
-
-@pytest.mark.django_db
-@pytest.mark.integration
 def test_sorting_by_last_review(
     token_client, course_factory, course_offering_factory, rating_factory
 ):

--- a/src/backend/rating_app/views/test_course.py
+++ b/src/backend/rating_app/views/test_course.py
@@ -1,6 +1,9 @@
+import datetime
 import uuid
 
 import pytest
+
+from rating_app.models import Rating
 
 
 @pytest.mark.django_db
@@ -660,3 +663,173 @@ def test_sorting_preserves_order_with_various_ratings(token_client, course_facto
         str(course_no_ratings.id),
     ]
     assert items_use_desc[3]["ratings_count"] == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_sorting_by_ratings_count(token_client, course_factory):
+    course_many = course_factory.create()
+    course_many.ratings_count = 12
+    course_many.save()
+
+    course_few = course_factory.create()
+    course_few.ratings_count = 2
+    course_few.save()
+
+    course_mid = course_factory.create()
+    course_mid.ratings_count = 5
+    course_mid.save()
+
+    course_none = course_factory.create()
+    course_none.ratings_count = 0
+    course_none.save()
+
+    response_desc = token_client.get(
+        "/api/v1/courses/?ratings_count_order=desc&page_size=10"
+    )
+    assert response_desc.status_code == 200
+    items_desc = response_desc.json()["items"]
+    assert [item["id"] for item in items_desc[:4]] == [
+        str(course_many.id),
+        str(course_mid.id),
+        str(course_few.id),
+        str(course_none.id),
+    ]
+
+    response_asc = token_client.get(
+        "/api/v1/courses/?ratings_count_order=asc&page_size=10"
+    )
+    assert response_asc.status_code == 200
+    items_asc = response_asc.json()["items"]
+    assert [item["id"] for item in items_asc[:4]] == [
+        str(course_few.id),
+        str(course_mid.id),
+        str(course_many.id),
+        str(course_none.id),
+    ]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_sorting_by_last_review(
+    token_client, course_factory, course_offering_factory, rating_factory
+):
+    course_newest = course_factory.create()
+    course_oldest = course_factory.create()
+    course_middle = course_factory.create()
+    course_no_reviews = course_factory.create()
+
+    offering_newest = course_offering_factory.create(course=course_newest)
+    offering_oldest = course_offering_factory.create(course=course_oldest)
+    offering_middle = course_offering_factory.create(course=course_middle)
+
+    rating_newest = rating_factory.create(course_offering=offering_newest)
+    rating_oldest = rating_factory.create(course_offering=offering_oldest)
+    rating_middle = rating_factory.create(course_offering=offering_middle)
+
+    Rating.objects.filter(id=rating_newest.id).update(
+        created_at=datetime.datetime(2026, 5, 20, tzinfo=datetime.timezone.utc)
+    )
+    Rating.objects.filter(id=rating_oldest.id).update(
+        created_at=datetime.datetime(2025, 1, 10, tzinfo=datetime.timezone.utc)
+    )
+    Rating.objects.filter(id=rating_middle.id).update(
+        created_at=datetime.datetime(2025, 8, 15, tzinfo=datetime.timezone.utc)
+    )
+
+    for course in (course_newest, course_oldest, course_middle):
+        course.ratings_count = 1
+        course.save()
+
+    response_desc = token_client.get(
+        "/api/v1/courses/?last_review_order=desc&page_size=10"
+    )
+    assert response_desc.status_code == 200
+    items_desc = response_desc.json()["items"]
+    assert [item["id"] for item in items_desc[:4]] == [
+        str(course_newest.id),
+        str(course_middle.id),
+        str(course_oldest.id),
+        str(course_no_reviews.id),
+    ]
+
+    response_asc = token_client.get(
+        "/api/v1/courses/?last_review_order=asc&page_size=10"
+    )
+    assert response_asc.status_code == 200
+    items_asc = response_asc.json()["items"]
+    assert [item["id"] for item in items_asc[:4]] == [
+        str(course_oldest.id),
+        str(course_middle.id),
+        str(course_newest.id),
+        str(course_no_reviews.id),
+    ]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_sorting_by_last_review_aggregates_across_offerings(
+    token_client, course_factory, course_offering_factory, rating_factory
+):
+    course_multi = course_factory.create()
+    offering_old = course_offering_factory.create(course=course_multi)
+    offering_recent = course_offering_factory.create(course=course_multi)
+    rating_on_old_offering = rating_factory.create(course_offering=offering_old)
+    rating_on_recent_offering = rating_factory.create(course_offering=offering_recent)
+    Rating.objects.filter(id=rating_on_old_offering.id).update(
+        created_at=datetime.datetime(2025, 1, 5, tzinfo=datetime.timezone.utc)
+    )
+    Rating.objects.filter(id=rating_on_recent_offering.id).update(
+        created_at=datetime.datetime(2026, 5, 20, tzinfo=datetime.timezone.utc)
+    )
+
+    course_single = course_factory.create()
+    offering_single = course_offering_factory.create(course=course_single)
+    rating_single = rating_factory.create(course_offering=offering_single)
+    Rating.objects.filter(id=rating_single.id).update(
+        created_at=datetime.datetime(2026, 3, 1, tzinfo=datetime.timezone.utc)
+    )
+
+    course_multi.ratings_count = 2
+    course_multi.save()
+    course_single.ratings_count = 1
+    course_single.save()
+
+    response = token_client.get("/api/v1/courses/?last_review_order=desc&page_size=10")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["id"] for item in items[:2]] == [
+        str(course_multi.id),
+        str(course_single.id),
+    ]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_sorting_by_last_review_breaks_ties_by_title(
+    token_client, course_factory, course_offering_factory, rating_factory
+):
+    course_b = course_factory.create(title="Курс Б")
+    course_a = course_factory.create(title="Курс А")
+
+    offering_a = course_offering_factory.create(course=course_a)
+    offering_b = course_offering_factory.create(course=course_b)
+    rating_a = rating_factory.create(course_offering=offering_a)
+    rating_b = rating_factory.create(course_offering=offering_b)
+
+    same_moment = datetime.datetime(2026, 5, 1, tzinfo=datetime.timezone.utc)
+    Rating.objects.filter(id=rating_a.id).update(created_at=same_moment)
+    Rating.objects.filter(id=rating_b.id).update(created_at=same_moment)
+
+    course_a.ratings_count = 1
+    course_a.save()
+    course_b.ratings_count = 1
+    course_b.save()
+
+    response = token_client.get("/api/v1/courses/?last_review_order=desc&page_size=10")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert [item["id"] for item in items[:2]] == [
+        str(course_a.id),
+        str(course_b.id),
+    ]

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
@@ -29,7 +29,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
-	freshOrder: null,
+	reviewSort: null,
 };
 
 function assertElement(

--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.test.tsx
@@ -29,6 +29,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
+	freshOrder: null,
 };
 
 function assertElement(

--- a/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
+++ b/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
@@ -1,11 +1,10 @@
-import { ChevronDown } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
-	DropdownMenuRadioGroup,
-	DropdownMenuRadioItem,
+	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from "@/components/ui/DropdownMenu";
 
@@ -42,18 +41,21 @@ export function CoursesReviewsSortMenu({
 				</Button>
 			</DropdownMenuTrigger>
 			<DropdownMenuContent align="center">
-				<DropdownMenuRadioGroup
-					value={value ?? ""}
-					onValueChange={(next) =>
-						onValueChange(next as CoursesReviewsSortOption)
-					}
-				>
-					{SORT_OPTIONS.map((option) => (
-						<DropdownMenuRadioItem key={option.value} value={option.value}>
+				{SORT_OPTIONS.map((option) => {
+					const isSelected = option.value === value;
+					return (
+						<DropdownMenuItem
+							key={option.value}
+							onSelect={() => onValueChange(option.value)}
+							className="pr-8"
+						>
 							{option.label}
-						</DropdownMenuRadioItem>
-					))}
-				</DropdownMenuRadioGroup>
+							{isSelected && (
+								<Check className="absolute right-2 size-4" />
+							)}
+						</DropdownMenuItem>
+					);
+				})}
 			</DropdownMenuContent>
 		</DropdownMenu>
 	);

--- a/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
+++ b/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
@@ -34,13 +34,17 @@ export function CoursesReviewsSortMenu({
 					type="button"
 					variant="ghost"
 					size="sm"
-					className="h-7 w-7 p-0"
+					className="-ml-2 inline-flex h-8 items-center gap-2 px-2 text-sm font-medium"
 					aria-label="Сортування за відгуками"
 				>
+					<span>Відгуки</span>
 					<ChevronDown className="h-4 w-4" />
 				</Button>
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="center">
+			<DropdownMenuContent
+				align="center"
+				onCloseAutoFocus={(event) => event.preventDefault()}
+			>
 				{SORT_OPTIONS.map((option) => {
 					const isSelected = option.value === value;
 					return (

--- a/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
+++ b/src/webapp/src/features/courses/components/CoursesReviewsSortMenu.tsx
@@ -1,0 +1,60 @@
+import { ChevronDown } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
+
+export type CoursesReviewsSortOption = "by-count" | "newest";
+
+interface CoursesReviewsSortMenuProps {
+	value: CoursesReviewsSortOption | null;
+	onValueChange: (value: CoursesReviewsSortOption) => void;
+}
+
+const SORT_OPTIONS: ReadonlyArray<{
+	value: CoursesReviewsSortOption;
+	label: string;
+}> = [
+	{ value: "by-count", label: "За кількістю" },
+	{ value: "newest", label: "Найновіші" },
+];
+
+export function CoursesReviewsSortMenu({
+	value,
+	onValueChange,
+}: Readonly<CoursesReviewsSortMenuProps>) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					className="h-7 w-7 p-0"
+					aria-label="Сортування за відгуками"
+				>
+					<ChevronDown className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="center">
+				<DropdownMenuRadioGroup
+					value={value ?? ""}
+					onValueChange={(next) =>
+						onValueChange(next as CoursesReviewsSortOption)
+					}
+				>
+					{SORT_OPTIONS.map((option) => (
+						<DropdownMenuRadioItem key={option.value} value={option.value}>
+							{option.label}
+						</DropdownMenuRadioItem>
+					))}
+				</DropdownMenuRadioGroup>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/src/webapp/src/features/courses/components/CoursesTable.test.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.test.tsx
@@ -90,6 +90,7 @@ const defaultParams: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
+	freshOrder: null,
 };
 
 const defaultSetParams = vi.fn();
@@ -360,6 +361,7 @@ describe("Reset Filters", () => {
 			size: 10,
 			diffOrder: null,
 			useOrder: null,
+			freshOrder: null,
 		});
 	});
 });
@@ -682,6 +684,7 @@ describe("Sorting", () => {
 		expect(setParams).toHaveBeenCalledWith({
 			diffOrder: "asc",
 			useOrder: null,
+			freshOrder: null,
 			page: 1,
 		});
 	});
@@ -716,6 +719,36 @@ describe("Sorting", () => {
 		expect(setParams).toHaveBeenCalledWith({
 			diffOrder: null,
 			useOrder: "desc",
+			freshOrder: null,
+			page: 1,
+		});
+	});
+
+	it("should set freshOrder=desc and clear column sorts when 'Найновіші' is picked", async () => {
+		const user = userEvent.setup();
+		const setParams = vi.fn();
+		const courses = Array.from({ length: 3 }, () => createMockCourse());
+
+		renderWithProviders(
+			<CoursesTable
+				{...defaultProps}
+				data={courses}
+				params={{ ...defaultParams, diffOrder: "asc" }}
+				setParams={setParams}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: "Сортування за відгуками" }),
+		);
+		await user.click(
+			screen.getByRole("menuitemradio", { name: "Найновіші" }),
+		);
+
+		expect(setParams).toHaveBeenCalledWith({
+			freshOrder: "desc",
+			diffOrder: null,
+			useOrder: null,
 			page: 1,
 		});
 	});

--- a/src/webapp/src/features/courses/components/CoursesTable.test.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.test.tsx
@@ -742,7 +742,7 @@ describe("Sorting", () => {
 			screen.getByRole("button", { name: "Сортування за відгуками" }),
 		);
 		await user.click(
-			screen.getByRole("menuitemradio", { name: "Найновіші" }),
+			screen.getByRole("menuitem", { name: "Найновіші" }),
 		);
 
 		expect(setParams).toHaveBeenCalledWith({

--- a/src/webapp/src/features/courses/components/CoursesTable.test.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.test.tsx
@@ -90,7 +90,7 @@ const defaultParams: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
-	freshOrder: null,
+	reviewSort: null,
 };
 
 const defaultSetParams = vi.fn();
@@ -361,7 +361,7 @@ describe("Reset Filters", () => {
 			size: 10,
 			diffOrder: null,
 			useOrder: null,
-			freshOrder: null,
+			reviewSort: null,
 		});
 	});
 });
@@ -684,7 +684,7 @@ describe("Sorting", () => {
 		expect(setParams).toHaveBeenCalledWith({
 			diffOrder: "asc",
 			useOrder: null,
-			freshOrder: null,
+			reviewSort: null,
 			page: 1,
 		});
 	});
@@ -719,12 +719,12 @@ describe("Sorting", () => {
 		expect(setParams).toHaveBeenCalledWith({
 			diffOrder: null,
 			useOrder: "desc",
-			freshOrder: null,
+			reviewSort: null,
 			page: 1,
 		});
 	});
 
-	it("should set freshOrder=desc and clear column sorts when 'Найновіші' is picked", async () => {
+	it("should clear all sort params when 'Найновіші' is picked (default state)", async () => {
 		const user = userEvent.setup();
 		const setParams = vi.fn();
 		const courses = Array.from({ length: 3 }, () => createMockCourse());
@@ -746,7 +746,36 @@ describe("Sorting", () => {
 		);
 
 		expect(setParams).toHaveBeenCalledWith({
-			freshOrder: "desc",
+			reviewSort: null,
+			diffOrder: null,
+			useOrder: null,
+			page: 1,
+		});
+	});
+
+	it("should set reviewSort='by-count' when 'За кількістю' is picked", async () => {
+		const user = userEvent.setup();
+		const setParams = vi.fn();
+		const courses = Array.from({ length: 3 }, () => createMockCourse());
+
+		renderWithProviders(
+			<CoursesTable
+				{...defaultProps}
+				data={courses}
+				params={{ ...defaultParams, useOrder: "desc" }}
+				setParams={setParams}
+			/>,
+		);
+
+		await user.click(
+			screen.getByRole("button", { name: "Сортування за відгуками" }),
+		);
+		await user.click(
+			screen.getByRole("menuitem", { name: "За кількістю" }),
+		);
+
+		expect(setParams).toHaveBeenCalledWith({
+			reviewSort: "by-count",
 			diffOrder: null,
 			useOrder: null,
 			page: 1,

--- a/src/webapp/src/features/courses/components/CoursesTable.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.tsx
@@ -403,7 +403,7 @@ export function CoursesTable({
 			setParams({
 				diffOrder,
 				useOrder,
-				freshOrder: null,
+				reviewSort: null,
 				page: 1,
 			});
 		},
@@ -413,14 +413,14 @@ export function CoursesTable({
 	const reviewsSortValue: CoursesReviewsSortOption | null =
 		params.diffOrder || params.useOrder
 			? null
-			: params.freshOrder === "desc"
-				? "newest"
-				: "by-count";
+			: params.reviewSort === "by-count"
+				? "by-count"
+				: "newest";
 
 	const handleReviewsSortChange = useCallback(
 		(value: CoursesReviewsSortOption) => {
 			setParams({
-				freshOrder: value === "newest" ? "desc" : null,
+				reviewSort: value === "by-count" ? "by-count" : null,
 				diffOrder: null,
 				useOrder: null,
 				page: 1,

--- a/src/webapp/src/features/courses/components/CoursesTable.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.tsx
@@ -410,12 +410,11 @@ export function CoursesTable({
 		[sorting, setParams],
 	);
 
-	const reviewsSortValue: CoursesReviewsSortOption | null =
-		params.diffOrder || params.useOrder
-			? null
-			: params.reviewSort === "by-count"
-				? "by-count"
-				: "newest";
+	const reviewsSortValue = useMemo<CoursesReviewsSortOption | null>(() => {
+		if (params.diffOrder || params.useOrder) return null;
+		if (params.reviewSort === "by-count") return "by-count";
+		return "newest";
+	}, [params.diffOrder, params.useOrder, params.reviewSort]);
 
 	const handleReviewsSortChange = useCallback(
 		(value: CoursesReviewsSortOption) => {

--- a/src/webapp/src/features/courses/components/CoursesTable.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.tsx
@@ -200,10 +200,7 @@ function buildCoursesTableColumns({
 			id: "ratings_count",
 			accessorKey: "ratings_count",
 			header: () => (
-				<div className="hidden sm:inline-flex h-8 items-center gap-1">
-					<span className="px-2 text-sm font-medium text-foreground">
-						Відгуки
-					</span>
+				<div className="hidden sm:block">
 					<CoursesReviewsSortMenu
 						value={reviewsSortValue}
 						onValueChange={onReviewsSortChange}

--- a/src/webapp/src/features/courses/components/CoursesTable.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.tsx
@@ -54,6 +54,10 @@ import { CourseColumnHeader } from "./CourseColumnHeader";
 import { CourseFiltersDrawer, CourseFiltersPanel } from "./CourseFiltersPanel";
 import { CourseScoreCell } from "./CourseScoreCell";
 import { CourseSpecialityBadges } from "./CourseSpecialityBadges";
+import {
+	type CoursesReviewsSortOption,
+	CoursesReviewsSortMenu,
+} from "./CoursesReviewsSortMenu";
 import { CoursesScatterPlot } from "./CoursesScatterPlot";
 import {
 	type CourseFiltersParamsSetter,
@@ -135,160 +139,174 @@ interface CoursesTableProps {
 const SCATTER_COLLAPSE_STORAGE_KEY = "courses:scatter-open";
 const FULLSCREEN_TRANSITION_DELAY_MS = 200;
 
-const columns: ColumnDef<CourseList>[] = [
-	{
-		id: "title",
-		accessorKey: "title",
-		header: ({ column }) => (
-			<CourseColumnHeader column={column} title="Назва курсу" />
-		),
-		cell: ({ row }) => {
-			const course = row.original;
-			const courseId = course.id;
-			return (
-				<span className="inline-flex flex-wrap items-center gap-1.5 whitespace-normal break-words">
-					{courseId ? (
-						<Link
-							to="/courses/$courseId"
-							params={{ courseId }}
-							className="font-semibold text-sm transition-colors hover:text-primary hover:underline md:text-base"
-							data-testid={testIds.courses.tableTitleLink}
-						>
-							{course.title}
-						</Link>
-					) : (
-						<span className="font-semibold text-sm md:text-base">
-							{course.title}
-						</span>
-					)}
-					{course.education_level === EducationLevelEnum.MASTER && (
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<span className="inline-flex shrink-0 cursor-default items-center rounded-sm border px-1 py-px text-[10px] font-medium leading-tight text-muted-foreground">
-									М
-								</span>
-							</TooltipTrigger>
-							<TooltipContent side="top">Магістр</TooltipContent>
-						</Tooltip>
-					)}
-					<CourseSpecialityBadges specialities={course.specialities} />
-				</span>
-			);
-		},
-		enableSorting: false,
-		size: 300,
-		meta: {
-			label: "Назва курсу",
-			placeholder: "Пошук курсів...",
-			variant: "text",
-			icon: BookOpen,
-			align: "left",
-		},
-	},
-	{
-		id: "ratings_count",
-		accessorKey: "ratings_count",
-		header: ({ column }) => (
-			<div className="hidden sm:block">
-				<CourseColumnHeader column={column} title="Відгуки" />
-			</div>
-		),
-		cell: ({ row }) => {
-			const count = row.getValue("ratings_count") as number;
-			return (
-				<div className="hidden sm:flex items-center justify-center">
-					<span className="text-sm font-medium text-muted-foreground md:text-base">
-						{count}
+function buildCoursesTableColumns({
+	reviewsSortValue,
+	onReviewsSortChange,
+}: {
+	reviewsSortValue: CoursesReviewsSortOption | null;
+	onReviewsSortChange: (value: CoursesReviewsSortOption) => void;
+}): ColumnDef<CourseList>[] {
+	return [
+		{
+			id: "title",
+			accessorKey: "title",
+			header: ({ column }) => (
+				<CourseColumnHeader column={column} title="Назва курсу" />
+			),
+			cell: ({ row }) => {
+				const course = row.original;
+				const courseId = course.id;
+				return (
+					<span className="inline-flex flex-wrap items-center gap-1.5 whitespace-normal break-words">
+						{courseId ? (
+							<Link
+								to="/courses/$courseId"
+								params={{ courseId }}
+								className="font-semibold text-sm transition-colors hover:text-primary hover:underline md:text-base"
+								data-testid={testIds.courses.tableTitleLink}
+							>
+								{course.title}
+							</Link>
+						) : (
+							<span className="font-semibold text-sm md:text-base">
+								{course.title}
+							</span>
+						)}
+						{course.education_level === EducationLevelEnum.MASTER && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span className="inline-flex shrink-0 cursor-default items-center rounded-sm border px-1 py-px text-[10px] font-medium leading-tight text-muted-foreground">
+										М
+									</span>
+								</TooltipTrigger>
+								<TooltipContent side="top">Магістр</TooltipContent>
+							</Tooltip>
+						)}
+						<CourseSpecialityBadges specialities={course.specialities} />
 					</span>
-				</div>
-			);
+				);
+			},
+			enableSorting: false,
+			size: 300,
+			meta: {
+				label: "Назва курсу",
+				placeholder: "Пошук курсів...",
+				variant: "text",
+				icon: BookOpen,
+				align: "left",
+			},
 		},
-		enableSorting: false,
-		size: 80,
-		meta: {
-			label: "Відгуки",
-			align: "center",
-		},
-	},
-	{
-		id: "avg_difficulty",
-		accessorKey: "avg_difficulty",
-		header: ({ column }) => (
-			<>
-				<div className="md:hidden">
-					<CourseColumnHeader
-						column={column}
-						title="Склад."
-						initialSortDirection="asc"
-						testId={testIds.courses.difficultySortButtonMobile}
+		{
+			id: "ratings_count",
+			accessorKey: "ratings_count",
+			header: () => (
+				<div className="hidden sm:inline-flex h-8 items-center gap-1">
+					<span className="px-2 text-sm font-medium text-foreground">
+						Відгуки
+					</span>
+					<CoursesReviewsSortMenu
+						value={reviewsSortValue}
+						onValueChange={onReviewsSortChange}
 					/>
 				</div>
-				<div className="hidden md:block">
-					<CourseColumnHeader
-						column={column}
-						title="Складність"
-						initialSortDirection="asc"
-						testId={testIds.courses.difficultySortButtonDesktop}
-					/>
-				</div>
-			</>
-		),
-		cell: ({ row }) => (
-			<CourseScoreCell
-				value={row.getValue("avg_difficulty") as number}
-				variant="difficulty"
-			/>
-		),
-		enableSorting: true,
-		size: 100,
-		meta: {
-			label: "Складність",
-			placeholder: "Фільтр за складністю...",
-			variant: "number",
-			range: DIFFICULTY_RANGE,
-			align: "center",
+			),
+			cell: ({ row }) => {
+				const count = row.getValue("ratings_count") as number;
+				return (
+					<div className="hidden sm:flex items-center justify-center">
+						<span className="text-sm font-medium text-muted-foreground md:text-base">
+							{count}
+						</span>
+					</div>
+				);
+			},
+			enableSorting: false,
+			size: 100,
+			meta: {
+				label: "Відгуки",
+				align: "center",
+			},
 		},
-	},
-	{
-		id: "avg_usefulness",
-		accessorKey: "avg_usefulness",
-		header: ({ column }) => (
-			<>
-				<div className="md:hidden">
-					<CourseColumnHeader
-						column={column}
-						title="Корисн."
-						initialSortDirection="desc"
-						testId={testIds.courses.usefulnessSortButtonMobile}
-					/>
-				</div>
-				<div className="hidden md:block">
-					<CourseColumnHeader
-						column={column}
-						title="Корисність"
-						initialSortDirection="desc"
-						testId={testIds.courses.usefulnessSortButtonDesktop}
-					/>
-				</div>
-			</>
-		),
-		cell: ({ row }) => (
-			<CourseScoreCell
-				value={row.getValue("avg_usefulness") as number}
-				variant="usefulness"
-			/>
-		),
-		enableSorting: true,
-		size: 100,
-		meta: {
-			label: "Корисність",
-			placeholder: "Фільтр за корисністю...",
-			variant: "number",
-			range: USEFULNESS_RANGE,
-			align: "center",
+		{
+			id: "avg_difficulty",
+			accessorKey: "avg_difficulty",
+			header: ({ column }) => (
+				<>
+					<div className="md:hidden">
+						<CourseColumnHeader
+							column={column}
+							title="Склад."
+							initialSortDirection="asc"
+							testId={testIds.courses.difficultySortButtonMobile}
+						/>
+					</div>
+					<div className="hidden md:block">
+						<CourseColumnHeader
+							column={column}
+							title="Складність"
+							initialSortDirection="asc"
+							testId={testIds.courses.difficultySortButtonDesktop}
+						/>
+					</div>
+				</>
+			),
+			cell: ({ row }) => (
+				<CourseScoreCell
+					value={row.getValue("avg_difficulty") as number}
+					variant="difficulty"
+				/>
+			),
+			enableSorting: true,
+			size: 100,
+			meta: {
+				label: "Складність",
+				placeholder: "Фільтр за складністю...",
+				variant: "number",
+				range: DIFFICULTY_RANGE,
+				align: "center",
+			},
 		},
-	},
-];
+		{
+			id: "avg_usefulness",
+			accessorKey: "avg_usefulness",
+			header: ({ column }) => (
+				<>
+					<div className="md:hidden">
+						<CourseColumnHeader
+							column={column}
+							title="Корисн."
+							initialSortDirection="desc"
+							testId={testIds.courses.usefulnessSortButtonMobile}
+						/>
+					</div>
+					<div className="hidden md:block">
+						<CourseColumnHeader
+							column={column}
+							title="Корисність"
+							initialSortDirection="desc"
+							testId={testIds.courses.usefulnessSortButtonDesktop}
+						/>
+					</div>
+				</>
+			),
+			cell: ({ row }) => (
+				<CourseScoreCell
+					value={row.getValue("avg_usefulness") as number}
+					variant="usefulness"
+				/>
+			),
+			enableSorting: true,
+			size: 100,
+			meta: {
+				label: "Корисність",
+				placeholder: "Фільтр за корисністю...",
+				variant: "number",
+				range: USEFULNESS_RANGE,
+				align: "center",
+			},
+		},
+	];
+}
 
 function DebouncedInput({
 	value: initialValue,
@@ -385,10 +403,30 @@ export function CoursesTable({
 			setParams({
 				diffOrder,
 				useOrder,
+				freshOrder: null,
 				page: 1,
 			});
 		},
 		[sorting, setParams],
+	);
+
+	const reviewsSortValue: CoursesReviewsSortOption | null =
+		params.diffOrder || params.useOrder
+			? null
+			: params.freshOrder === "desc"
+				? "newest"
+				: "by-count";
+
+	const handleReviewsSortChange = useCallback(
+		(value: CoursesReviewsSortOption) => {
+			setParams({
+				freshOrder: value === "newest" ? "desc" : null,
+				diffOrder: null,
+				useOrder: null,
+				page: 1,
+			});
+		},
+		[setParams],
 	);
 
 	const pagination = useMemo<PaginationState>(
@@ -501,6 +539,15 @@ export function CoursesTable({
 	const apiFilters = useMemo(
 		() => transformFiltersToApiParams(params),
 		[params],
+	);
+
+	const columns = useMemo(
+		() =>
+			buildCoursesTableColumns({
+				reviewsSortValue,
+				onReviewsSortChange: handleReviewsSortChange,
+			}),
+		[reviewsSortValue, handleReviewsSortChange],
 	);
 
 	const table = useReactTable({

--- a/src/webapp/src/features/courses/courseFiltersParams.ts
+++ b/src/webapp/src/features/courses/courseFiltersParams.ts
@@ -36,6 +36,7 @@ const VALID_EDUCATION_LEVELS: readonly EducationLevelEnum[] = [
 
 type SortOrder = "asc" | "desc";
 const VALID_SORT_ORDERS: readonly SortOrder[] = ["asc", "desc"];
+const VALID_FRESH_ORDERS: readonly "desc"[] = ["desc"];
 
 function createRangeParser(bounds: [number, number], step?: number) {
 	const [minBound, maxBound] = bounds;
@@ -102,8 +103,8 @@ export const courseFiltersParams = {
 	useOrder: parseAsStringEnum<SortOrder>(
 		VALID_SORT_ORDERS as unknown as SortOrder[],
 	),
-	freshOrder: parseAsStringEnum<SortOrder>(
-		VALID_SORT_ORDERS as unknown as SortOrder[],
+	freshOrder: parseAsStringEnum<"desc">(
+		VALID_FRESH_ORDERS as unknown as "desc"[],
 	),
 };
 

--- a/src/webapp/src/features/courses/courseFiltersParams.ts
+++ b/src/webapp/src/features/courses/courseFiltersParams.ts
@@ -36,7 +36,7 @@ const VALID_EDUCATION_LEVELS: readonly EducationLevelEnum[] = [
 
 type SortOrder = "asc" | "desc";
 const VALID_SORT_ORDERS: readonly SortOrder[] = ["asc", "desc"];
-const VALID_REVIEW_SORTS: readonly "by-count"[] = ["by-count"];
+const VALID_REVIEW_SORTS: "by-count"[] = ["by-count"];
 
 function createRangeParser(bounds: [number, number], step?: number) {
 	const [minBound, maxBound] = bounds;
@@ -103,9 +103,7 @@ export const courseFiltersParams = {
 	useOrder: parseAsStringEnum<SortOrder>(
 		VALID_SORT_ORDERS as unknown as SortOrder[],
 	),
-	reviewSort: parseAsStringEnum<"by-count">(
-		VALID_REVIEW_SORTS as unknown as "by-count"[],
-	),
+	reviewSort: parseAsStringEnum<"by-count">(VALID_REVIEW_SORTS),
 };
 
 export function useCourseFiltersParams() {

--- a/src/webapp/src/features/courses/courseFiltersParams.ts
+++ b/src/webapp/src/features/courses/courseFiltersParams.ts
@@ -36,7 +36,7 @@ const VALID_EDUCATION_LEVELS: readonly EducationLevelEnum[] = [
 
 type SortOrder = "asc" | "desc";
 const VALID_SORT_ORDERS: readonly SortOrder[] = ["asc", "desc"];
-const VALID_FRESH_ORDERS: readonly "desc"[] = ["desc"];
+const VALID_REVIEW_SORTS: readonly "by-count"[] = ["by-count"];
 
 function createRangeParser(bounds: [number, number], step?: number) {
 	const [minBound, maxBound] = bounds;
@@ -103,8 +103,8 @@ export const courseFiltersParams = {
 	useOrder: parseAsStringEnum<SortOrder>(
 		VALID_SORT_ORDERS as unknown as SortOrder[],
 	),
-	freshOrder: parseAsStringEnum<"desc">(
-		VALID_FRESH_ORDERS as unknown as "desc"[],
+	reviewSort: parseAsStringEnum<"by-count">(
+		VALID_REVIEW_SORTS as unknown as "by-count"[],
 	),
 };
 
@@ -141,7 +141,7 @@ export const DEFAULT_COURSE_FILTERS_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
-	freshOrder: null,
+	reviewSort: null,
 };
 
 export function courseFiltersStateToSearchParams(
@@ -181,7 +181,7 @@ export function courseFiltersStateToSearchParams(
 	if (state.size !== 10) params.size = state.size;
 	if (state.diffOrder) params.diffOrder = state.diffOrder;
 	if (state.useOrder) params.useOrder = state.useOrder;
-	if (state.freshOrder) params.freshOrder = state.freshOrder;
+	if (state.reviewSort) params.reviewSort = state.reviewSort;
 
 	return params;
 }

--- a/src/webapp/src/features/courses/courseFiltersParams.ts
+++ b/src/webapp/src/features/courses/courseFiltersParams.ts
@@ -102,6 +102,9 @@ export const courseFiltersParams = {
 	useOrder: parseAsStringEnum<SortOrder>(
 		VALID_SORT_ORDERS as unknown as SortOrder[],
 	),
+	freshOrder: parseAsStringEnum<SortOrder>(
+		VALID_SORT_ORDERS as unknown as SortOrder[],
+	),
 };
 
 export function useCourseFiltersParams() {
@@ -137,6 +140,7 @@ export const DEFAULT_COURSE_FILTERS_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
+	freshOrder: null,
 };
 
 export function courseFiltersStateToSearchParams(
@@ -176,6 +180,7 @@ export function courseFiltersStateToSearchParams(
 	if (state.size !== 10) params.size = state.size;
 	if (state.diffOrder) params.diffOrder = state.diffOrder;
 	if (state.useOrder) params.useOrder = state.useOrder;
+	if (state.freshOrder) params.freshOrder = state.freshOrder;
 
 	return params;
 }

--- a/src/webapp/src/features/courses/filterTransformations.test.ts
+++ b/src/webapp/src/features/courses/filterTransformations.test.ts
@@ -28,7 +28,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
-	freshOrder: null,
+	reviewSort: null,
 };
 
 describe("filterTransformations", () => {

--- a/src/webapp/src/features/courses/filterTransformations.test.ts
+++ b/src/webapp/src/features/courses/filterTransformations.test.ts
@@ -28,6 +28,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
+	freshOrder: null,
 };
 
 describe("filterTransformations", () => {

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
@@ -27,6 +27,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
+	freshOrder: null,
 };
 
 // Shared mock data

--- a/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
+++ b/src/webapp/src/features/courses/hooks/useCourseFiltersData.test.ts
@@ -27,7 +27,7 @@ const DEFAULT_PARAMS: CourseFiltersParamsState = {
 	size: 10,
 	diffOrder: null,
 	useOrder: null,
-	freshOrder: null,
+	reviewSort: null,
 };
 
 // Shared mock data

--- a/src/webapp/src/routes/index.tsx
+++ b/src/webapp/src/routes/index.tsx
@@ -49,6 +49,7 @@ export function CoursesRoute() {
 		education_level: params.eduLevel ?? undefined,
 		avg_difficulty_order: params.diffOrder ?? undefined,
 		avg_usefulness_order: params.useOrder ?? undefined,
+		last_review_order: params.freshOrder ?? undefined,
 	};
 
 	const { data, isFetching, isError, refetch } = useCoursesList(apiFilters, {

--- a/src/webapp/src/routes/index.tsx
+++ b/src/webapp/src/routes/index.tsx
@@ -49,7 +49,10 @@ export function CoursesRoute() {
 		education_level: params.eduLevel ?? undefined,
 		avg_difficulty_order: params.diffOrder ?? undefined,
 		avg_usefulness_order: params.useOrder ?? undefined,
-		last_review_order: params.freshOrder ?? undefined,
+		last_review_order:
+			params.diffOrder || params.useOrder || params.reviewSort === "by-count"
+				? undefined
+				: "desc",
 	};
 
 	const { data, isFetching, isError, refetch } = useCoursesList(apiFilters, {


### PR DESCRIPTION
## Summary
Adds a small dropdown next to the "Відгуки" column header with two options, and **flips the homepage default to show freshest courses first**:

- **Найновіші** — implicit default; URL has no review-sort param. Frontend explicitly sends `last_review_order=desc` so the page lands on most-recent-review-first on every fresh visit.
- **За кількістю** — sets `?reviewSort=by-count`. Frontend stops sending `last_review_order`, letting the backend's natural fallback (`-has_ratings, -ratings_count, title`) take over.

Backend annotates `Max("offerings__ratings__created_at")` per course when freshness is requested; courses with no reviews land last (`NULLS LAST`). The backend default itself is unchanged — the "newest as default" behaviour is a frontend-only decision, so analytics / scatter plot / future API consumers keep their original popular-first semantic.

Single-select across the table: picking a dropdown option clears any active Складність/Корисність column sort, and clicking a column header un-highlights the dropdown (no checkmark while a column sort is active).

Resolves #583 

## Testing
- `pytest rating_app/views/test_course.py rating_app/services/test_course_service.py rating_app/repositories/test_course_repository.py` — 47 passed
- `pnpm vitest run src/features/courses` — 168 passed
- `pnpm exec tsc --noEmit` — clean
- Manual: dropdown cycles, URL round-trip through `?freshOrder=desc`, single-select behaviour across Складність / Корисність / dropdown

## Notes
- "Найновіші" is based on `Rating.created_at`. The model has no `updated_at`, so edits don't bump freshness — intentional ("recently posted activity", not "recently touched").
- Backend default sort is intentionally left untouched. Homepage explicitly opts into freshness via `last_review_order=desc`; other API consumers (analytics, etc.) still get the original popular-first order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Courses table gains a reviews sort menu with options to sort by number of reviews ("by-count") or by most recent review ("newest"); choosing a reviews sort resets other sort fields and pagination.
  * Backend/API now supports sorting courses by most-recent review timestamp so "newest" reflects latest reviews across offerings.

* **Tests**
  * Added tests for review-based sorting, aggregation across offerings, and deterministic tie-breaking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->