### PR TITLE
fix(#609): update gunicorn worker class from `gthread` to `sync`

### DIFF
--- a/docs/architecture/decisions/0008-gunicorn-worker-class.md
+++ b/docs/architecture/decisions/0008-gunicorn-worker-class.md
@@ -1,0 +1,196 @@
+# ADR-0008: Gunicorn Worker Class — Move from `gthread` to `sync`
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-14
+
+## Context
+
+The live backend exhibited intermittent 8–20s stalls while the server was
+otherwise idle (CPU ~0%, load 0.14, database idle). Investigation (issue
+[#609](https://github.com/ukma-cs-ssdm-2025/rate-ukma/issues/609)) traced this to
+a **socket leak**: connections piling up in the `CLOSE_WAIT` state inside the
+gunicorn backend container (905 leaked sockets observed over ~5 days,
+concentrated on 2 of 5 workers, one worker at 530/1024 file descriptors). The
+clogged workers spent their time scanning dead sockets in their selector loop
+instead of serving requests, producing the stalls.
+
+The root defect lives in gunicorn's **`gthread`** worker: it keeps a pool of
+idle keep-alive connections registered in a `selectors` poller, and when a peer
+half-closes such a connection it does not reliably `close()` its own end (see
+gunicorn [#1976](https://github.com/benoitc/gunicorn/issues/1976),
+[#2297](https://github.com/benoitc/gunicorn/issues/2297), and nginx trac
+[#2145](https://trac.nginx.org/nginx/ticket/2145)). The precondition is always
+*an idle keep-alive connection that the peer closes*.
+
+Two earlier fixes removed the **triggers** but not the defect:
+
+- **PR [#610](https://github.com/ukma-cs-ssdm-2025/rate-ukma/pull/610)** disabled
+  nginx → gunicorn upstream keep-alive (`keepalive 16` removed, upstream
+  `Connection: close`). This stopped nginx from holding idle reusable upstream
+  connections — the ~14% of the leak that came from nginx.
+- **PR [#612](https://github.com/ukma-cs-ssdm-2025/rate-ukma/pull/612)** bound all
+  published container ports (`8000`, `5432`, `6379`) to `127.0.0.1`. Gunicorn's
+  `:8000` had been reachable from the public internet; abandoned scanner/bot
+  connections were ~86% of the leak. (This also closed an unrelated data-layer
+  exposure: an internet-reachable, password-less Redis.)
+
+After both fixes the box is healthy, but health now **depends on that config
+holding**: re-introducing upstream keep-alive or re-exposing the port would
+revive the leak, because the `gthread` defect itself is still present.
+
+**Forces:**
+
+- The leak's only home is the `gthread` keep-alive connection pool.
+- With nginx already sending upstream `Connection: close`, gunicorn-side
+  keep-alive on the upstream hop provides **no benefit** — nginx closes each
+  upstream connection after one request regardless.
+- The deployment target is small and I/O-bound: **2 vCPU / 4 GB** (Hetzner),
+  serving an aggressively Redis-cached Django app (DB and Redis reached over the
+  Docker network; nginx terminates TLS and buffers requests/responses in front).
+- Measured load is modest: peak arrival *to gunicorn* ≈ **19 req/s** in the
+  busiest single second (including scanner `400`s), busiest minute ≈ 244 req/min
+  (~4/s average); fast/cached responses measured at **~7–12 ms** through nginx.
+  Observed peak **concurrency** ≈ 50 — but that is *edge connections* (TLS +
+  keep-alive idle + the SPA firing ~7 API calls per page load), not simultaneous
+  in-worker execution. By Little's Law, simultaneous work inside gunicorn at peak
+  is single digits.
+
+## Decision
+
+We will switch the gunicorn worker class from **`gthread` to `sync`**, and raise
+the worker count to compensate for the loss of per-worker threads.
+
+In `src/backend/django-entrypoint.sh`:
+
+- `--worker-class gthread` → `--worker-class sync`.
+- Remove `--threads` (ignored by the sync worker).
+- Remove `--keep-alive 5` (ignored by the sync worker; sync closes every
+  connection after one request, which matches the nginx upstream
+  `Connection: close` already in place).
+- Change the worker formula from `2·cores + 1` to `4·cores + 1`, keeping the
+  existing memory ceiling (`AVAILABLE_MEMORY_MB / 150`). On the 2-vCPU / 4 GB
+  live box this yields **9 workers** (memory cap ≈ 27, so cores govern),
+  restoring the concurrency previously provided by `5 workers × 2 threads = 10`
+  slots while every slot is now an independent process.
+
+The `sync` worker has **no persistent keep-alive connection pool**, so the
+`CLOSE_WAIT` accumulation is structurally impossible — this removes the bug class
+rather than starving it of triggers.
+
+## Consequences
+
+### Positive
+
+- ✅ **Eliminates the leak at the root.** No keep-alive pool ⇒ no idle
+  half-closed sockets ⇒ no `CLOSE_WAIT` accumulation, independent of nginx or
+  firewall configuration.
+- ✅ **No loss of function.** Upstream keep-alive was already disabled
+  (`Connection: close`), so sync's per-request connection close costs nothing on
+  the only hop that talks to gunicorn.
+- ✅ **Health no longer depends on load-bearing config.** PRs #610/#612 become a
+  defense-in-depth nicety rather than the only thing preventing worker wedging.
+- ✅ **Concurrency preserved.** `4·cores + 1 = 9` sync workers ≈ the previous 10
+  gthread slots, now without intra-process GIL contention.
+- ✅ Simpler model: one request per worker is easier to reason about; nginx
+  already buffers slow clients, neutralizing sync's classic weakness.
+
+### Negative / Trade-offs
+
+- ⚠️ **A blocking request occupies a whole worker** for its full duration.
+  The relevant case is the Microsoft OAuth token exchange in
+  `/accounts/microsoft/login/callback/` (a server-side round-trip to Microsoft,
+  ~hundreds of ms). Under gthread the worker's *other* thread kept serving; under
+  sync the worker is fully held. Raising workers to `4·cores+1` is the
+  mitigation; a start-of-semester login burst is the scenario to watch.
+- ⚠️ **CPU-bound parallelism is still capped at the core count** (2). Extra
+  workers only hide I/O wait, not CPU work — true for any config on this box.
+- ⚠️ **Higher memory footprint** from more processes (~9 × ≤150 MB ≈ ≤1.35 GB;
+  lower in practice thanks to `--preload` copy-on-write). Comfortable on 4 GB,
+  and still bounded by the existing memory cap.
+- ⚠️ The `--timeout 300` setting means a hung request holds a worker for up to
+  5 minutes; with more workers this is less risky, but the long timeout is worth
+  revisiting separately.
+
+### Validation / Success Criteria
+
+- After deploy, `CLOSE_WAIT` socket count in the backend container stays flat
+  over days (previously climbed to hundreds):
+  `awk 'NR>1{print $4}' /proc/net/tcp /proc/net/tcp6 | sort | uniq -c` — expect
+  `08` (CLOSE_WAIT) to remain negligible.
+- Per-worker file-descriptor counts stay low and even across workers.
+- No regression in P50/P95 API latency under normal and login-burst traffic.
+
+## Considered Alternatives
+
+### Alternative 1: Keep `gthread`, rely on PRs #610 + #612
+
+Leave the worker class unchanged and trust that removing the triggers (upstream
+keep-alive off, ports bound to loopback) keeps the leak dormant.
+
+**Pros:**
+
+- No change; keeps per-worker thread concurrency for blocking I/O.
+
+**Cons:**
+
+- The defect remains in the code; health is permanently contingent on config
+  that a future change could silently undo (re-enable upstream keep-alive,
+  re-expose a port).
+
+**Reason for rejection:** Leaves a latent failure mode in place for a benefit
+(upstream keep-alive) we no longer use.
+
+### Alternative 2: `gevent` / `eventlet` async workers
+
+Greenlet-based async workers with monkey-patching for high I/O concurrency.
+
+**Pros:**
+
+- Very high concurrency for I/O-bound workloads.
+
+**Cons:**
+
+- Requires monkey-patching the standard library, which can interact badly with
+  psycopg, native extensions, and Django internals; adds debugging surface for a
+  workload that does not need that level of concurrency.
+
+**Reason for rejection:** Disproportionate complexity and risk for ~19 req/s
+peak; introduces a different class of subtle bugs.
+
+### Alternative 3: `uvicorn` ASGI worker
+
+Move to ASGI (`rateukma.asgi`) under a uvicorn worker — a real async event loop,
+no gthread reaper, and reportedly ~36% faster (issue #609 follow-up).
+
+**Pros:**
+
+- No keep-alive reaper bug; better throughput; would allow re-enabling upstream
+  reuse if the backend ever moves off-host.
+
+**Cons:**
+
+- WSGI → ASGI is a **migration, not a flag flip**: changes middleware execution,
+  runs sync views via a `sync_to_async` threadpool, and requires auditing any
+  blocking I/O in middleware/signals.
+
+**Reason for rejection (for now):** Correct long-term direction, but out of scope
+for fixing #609. Tracked as a separate follow-up; this ADR can be superseded if
+and when the ASGI migration is undertaken.
+
+## References
+
+- Issue [#609](https://github.com/ukma-cs-ssdm-2025/rate-ukma/issues/609) —
+  gunicorn `gthread` + nginx upstream keep-alive `CLOSE_WAIT` socket leak
+- PR [#610](https://github.com/ukma-cs-ssdm-2025/rate-ukma/pull/610) — disable
+  nginx → gunicorn upstream keep-alive
+- PR [#612](https://github.com/ukma-cs-ssdm-2025/rate-ukma/pull/612) — bind
+  published container ports to loopback
+- gunicorn [#1976](https://github.com/benoitc/gunicorn/issues/1976),
+  [#2297](https://github.com/benoitc/gunicorn/issues/2297)
+- nginx trac [#2145](https://trac.nginx.org/nginx/ticket/2145)
+- [ADR-0007](0007-hetzner-deployment.md) — Hetzner deployment target

--- a/docs/architecture/decisions/INDEX.md
+++ b/docs/architecture/decisions/INDEX.md
@@ -14,3 +14,4 @@ This document serves as the central index and log for all significant **Architec
 * [ADR-0005](0005-api-data-validation.md) - API Data Validation
 * [ADR-0006](0006-server-side-caching.md) - Server-Side Caching
 * [ADR-0007](0007-hetzner-deployment.md) - Migrate Deployment from AWS EC2 to Hetzner Cloud
+* [ADR-0008](0008-gunicorn-worker-class.md) - Gunicorn Worker Class — `gthread` → `sync`

--- a/src/backend/django-entrypoint.sh
+++ b/src/backend/django-entrypoint.sh
@@ -34,10 +34,13 @@ AVAILABLE_MEMORY_MB=$((AVAILABLE_MEMORY_KB / 1024))
 MAX_REQUESTS=$((AVAILABLE_MEMORY_MB * 2))
 
 # optimal number of workers
+# sync workers handle one request at a time (no threads), so we run ~2x the
+# process count gthread used (it had 2 threads/worker) to keep equivalent
+# concurrency for I/O-bound requests. Still capped by available memory.
 CORES=$(nproc)
 MEMORY_PER_WORKER_MB=150
 MAX_WORKERS_BY_MEMORY=$((AVAILABLE_MEMORY_MB / MEMORY_PER_WORKER_MB))
-WORKERS_BY_CORES=$((2 * CORES + 1))
+WORKERS_BY_CORES=$((4 * CORES + 1))
 WORKERS=$((WORKERS_BY_CORES < MAX_WORKERS_BY_MEMORY ? WORKERS_BY_CORES : MAX_WORKERS_BY_MEMORY))
 WORKERS=$((WORKERS < 1 ? 1 : WORKERS))
 
@@ -46,24 +49,22 @@ if [[ -n "${GUNICORN_WORKERS:-}" ]]; then
     WORKERS="$GUNICORN_WORKERS"
 fi # minimum 1 worker
 
-# number of threads
-THREADS=2 # for bigger instances we can use 4
-
 # start gunicorn
-echo "Starting gunicorn with $WORKERS workers, $THREADS threads and $MAX_REQUESTS max requests"
+echo "Starting gunicorn (sync) with $WORKERS workers and $MAX_REQUESTS max requests"
 
 GUNICORN_ARGS=(
     --timeout 300
     --bind 0.0.0.0:8000
     --workers "$WORKERS"
-    --worker-class gthread
-    --threads "$THREADS"
+    # sync worker: one request per worker, no persistent keep-alive connection
+    # pool. This removes the gthread CLOSE_WAIT socket leak (issue #609, ADR-0008)
+    # at its root. Each connection is closed after a single request, which matches
+    # nginx's upstream "Connection: close" exactly, so we give up nothing.
+    # (sync ignores --threads and --keep-alive, so they are intentionally absent.)
+    --worker-class sync
     --access-logfile -
     --max-requests "$MAX_REQUESTS"
     --max-requests-jitter "$((MAX_REQUESTS / 10))"
-    # short keep-alive: nginx closes each upstream connection (Connection: close),
-    # so this only bounds direct/idle clients; 5s is the recommended 5-15s range
-    --keep-alive 5
 )
 
 # environment-specific settings


### PR DESCRIPTION
Switch gunicorn worker class `gthread` -> `sync` to fix socket leak + add ADR

  ## Summary
  <!-- What changed and why? Include any context or screenshots that help reviewers. -->
  Resolves #609

  The live backend randomly stalled 8–20s while idle. Cause: gunicorn's `gthread` worker leaks idle keep-alive connections into `CLOSE_WAIT` until workers wedge (905 leaked over ~5 days).
  PRs #610 and #612 removed the *triggers*, but the bug still lives in `gthread`.

  `sync` has **no keep-alive connection pool**, so the leak is structurally impossible — this fixes the root cause, not just the triggers. It's safe because nginx already sends upstream
  `Connection: close`, so we were getting nothing from gunicorn-side keepalive anyway.

  Changes in `src/backend/django-entrypoint.sh`:

  - `--worker-class gthread` → `sync`
  - Removed `--threads` / `--keep-alive` (ignored by `sync`)
  - Worker formula `2·cores+1` → `4·cores+1` to keep the same concurrency without threads (9 workers on the 2-core/4GB box vs. the old `5×2=10` slots)

  Plus **ADR-0008** with the analysis and rejected alternatives, and an `INDEX.md` entry.

  ## Testing
  <!-- How did you exercise this change? Include commands or screenshots when useful. -->

  - `bash -n src/backend/django-entrypoint.sh` — syntax valid.
  - Diagnosis based on live measurements (`CLOSE_WAIT` counts, per-worker fds, request rate, latency). **Deploy to staging first** and verify before live.
  - After deploy, `CLOSE_WAIT` should stay flat over days: `awk 'NR>1{print $4}' /proc/net/tcp /proc/net/tcp6 | sort | uniq -c` (code `08`).

  ## Notes
  <!-- Optional: follow-up tasks, risks, or anything reviewers should know. -->

  - **Trade-off:** under `sync` a blocking request (e.g. Microsoft OAuth callback) holds a whole worker; the extra workers cover this. Watch login bursts.
  - **`--bind 0.0.0.0:8000` left unchanged on purpose** — that's the container-internal bind; public exposure was fixed at the docker publish layer (#612). Changing it would break nginx →
  backend.
  - **Follow-up (out of scope):** `uvicorn`/ASGI migration (~36% faster) could later supersede this **ADR.**
