### PR TITLE
feat(#623): re-land feature flags implementation (MR2) into main

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -1764,6 +1764,23 @@ paths:
                     detail: You do not have permission to perform this action
                     status: 403
           description: Forbidden
+  /api/v1/flags/:
+    get:
+      operationId: flags_list
+      summary: List public feature flags evaluated for the current user
+      tags:
+      - flags
+      security:
+      - cookieAuth: []
+      - tokenAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeatureFlags'
+          description: OK
   /api/v1/instructors/{instructor_id}:
     get:
       operationId: instructors_retrieve
@@ -3072,6 +3089,16 @@ components:
       - id
       - name
       - specialities
+    FeatureFlags:
+      type: object
+      properties:
+        flags:
+          type: object
+          additionalProperties:
+            type: boolean
+          readOnly: true
+          description: Map of public feature flag name to its enabled state for the
+            current user.
     FilterOptions:
       type: object
       properties:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,126 @@
+# Feature flags
+
+How to add, toggle, and remove feature flags in rate-ukma. The rationale lives
+in [ADR-0009](architecture/decisions/0009-feature-flags.md); this is the how-to.
+
+## Model in one minute
+
+- Backend uses [**django-waffle**](https://waffle.readthedocs.io/). Flags are DB
+  rows (`Flag`) evaluated **per request user** via `waffle.flag_is_active(request, name)`.
+- `GET /api/v1/flags/` returns `{ "flags": { name: bool } }` for the current
+  user, but **only for flags listed in the `PUBLIC_FEATURE_FLAGS` allowlist**
+  (`src/backend/rateukma/settings/_base.py`). The endpoint is `AllowAny` and
+  intentionally uncached.
+- The frontend consumes it through `src/webapp/src/lib/feature-flags/`:
+  `useFeatureFlag(name)` returns a boolean; `useFeatureFlags()` also gives
+  `isReady`.
+
+### Two kinds of flags
+
+| | Where it lives | Exposed to the browser? |
+|---|---|---|
+| **Client-facing** | name in `PUBLIC_FEATURE_FLAGS`, conventionally `fe_<name>` | Yes, via `/api/v1/flags/` |
+| **Server-only** | any flag **not** in the allowlist | No — never serialized |
+
+`PUBLIC_FEATURE_FLAGS` is the **security boundary** (fails closed). A flag is
+public only when a developer adds it to that list in a reviewed PR — a naming
+mistake cannot leak a server-only flag. `fe_` is a readability convention, not
+the boundary. **Never add a sensitive/server-only flag to the allowlist.**
+
+## Add a new client-facing flag
+
+Exposing a *new* flag name is a code change (allowlist + frontend consumer), so
+it ships with a deploy. **Toggling** an already-exposed flag is runtime-only
+(Django admin), no deploy.
+
+1. **Allowlist it** — add the name to `PUBLIC_FEATURE_FLAGS` in
+   `src/backend/rateukma/settings/_base.py`:
+   ```python
+   PUBLIC_FEATURE_FLAGS = ["fe_test_header", "fe_my_new_flag"]
+   ```
+   No new endpoint, serializer, or OpenAPI regen needed — the response schema is
+   a dynamic `Record<string, boolean>`, so it does not change when flags are
+   added.
+
+2. **Create the `Flag` row** in each environment (default off): Django admin
+   (Waffle ▸ Flags) or CLI —
+   ```bash
+   .venv/bin/python manage.py waffle_flag fe_my_new_flag --everyone off
+   ```
+   For a reproducible demo across envs, ship a data migration that creates it.
+
+3. **Gate the UI** in the frontend:
+   ```tsx
+   import { useFeatureFlag } from "@/lib/feature-flags";
+
+   const isOn = useFeatureFlag("fe_my_new_flag");
+   return isOn ? <NewThing /> : <OldThing />;
+   ```
+   For non-trivial content where a flash of the wrong variant matters, wait for
+   `isReady` so you do not render the OFF state before flags resolve:
+   ```tsx
+   import { useFeatureFlags } from "@/lib/feature-flags";
+
+   const { flags, isReady } = useFeatureFlags();
+   if (!isReady) return null; // or a skeleton
+   return flags.fe_my_new_flag ? <NewThing /> : <OldThing />;
+   ```
+
+## Server-only flags
+
+For backend-only behaviour, create a `Flag` **not** in `PUBLIC_FEATURE_FLAGS`
+and check it in a view/service:
+```python
+from waffle import flag_is_active
+
+if flag_is_active(request, "new_pipeline"):
+    ...
+```
+It is never exposed through the API.
+
+## Toggle / target a flag
+
+Runtime, no deploy. Django admin (Waffle ▸ Flags) or CLI. A `Flag` supports:
+
+- `everyone` — master on/off for all users.
+- `users` / `groups` — explicit allowlists.
+- `percent` — sticky percentage rollout.
+- `staff` / `superusers` / `authenticated` — role targeting.
+
+```bash
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --everyone on
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --percent 25
+```
+
+> Live env runs `sudo docker exec <backend-container> ...`; dump the DB before
+> any write. Anonymous users get waffle's `AnonymousUser` defaults
+> (`WAFFLE_FLAG_DEFAULT`, currently off).
+
+## Test
+
+- **Backend** — force a state without DB rows, and pin the allowlist:
+  ```python
+  from waffle.testutils import override_flag
+
+  @override_flag("fe_my_new_flag", active=True)
+  def test_on(api_client, settings):
+      settings.PUBLIC_FEATURE_FLAGS = ["fe_my_new_flag"]
+      ...
+  ```
+  Always test **both** states. See `src/backend/rating_app/views/test_flags.py`.
+- **Frontend** — mock the hook (no MSW), mirroring
+  `src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx`:
+  ```ts
+  vi.mock("@/lib/feature-flags", () => ({
+    useFeatureFlag: () => true,
+  }));
+  ```
+
+## Remove a flag (do not skip)
+
+Flags are temporary debt. Once a feature is fully rolled out or dropped:
+
+1. Delete the consumer code on both sides (the `flag_is_active` /
+   `useFeatureFlag` call and the dead branch).
+2. Remove the name from `PUBLIC_FEATURE_FLAGS`.
+3. Delete the `Flag` row in each environment.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -96,6 +96,39 @@ Runtime, no deploy. Django admin (Waffle ▸ Flags) or CLI. A `Flag` supports:
 > any write. Anonymous users get waffle's `AnonymousUser` defaults
 > (`WAFFLE_FLAG_DEFAULT`, currently off).
 
+## Override a flag in the browser (QA / Playwright)
+
+Waffle evaluates flags per user on the server, so you cannot flip one from the
+browser by editing a cookie. The frontend adds a thin client-side override layer
+(`src/webapp/src/lib/feature-flags/overrides.ts`) that **wins over** the
+`/api/v1/flags/` response, so QA and E2E can force a flag on/off without touching
+the backend.
+
+Overrides live in `localStorage` under `ff:overrides` and are enabled in
+**every** environment, including live. They only change client-side display
+gating — the write path is validated server-side regardless — so this is a
+convenience affordance, **not** a security boundary.
+
+**From the browser console** (helpers exposed on `window`):
+```js
+featureFlags.set("fe_instructor_multiselect", true)   // force on,  then reload
+featureFlags.set("fe_instructor_multiselect", false)  // force off, then reload
+featureFlags.clear("fe_instructor_multiselect")        // back to the server value
+featureFlags.clearAll()                                // drop all overrides
+featureFlags.list()                                    // inspect current overrides
+```
+
+**From Playwright** — seed before navigation (runs on every page load):
+```ts
+import { setFeatureFlagOverride } from "../shared/feature-flags";
+
+await setFeatureFlagOverride(page, "fe_instructor_multiselect", true);
+await page.goto(...);
+```
+Cover both variants by setting the flag on in one spec and off in another (see
+`tests/e2e/ratings/instructor-multiselect.spec.ts` for the on path and
+`instructor-legacy.spec.ts` for the legacy off path).
+
 ## Test
 
 - **Backend** — force a state without DB rows, and pin the allowlist:
@@ -108,13 +141,14 @@ Runtime, no deploy. Django admin (Waffle ▸ Flags) or CLI. A `Flag` supports:
       ...
   ```
   Always test **both** states. See `src/backend/rating_app/views/test_flags.py`.
-- **Frontend** — mock the hook (no MSW), mirroring
-  `src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx`:
-  ```ts
-  vi.mock("@/lib/feature-flags", () => ({
-    useFeatureFlag: () => true,
-  }));
+- **Frontend** — pass `flags` to `renderWithProviders`, which seeds the
+  `FeatureFlagsContext` directly (no network, no mock):
+  ```tsx
+  render(<RatingForm />, { flags: { fe_instructor_multiselect: true } });
   ```
+  Default is all-off. Test **both** states (see `RatingForm.test.tsx` /
+  `RatingCardBody.test.tsx`). For hook/provider internals, mirror
+  `src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx`.
 
 ## Remove a flag (do not skip)
 

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -8,6 +8,17 @@ The OpenAPI spec at `docs/api/openapi-generated.yaml` is the source of truth for
 .venv/bin/python manage.py spectacular --file ../../docs/api/openapi-generated.yaml
 ```
 
+## Feature flags
+
+Runtime toggles via [django-waffle](https://waffle.readthedocs.io/), evaluated
+per request user. Backend: a flag is exposed to the frontend only if its name is
+in `PUBLIC_FEATURE_FLAGS` (`rateukma/settings/_base.py`) — that allowlist is the
+security boundary, so never put a server-only/sensitive flag there. Check
+server-only flags with `waffle.flag_is_active(request, name)`. See
+[docs/feature-flags.md](../../docs/feature-flags.md) for adding, toggling, and
+removing flags, and [ADR-0009](../../docs/architecture/decisions/0009-feature-flags.md)
+for the rationale.
+
 ## Logging style
 
 Start log calls with a snake_case event name, then pass structured context via keyword args so tools can parse them.

--- a/src/backend/rateukma/settings/_base.py
+++ b/src/backend/rateukma/settings/_base.py
@@ -313,3 +313,10 @@ CORPORATE_PASSWORD = config("CORPORATE_PASSWORD", default="")
 
 # Base URL for parsing
 PARSE_BASE_URL = "https://my.ukma.edu.ua"
+
+# Feature flags (django-waffle)
+# Only flags listed here are exposed via GET /api/v1/flags/. A flag is public
+# ONLY when added to this allowlist in a reviewed PR — the endpoint fails closed,
+# so server-only flags can never leak through a naming mistake. `fe_` is a soft
+# naming convention for client-facing flags, not the security boundary.
+PUBLIC_FEATURE_FLAGS = ["fe_test_header"]

--- a/src/backend/rating_app/ioc_container/web.py
+++ b/src/backend/rating_app/ioc_container/web.py
@@ -10,6 +10,7 @@ from ..views import (
     CommentViewset,
     CourseOfferingViewSet,
     CourseViewSet,
+    FlagsViewSet,
     InstructorViewSet,
     NotificationViewSet,
     RatingViewSet,
@@ -222,6 +223,11 @@ def course_page_view():
 
 
 @once
+def flags_list_view():
+    return FlagsViewSet.as_view({"get": "list"})
+
+
+@once
 def rest_urlpatterns() -> list:
     return [
         path(
@@ -348,6 +354,11 @@ def rest_urlpatterns() -> list:
             "notifications/mark-group-read/",
             notification_mark_group_read_view(),
             name="notification-mark-group-read",
+        ),
+        path(
+            "flags/",
+            flags_list_view(),
+            name="flags-list",
         ),
     ]
 

--- a/src/backend/rating_app/serializers/__init__.py
+++ b/src/backend/rating_app/serializers/__init__.py
@@ -6,6 +6,7 @@ from .course.course_list import CourseListSerializer
 from .course.course_list_resp import CourseListResponseSerializer
 from .course.filter_options import FilterOptionsSerializer
 from .error_envelope import ErrorEnvelopeSerializer
+from .feature_flags import FeatureFlagsSerializer
 from .instructor import InstructorSerializer
 from .notification import NotificationGroupSerializer, UnreadCountSerializer
 from .rating_list_resp import RatingsWithUserListSerializer
@@ -26,6 +27,7 @@ __all__ = [
     "StudentRatingsDetailedSerializer",
     "InstructorSerializer",
     "ErrorEnvelopeSerializer",
+    "FeatureFlagsSerializer",
     "FilterOptionsSerializer",
     "RatingsWithUserListSerializer",
     "RatingVoteReadSerializer",

--- a/src/backend/rating_app/serializers/feature_flags.py
+++ b/src/backend/rating_app/serializers/feature_flags.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+
+class FeatureFlagsSerializer(serializers.Serializer):
+    flags = serializers.DictField(
+        child=serializers.BooleanField(),
+        read_only=True,
+        help_text="Map of public feature flag name to its enabled state for the current user.",
+    )

--- a/src/backend/rating_app/views/__init__.py
+++ b/src/backend/rating_app/views/__init__.py
@@ -2,6 +2,7 @@ from .analytics import AnalyticsViewSet
 from .comment_viewset import CommentViewset
 from .course_offering import CourseOfferingViewSet
 from .course_viewset import CourseViewSet
+from .flags_viewset import FlagsViewSet
 from .instructor_viewset import InstructorViewSet
 from .notification_viewset import NotificationViewSet
 from .rating_viewset import RatingViewSet
@@ -18,4 +19,5 @@ __all__ = [
     "RatingVoteViewSet",
     "CommentViewset",
     "NotificationViewSet",
+    "FlagsViewSet",
 ]

--- a/src/backend/rating_app/views/flags_viewset.py
+++ b/src/backend/rating_app/views/flags_viewset.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from rest_framework import status, viewsets
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -19,9 +21,8 @@ class FlagsViewSet(viewsets.ViewSet):
         summary="List public feature flags evaluated for the current user",
         responses=R_FLAGS,
     )
+    @method_decorator(never_cache)
     def list(self, request) -> Response:
-        flags = {
-            name: flag_is_active(request, name) for name in settings.PUBLIC_FEATURE_FLAGS
-        }
+        flags = {name: flag_is_active(request, name) for name in settings.PUBLIC_FEATURE_FLAGS}
         serializer = FeatureFlagsSerializer({"flags": flags})
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/src/backend/rating_app/views/flags_viewset.py
+++ b/src/backend/rating_app/views/flags_viewset.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from rest_framework import status, viewsets
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from drf_spectacular.utils import extend_schema
+from waffle import flag_is_active
+
+from rating_app.serializers import FeatureFlagsSerializer
+from rating_app.views.responses import R_FLAGS
+
+
+@extend_schema(tags=["flags"])
+class FlagsViewSet(viewsets.ViewSet):
+    permission_classes = [AllowAny]
+    serializer_class = FeatureFlagsSerializer
+
+    @extend_schema(
+        summary="List public feature flags evaluated for the current user",
+        responses=R_FLAGS,
+    )
+    def list(self, request) -> Response:
+        flags = {
+            name: flag_is_active(request, name) for name in settings.PUBLIC_FEATURE_FLAGS
+        }
+        serializer = FeatureFlagsSerializer({"flags": flags})
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/src/backend/rating_app/views/responses.py
+++ b/src/backend/rating_app/views/responses.py
@@ -7,6 +7,7 @@ from rating_app.serializers import (
     CommentReadSerializer,
     CourseDetailSerializer,
     CourseListResponseSerializer,
+    FeatureFlagsSerializer,
     FilterOptionsSerializer,
     InstructorSerializer,
     RatingReadSerializer,
@@ -245,4 +246,8 @@ R_NOTIFICATION_GROUP_MARK_READ = {
     204: OpenApiResponse(description="Notification group marked as read"),
     400: OpenApiResponse(Err, BAD_REQUEST, [EX_400]),
     401: OpenApiResponse(Err, UNAUTHORIZED, [EX_401]),
+}
+
+R_FLAGS = {
+    200: OpenApiResponse(forced_singular_serializer(FeatureFlagsSerializer), "OK"),
 }

--- a/src/backend/rating_app/views/test_flags.py
+++ b/src/backend/rating_app/views/test_flags.py
@@ -1,0 +1,50 @@
+import pytest
+from waffle.models import Flag
+
+FLAGS_URL = "/api/v1/flags/"
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_flags_accessible_anonymously(api_client, settings):
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+
+    response = api_client.get(FLAGS_URL)
+
+    assert response.status_code == 200
+    assert "fe_test_header" in response.json()["flags"]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_flags_reflect_active_state(api_client, settings):
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    Flag.objects.create(name="fe_test_header", everyone=True)
+
+    response = api_client.get(FLAGS_URL)
+
+    assert response.status_code == 200
+    assert response.json()["flags"]["fe_test_header"] is True
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_flags_default_to_false_when_not_created(api_client, settings):
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+
+    response = api_client.get(FLAGS_URL)
+
+    assert response.status_code == 200
+    assert response.json()["flags"]["fe_test_header"] is False
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_non_allowlisted_flag_is_never_exposed(api_client, settings):
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    Flag.objects.create(name="fe_secret_internal", everyone=True)
+
+    response = api_client.get(FLAGS_URL)
+
+    assert response.status_code == 200
+    assert "fe_secret_internal" not in response.json()["flags"]

--- a/src/backend/rating_app/views/test_flags.py
+++ b/src/backend/rating_app/views/test_flags.py
@@ -40,6 +40,17 @@ def test_flags_default_to_false_when_not_created(api_client, settings):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_flags_response_is_not_cacheable(api_client, settings):
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+
+    response = api_client.get(FLAGS_URL)
+
+    assert response.status_code == 200
+    assert "no-store" in response.headers["Cache-Control"]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_non_allowlisted_flag_is_never_exposed(api_client, settings):
     settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
     Flag.objects.create(name="fe_secret_internal", everyone=True)

--- a/src/webapp/AGENTS.md
+++ b/src/webapp/AGENTS.md
@@ -33,6 +33,16 @@ pnpm format --write
 pnpm check
 ```
 
+## Feature flags
+
+Gate UI with `useFeatureFlag("fe_<name>")` from `@/lib/feature-flags` (mirrors
+`@/lib/auth`); use `useFeatureFlags().isReady` to avoid a flash of the wrong
+variant for non-trivial content. Flags are served by `GET /api/v1/flags/` and
+must be allowlisted backend-side. See
+[docs/feature-flags.md](../../docs/feature-flags.md) for the end-to-end flow
+(add / toggle / test / remove) and
+[ADR-0009](../../docs/architecture/decisions/0009-feature-flags.md) for the why.
+
 ## Small tips
 
 - Prefer `globalThis` over `window` when touching the global scope.

--- a/src/webapp/src/components/Header/Header.tsx
+++ b/src/webapp/src/components/Header/Header.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "@/components/ThemeProvider";
 import { NotificationBell } from "@/features/notifications/components/NotificationBell";
 import { useAuth } from "@/lib/auth";
 import { lockBodyScroll } from "@/lib/body-scroll-lock";
+import { useFeatureFlag } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { HeaderNav } from "./HeaderNav";
 import { MobileMenu } from "./MobileMenu";
@@ -20,6 +21,7 @@ export default function Header() {
 	const { status, user, logout } = useAuth();
 	const { theme, setTheme } = useTheme();
 	const isAuthenticated = status === "authenticated";
+	const showTestFlag = useFeatureFlag("fe_test_header");
 
 	useEffect(() => {
 		if (typeof document === "undefined") {
@@ -57,6 +59,15 @@ export default function Header() {
 			>
 				<div className="container mx-auto px-6 max-w-7xl flex h-16 items-center justify-between">
 					<Logo />
+
+					{showTestFlag && (
+						<span
+							className="ml-2 text-sm font-medium text-muted-foreground"
+							data-testid={testIds.header.testFlag}
+						>
+							Test
+						</span>
+					)}
 
 					<div className="flex items-center justify-center flex-1">
 						<HeaderNav

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -1,6 +1,5 @@
 import type { PropsWithChildren } from "react";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -21,27 +20,26 @@ const { authState } = vi.hoisted(() => ({
 
 vi.mock("../api/generated", () => ({
 	useFlagsList: (...args: unknown[]) => mockUseFlagsList(...args),
-	getFlagsListQueryKey: () => FLAGS_QUERY_KEY,
+	getFlagsListQueryKey: () => [...FLAGS_QUERY_KEY],
 }));
 
 vi.mock("@/lib/auth", () => ({
 	useAuth: () => authState.current,
 }));
 
-let queryClient: QueryClient;
-
 function wrapper({ children }: PropsWithChildren) {
-	return (
-		<QueryClientProvider client={queryClient}>
-			<FeatureFlagsProvider>{children}</FeatureFlagsProvider>
-		</QueryClientProvider>
-	);
+	return <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
+}
+
+function lastQueryKey() {
+	const lastCall = mockUseFlagsList.mock.calls.at(-1)?.[0];
+	return lastCall?.query?.queryKey;
 }
 
 describe("feature flags", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		queryClient = new QueryClient();
+		localStorage.clear(); // drop any ff:overrides leaked from other tests
 		authState.current = { status: "unauthenticated", user: null };
 		mockUseFlagsList.mockReturnValue({
 			data: { flags: { fe_test_header: true } },
@@ -86,14 +84,14 @@ describe("feature flags", () => {
 		expect(result.current.flags).toEqual({});
 	});
 
-	it("drops the previous user's flags when the auth identity changes", () => {
-		const removeSpy = vi.spyOn(queryClient, "removeQueries");
+	it("keys the flags query by auth identity", () => {
 		const { rerender } = renderHook(() => useFeatureFlags(), { wrapper });
-		expect(removeSpy).not.toHaveBeenCalled(); // initial mount is skipped
+		const anonKey = lastQueryKey();
+		expect(anonKey).toEqual([...FLAGS_QUERY_KEY, "unauthenticated", null]);
 
 		authState.current = { status: "authenticated", user: { id: 1 } };
 		rerender();
-		expect(removeSpy).toHaveBeenCalledWith({ queryKey: FLAGS_QUERY_KEY });
+		expect(lastQueryKey()).toEqual([...FLAGS_QUERY_KEY, "authenticated", 1]);
 	});
 
 	it("throws when used outside the provider", () => {

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -1,0 +1,54 @@
+import type { PropsWithChildren } from "react";
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FeatureFlagsProvider } from "./FeatureFlagsContext";
+import { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";
+
+const mockUseFlagsList = vi.fn();
+
+vi.mock("../api/generated", () => ({
+	useFlagsList: (...args: unknown[]) => mockUseFlagsList(...args),
+}));
+
+function wrapper({ children }: PropsWithChildren) {
+	return <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
+}
+
+describe("feature flags", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUseFlagsList.mockReturnValue({
+			data: { flags: { fe_test_header: true } },
+			isSuccess: true,
+		});
+	});
+
+	it("returns true for an enabled flag", () => {
+		const { result } = renderHook(() => useFeatureFlag("fe_test_header"), {
+			wrapper,
+		});
+		expect(result.current).toBe(true);
+	});
+
+	it("returns false for an unknown flag", () => {
+		const { result } = renderHook(() => useFeatureFlag("fe_missing"), {
+			wrapper,
+		});
+		expect(result.current).toBe(false);
+	});
+
+	it("is not ready and exposes no flags before the query resolves", () => {
+		mockUseFlagsList.mockReturnValue({ data: undefined, isSuccess: false });
+		const { result } = renderHook(() => useFeatureFlags(), { wrapper });
+		expect(result.current.isReady).toBe(false);
+		expect(result.current.flags).toEqual({});
+	});
+
+	it("throws when used outside the provider", () => {
+		expect(() => renderHook(() => useFeatureFlag("fe_test_header"))).toThrow(
+			/within a FeatureFlagsProvider/,
+		);
+	});
+});

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -8,8 +8,21 @@ import { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";
 
 const mockUseFlagsList = vi.fn();
 
+const { authState } = vi.hoisted(() => ({
+	authState: {
+		current: { status: "unauthenticated", user: null } as {
+			status: string;
+			user: { id: number } | null;
+		},
+	},
+}));
+
 vi.mock("../api/generated", () => ({
 	useFlagsList: (...args: unknown[]) => mockUseFlagsList(...args),
+}));
+
+vi.mock("@/lib/auth", () => ({
+	useAuth: () => authState.current,
 }));
 
 function wrapper({ children }: PropsWithChildren) {
@@ -19,9 +32,12 @@ function wrapper({ children }: PropsWithChildren) {
 describe("feature flags", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		authState.current = { status: "unauthenticated", user: null };
 		mockUseFlagsList.mockReturnValue({
 			data: { flags: { fe_test_header: true } },
 			isSuccess: true,
+			isError: false,
+			refetch: vi.fn(),
 		});
 	});
 
@@ -40,10 +56,43 @@ describe("feature flags", () => {
 	});
 
 	it("is not ready and exposes no flags before the query resolves", () => {
-		mockUseFlagsList.mockReturnValue({ data: undefined, isSuccess: false });
+		mockUseFlagsList.mockReturnValue({
+			data: undefined,
+			isSuccess: false,
+			isError: false,
+			refetch: vi.fn(),
+		});
 		const { result } = renderHook(() => useFeatureFlags(), { wrapper });
 		expect(result.current.isReady).toBe(false);
 		expect(result.current.flags).toEqual({});
+	});
+
+	it("is ready with default-off flags after a failed fetch", () => {
+		mockUseFlagsList.mockReturnValue({
+			data: undefined,
+			isSuccess: false,
+			isError: true,
+			refetch: vi.fn(),
+		});
+		const { result } = renderHook(() => useFeatureFlags(), { wrapper });
+		expect(result.current.isReady).toBe(true);
+		expect(result.current.flags).toEqual({});
+	});
+
+	it("refetches when the auth identity changes", () => {
+		const refetch = vi.fn();
+		mockUseFlagsList.mockReturnValue({
+			data: { flags: {} },
+			isSuccess: true,
+			isError: false,
+			refetch,
+		});
+		const { rerender } = renderHook(() => useFeatureFlags(), { wrapper });
+		expect(refetch).not.toHaveBeenCalled(); // skips initial mount
+
+		authState.current = { status: "authenticated", user: { id: 1 } };
+		rerender();
+		expect(refetch).toHaveBeenCalledTimes(1);
 	});
 
 	it("throws when used outside the provider", () => {

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -1,11 +1,13 @@
 import type { PropsWithChildren } from "react";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FeatureFlagsProvider } from "./FeatureFlagsContext";
 import { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";
 
+const FLAGS_QUERY_KEY = ["/api/v1/flags/"];
 const mockUseFlagsList = vi.fn();
 
 const { authState } = vi.hoisted(() => ({
@@ -19,25 +21,32 @@ const { authState } = vi.hoisted(() => ({
 
 vi.mock("../api/generated", () => ({
 	useFlagsList: (...args: unknown[]) => mockUseFlagsList(...args),
+	getFlagsListQueryKey: () => FLAGS_QUERY_KEY,
 }));
 
 vi.mock("@/lib/auth", () => ({
 	useAuth: () => authState.current,
 }));
 
+let queryClient: QueryClient;
+
 function wrapper({ children }: PropsWithChildren) {
-	return <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
+	return (
+		<QueryClientProvider client={queryClient}>
+			<FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+		</QueryClientProvider>
+	);
 }
 
 describe("feature flags", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		queryClient = new QueryClient();
 		authState.current = { status: "unauthenticated", user: null };
 		mockUseFlagsList.mockReturnValue({
 			data: { flags: { fe_test_header: true } },
 			isSuccess: true,
 			isError: false,
-			refetch: vi.fn(),
 		});
 	});
 
@@ -60,7 +69,6 @@ describe("feature flags", () => {
 			data: undefined,
 			isSuccess: false,
 			isError: false,
-			refetch: vi.fn(),
 		});
 		const { result } = renderHook(() => useFeatureFlags(), { wrapper });
 		expect(result.current.isReady).toBe(false);
@@ -72,27 +80,20 @@ describe("feature flags", () => {
 			data: undefined,
 			isSuccess: false,
 			isError: true,
-			refetch: vi.fn(),
 		});
 		const { result } = renderHook(() => useFeatureFlags(), { wrapper });
 		expect(result.current.isReady).toBe(true);
 		expect(result.current.flags).toEqual({});
 	});
 
-	it("refetches when the auth identity changes", () => {
-		const refetch = vi.fn();
-		mockUseFlagsList.mockReturnValue({
-			data: { flags: {} },
-			isSuccess: true,
-			isError: false,
-			refetch,
-		});
+	it("drops the previous user's flags when the auth identity changes", () => {
+		const removeSpy = vi.spyOn(queryClient, "removeQueries");
 		const { rerender } = renderHook(() => useFeatureFlags(), { wrapper });
-		expect(refetch).not.toHaveBeenCalled(); // skips initial mount
+		expect(removeSpy).not.toHaveBeenCalled(); // initial mount is skipped
 
 		authState.current = { status: "authenticated", user: { id: 1 } };
 		rerender();
-		expect(refetch).toHaveBeenCalledTimes(1);
+		expect(removeSpy).toHaveBeenCalledWith({ queryKey: FLAGS_QUERY_KEY });
 	});
 
 	it("throws when used outside the provider", () => {

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
@@ -1,6 +1,8 @@
 import type { PropsWithChildren } from "react";
 import { createContext, useEffect, useMemo, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import { useAuth } from "@/lib/auth";
 import {
 	FEATURE_FLAG_OVERRIDES_EVENT,
@@ -8,7 +10,7 @@ import {
 	installFeatureFlagConsoleHelpers,
 	readFeatureFlagOverrides,
 } from "./overrides";
-import { useFlagsList } from "../api/generated";
+import { getFlagsListQueryKey, useFlagsList } from "../api/generated";
 
 export interface FeatureFlagsState {
 	flags: Record<string, boolean>;
@@ -21,10 +23,11 @@ const FLAGS_REFETCH_INTERVAL = 5 * 60_000;
 const FeatureFlagsContext = createContext<FeatureFlagsState | null>(null);
 
 export function FeatureFlagsProvider({ children }: PropsWithChildren) {
+	const queryClient = useQueryClient();
 	const { status, user } = useAuth();
 	const userId = user?.id ?? null;
 
-	const { data, isSuccess, isError, refetch } = useFlagsList({
+	const { data, isSuccess, isError } = useFlagsList({
 		query: {
 			staleTime: FLAGS_STALE_TIME,
 			refetchInterval: FLAGS_REFETCH_INTERVAL,
@@ -32,19 +35,20 @@ export function FeatureFlagsProvider({ children }: PropsWithChildren) {
 		},
 	});
 
-	// Flags are evaluated per request user, so refetch when the identity changes
-	// (anonymous <-> authenticated, or user A -> user B) instead of serving the
-	// previous user's flags until the next poll/focus refetch. Skip the initial
-	// mount — the query already fetches on mount.
+	// Flags are evaluated per request user. When the identity changes (anonymous
+	// <-> authenticated, or user A -> user B) drop the cached flags immediately so
+	// we never serve the previous user's values while the new request is in
+	// flight; the mounted query then refetches for the new identity. Skip the
+	// initial mount — the query already fetches on mount.
 	const isInitialIdentity = useRef(true);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: refetch only when the auth identity (status/userId) changes
+	// biome-ignore lint/correctness/useExhaustiveDependencies: act only when the auth identity (status/userId) changes
 	useEffect(() => {
 		if (isInitialIdentity.current) {
 			isInitialIdentity.current = false;
 			return;
 		}
-		refetch();
-	}, [status, userId, refetch]);
+		queryClient.removeQueries({ queryKey: getFlagsListQueryKey() });
+	}, [status, userId, queryClient]);
 
 	const [overrides, setOverrides] = useState<Record<string, boolean>>(
 		readFeatureFlagOverrides,

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
-import { createContext, useEffect, useMemo, useState } from "react";
+import { createContext, useEffect, useMemo, useRef, useState } from "react";
 
+import { useAuth } from "@/lib/auth";
 import {
 	FEATURE_FLAG_OVERRIDES_EVENT,
 	FEATURE_FLAG_OVERRIDES_STORAGE_KEY,
@@ -20,13 +21,30 @@ const FLAGS_REFETCH_INTERVAL = 5 * 60_000;
 const FeatureFlagsContext = createContext<FeatureFlagsState | null>(null);
 
 export function FeatureFlagsProvider({ children }: PropsWithChildren) {
-	const { data, isSuccess } = useFlagsList({
+	const { status, user } = useAuth();
+	const userId = user?.id ?? null;
+
+	const { data, isSuccess, isError, refetch } = useFlagsList({
 		query: {
 			staleTime: FLAGS_STALE_TIME,
 			refetchInterval: FLAGS_REFETCH_INTERVAL,
 			refetchOnWindowFocus: true,
 		},
 	});
+
+	// Flags are evaluated per request user, so refetch when the identity changes
+	// (anonymous <-> authenticated, or user A -> user B) instead of serving the
+	// previous user's flags until the next poll/focus refetch. Skip the initial
+	// mount — the query already fetches on mount.
+	const isInitialIdentity = useRef(true);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: refetch only when the auth identity (status/userId) changes
+	useEffect(() => {
+		if (isInitialIdentity.current) {
+			isInitialIdentity.current = false;
+			return;
+		}
+		refetch();
+	}, [status, userId, refetch]);
 
 	const [overrides, setOverrides] = useState<Record<string, boolean>>(
 		readFeatureFlagOverrides,
@@ -50,9 +68,12 @@ export function FeatureFlagsProvider({ children }: PropsWithChildren) {
 		() => ({
 			// Client overrides win over the server response (non-live only).
 			flags: { ...(data?.flags ?? {}), ...overrides },
-			isReady: isSuccess,
+			// Ready once the first request settles (success OR error) so consumers
+			// behind the isReady gate fall back to default-disabled flags instead of
+			// getting stuck on a failed fetch.
+			isReady: isSuccess || isError,
 		}),
-		[data, isSuccess, overrides],
+		[data, isSuccess, isError, overrides],
 	);
 
 	return (

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
@@ -1,7 +1,5 @@
 import type { PropsWithChildren } from "react";
-import { createContext, useEffect, useMemo, useRef, useState } from "react";
-
-import { useQueryClient } from "@tanstack/react-query";
+import { createContext, useEffect, useMemo, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
 import {
@@ -23,32 +21,21 @@ const FLAGS_REFETCH_INTERVAL = 5 * 60_000;
 const FeatureFlagsContext = createContext<FeatureFlagsState | null>(null);
 
 export function FeatureFlagsProvider({ children }: PropsWithChildren) {
-	const queryClient = useQueryClient();
 	const { status, user } = useAuth();
 	const userId = user?.id ?? null;
 
+	// Flags are evaluated per request user, so key the query by auth identity.
+	// A login/logout or user A -> user B switch immediately reads the new
+	// identity's (empty, pending) cache entry instead of painting the previous
+	// user's flags, with no stale frame and no manual invalidation.
 	const { data, isSuccess, isError } = useFlagsList({
 		query: {
+			queryKey: [...getFlagsListQueryKey(), status, userId],
 			staleTime: FLAGS_STALE_TIME,
 			refetchInterval: FLAGS_REFETCH_INTERVAL,
 			refetchOnWindowFocus: true,
 		},
 	});
-
-	// Flags are evaluated per request user. When the identity changes (anonymous
-	// <-> authenticated, or user A -> user B) drop the cached flags immediately so
-	// we never serve the previous user's values while the new request is in
-	// flight; the mounted query then refetches for the new identity. Skip the
-	// initial mount — the query already fetches on mount.
-	const isInitialIdentity = useRef(true);
-	// biome-ignore lint/correctness/useExhaustiveDependencies: act only when the auth identity (status/userId) changes
-	useEffect(() => {
-		if (isInitialIdentity.current) {
-			isInitialIdentity.current = false;
-			return;
-		}
-		queryClient.removeQueries({ queryKey: getFlagsListQueryKey() });
-	}, [status, userId, queryClient]);
 
 	const [overrides, setOverrides] = useState<Record<string, boolean>>(
 		readFeatureFlagOverrides,

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
@@ -1,0 +1,40 @@
+import type { PropsWithChildren } from "react";
+import { createContext, useMemo } from "react";
+
+import { useFlagsList } from "../api/generated";
+
+export interface FeatureFlagsState {
+	flags: Record<string, boolean>;
+	isReady: boolean;
+}
+
+const FLAGS_STALE_TIME = 60_000;
+const FLAGS_REFETCH_INTERVAL = 5 * 60_000;
+
+const FeatureFlagsContext = createContext<FeatureFlagsState | null>(null);
+
+export function FeatureFlagsProvider({ children }: PropsWithChildren) {
+	const { data, isSuccess } = useFlagsList({
+		query: {
+			staleTime: FLAGS_STALE_TIME,
+			refetchInterval: FLAGS_REFETCH_INTERVAL,
+			refetchOnWindowFocus: true,
+		},
+	});
+
+	const value = useMemo<FeatureFlagsState>(
+		() => ({
+			flags: data?.flags ?? {},
+			isReady: isSuccess,
+		}),
+		[data, isSuccess],
+	);
+
+	return (
+		<FeatureFlagsContext.Provider value={value}>
+			{children}
+		</FeatureFlagsContext.Provider>
+	);
+}
+
+export { FeatureFlagsContext };

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.tsx
@@ -1,6 +1,12 @@
 import type { PropsWithChildren } from "react";
-import { createContext, useMemo } from "react";
+import { createContext, useEffect, useMemo, useState } from "react";
 
+import {
+	FEATURE_FLAG_OVERRIDES_EVENT,
+	FEATURE_FLAG_OVERRIDES_STORAGE_KEY,
+	installFeatureFlagConsoleHelpers,
+	readFeatureFlagOverrides,
+} from "./overrides";
 import { useFlagsList } from "../api/generated";
 
 export interface FeatureFlagsState {
@@ -22,12 +28,31 @@ export function FeatureFlagsProvider({ children }: PropsWithChildren) {
 		},
 	});
 
+	const [overrides, setOverrides] = useState<Record<string, boolean>>(
+		readFeatureFlagOverrides,
+	);
+
+	useEffect(() => {
+		installFeatureFlagConsoleHelpers();
+		const refresh = () => setOverrides(readFeatureFlagOverrides());
+		const onStorage = (e: StorageEvent) => {
+			if (e.key === FEATURE_FLAG_OVERRIDES_STORAGE_KEY) refresh();
+		};
+		globalThis.addEventListener(FEATURE_FLAG_OVERRIDES_EVENT, refresh);
+		globalThis.addEventListener("storage", onStorage);
+		return () => {
+			globalThis.removeEventListener(FEATURE_FLAG_OVERRIDES_EVENT, refresh);
+			globalThis.removeEventListener("storage", onStorage);
+		};
+	}, []);
+
 	const value = useMemo<FeatureFlagsState>(
 		() => ({
-			flags: data?.flags ?? {},
+			// Client overrides win over the server response (non-live only).
+			flags: { ...(data?.flags ?? {}), ...overrides },
 			isReady: isSuccess,
 		}),
-		[data, isSuccess],
+		[data, isSuccess, overrides],
 	);
 
 	return (

--- a/src/webapp/src/lib/feature-flags/index.ts
+++ b/src/webapp/src/lib/feature-flags/index.ts
@@ -1,3 +1,10 @@
 export type { FeatureFlagsState } from "./FeatureFlagsContext";
 export { FeatureFlagsProvider } from "./FeatureFlagsContext";
+export {
+	clearFeatureFlagOverride,
+	clearFeatureFlagOverrides,
+	featureFlagOverridesEnabled,
+	readFeatureFlagOverrides,
+	setFeatureFlagOverride,
+} from "./overrides";
 export { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";

--- a/src/webapp/src/lib/feature-flags/index.ts
+++ b/src/webapp/src/lib/feature-flags/index.ts
@@ -1,0 +1,3 @@
+export type { FeatureFlagsState } from "./FeatureFlagsContext";
+export { FeatureFlagsProvider } from "./FeatureFlagsContext";
+export { useFeatureFlag, useFeatureFlags } from "./useFeatureFlag";

--- a/src/webapp/src/lib/feature-flags/overrides.ts
+++ b/src/webapp/src/lib/feature-flags/overrides.ts
@@ -1,0 +1,83 @@
+/**
+ * Client-side feature-flag overrides.
+ *
+ * Waffle evaluates flags per-user on the server, so there is no way to flip a
+ * flag from the browser for testing. These overrides layer on top of the
+ * server response (see `FeatureFlagsProvider`) so QA / Playwright can force a
+ * flag on or off without touching the backend.
+ *
+ * Enabled in EVERY environment (including live): the E2E suite runs against
+ * live too and relies on flipping flags, and the override is an obscure,
+ * console-only affordance that only changes client-side display gating (the
+ * write path is validated server-side regardless). Not a security boundary.
+ */
+
+const STORAGE_KEY = "ff:overrides";
+const CHANGE_EVENT = "ff:overrides-changed";
+
+export const featureFlagOverridesEnabled = true;
+
+export function readFeatureFlagOverrides(): Record<string, boolean> {
+	if (!featureFlagOverridesEnabled || typeof localStorage === "undefined") {
+		return {};
+	}
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return {};
+		const parsed: unknown = JSON.parse(raw);
+		if (parsed && typeof parsed === "object") {
+			return Object.fromEntries(
+				Object.entries(parsed as Record<string, unknown>)
+					.filter(([, v]) => typeof v === "boolean")
+					.map(([k, v]) => [k, v as boolean]),
+			);
+		}
+	} catch {
+		// corrupt value — treat as no overrides
+	}
+	return {};
+}
+
+function writeOverrides(next: Record<string, boolean>): void {
+	if (!featureFlagOverridesEnabled || typeof localStorage === "undefined") {
+		return;
+	}
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+	globalThis.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+export function setFeatureFlagOverride(name: string, value: boolean): void {
+	writeOverrides({ ...readFeatureFlagOverrides(), [name]: value });
+}
+
+export function clearFeatureFlagOverride(name: string): void {
+	const next = readFeatureFlagOverrides();
+	delete next[name];
+	writeOverrides(next);
+}
+
+export function clearFeatureFlagOverrides(): void {
+	writeOverrides({});
+}
+
+export const FEATURE_FLAG_OVERRIDES_EVENT = CHANGE_EVENT;
+export const FEATURE_FLAG_OVERRIDES_STORAGE_KEY = STORAGE_KEY;
+
+/**
+ * Expose `window.featureFlags` helpers in non-live environments so a flag can
+ * be flipped straight from the browser console:
+ *   featureFlags.set("fe_instructor_multiselect", true)
+ *   featureFlags.clear("fe_instructor_multiselect")
+ *   featureFlags.list()
+ */
+export function installFeatureFlagConsoleHelpers(): void {
+	if (!featureFlagOverridesEnabled || typeof window === "undefined") {
+		return;
+	}
+	(window as unknown as { featureFlags?: unknown }).featureFlags = {
+		set: setFeatureFlagOverride,
+		clear: clearFeatureFlagOverride,
+		clearAll: clearFeatureFlagOverrides,
+		list: readFeatureFlagOverrides,
+	};
+}

--- a/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
+++ b/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
@@ -1,0 +1,17 @@
+import { useContext } from "react";
+
+import { FeatureFlagsContext } from "./FeatureFlagsContext";
+
+export function useFeatureFlags() {
+	const context = useContext(FeatureFlagsContext);
+	if (!context) {
+		throw new Error(
+			"useFeatureFlags must be used within a FeatureFlagsProvider",
+		);
+	}
+	return context;
+}
+
+export function useFeatureFlag(name: string): boolean {
+	return useFeatureFlags().flags[name] ?? false;
+}

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -90,6 +90,7 @@ export const testIds = {
 		userMenu: "header-user-menu",
 		userMenuTrigger: "header-user-menu-trigger",
 		logoutButton: "header-logout-button",
+		testFlag: "header-test-flag",
 	},
 
 	// Courses page

--- a/src/webapp/src/routes/__root.tsx
+++ b/src/webapp/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import { Toaster } from "@/components/ui/Toaster";
 import { SentryUserSync } from "@/integrations/sentry/SentryUserSync";
 import { AppMetadataDefaults } from "@/lib/app-metadata";
 import { AuthProvider } from "@/lib/auth";
+import { FeatureFlagsProvider } from "@/lib/feature-flags";
 
 const TanStackRouterDevtools = import.meta.env.PROD
 	? () => null
@@ -30,16 +31,18 @@ export const Route = createRootRouteWithContext<MyRouterContext>()({
 			<HelmetProvider>
 				<AppMetadataDefaults />
 				<AuthProvider>
-					<SentryUserSync />
-					<ThemeProvider defaultTheme="system" storageKey="rate-ukma-theme">
-						<NuqsAdapter>
-							<Outlet />
-						</NuqsAdapter>
-						<Toaster />
-					</ThemeProvider>
-					<Suspense>
-						<TanStackRouterDevtools position="bottom-left" />
-					</Suspense>
+					<FeatureFlagsProvider>
+						<SentryUserSync />
+						<ThemeProvider defaultTheme="system" storageKey="rate-ukma-theme">
+							<NuqsAdapter>
+								<Outlet />
+							</NuqsAdapter>
+							<Toaster />
+						</ThemeProvider>
+						<Suspense>
+							<TanStackRouterDevtools position="bottom-left" />
+						</Suspense>
+					</FeatureFlagsProvider>
 				</AuthProvider>
 			</HelmetProvider>
 		</ErrorBoundary>

--- a/src/webapp/src/test-utils/render.tsx
+++ b/src/webapp/src/test-utils/render.tsx
@@ -4,16 +4,20 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type RenderOptions, render, renderHook } from "@testing-library/react";
 
 import { AuthProvider } from "@/lib/auth";
+import { FeatureFlagsContext } from "@/lib/feature-flags/FeatureFlagsContext";
 
 /**
  * Custom render function that wraps components with necessary providers
  * Use this instead of @testing-library/react's render for tests that need API/query context
+ *
+ * Pass `flags` to control feature flags under test (defaults to all-off).
  */
 export function renderWithProviders(
 	ui: ReactElement,
 	options?: Readonly<
 		RenderOptions & {
 			queryClient?: QueryClient;
+			flags?: Record<string, boolean>;
 		}
 	>,
 ) {
@@ -30,7 +34,13 @@ export function renderWithProviders(
 	function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
 		return (
 			<QueryClientProvider client={queryClient}>
-				<AuthProvider>{children}</AuthProvider>
+				<AuthProvider>
+					<FeatureFlagsContext.Provider
+						value={{ flags: options?.flags ?? {}, isReady: true }}
+					>
+						{children}
+					</FeatureFlagsContext.Provider>
+				</AuthProvider>
 			</QueryClientProvider>
 		);
 	}

--- a/src/webapp/src/test-utils/render.tsx
+++ b/src/webapp/src/test-utils/render.tsx
@@ -75,7 +75,11 @@ export function renderHookWithProviders<Result, Props>(
 	function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
 		return (
 			<QueryClientProvider client={queryClient}>
-				<AuthProvider>{children}</AuthProvider>
+				<AuthProvider>
+					<FeatureFlagsContext.Provider value={{ flags: {}, isReady: true }}>
+						{children}
+					</FeatureFlagsContext.Provider>
+				</AuthProvider>
 			</QueryClientProvider>
 		);
 	}

--- a/src/webapp/tests/e2e/shared/feature-flags.ts
+++ b/src/webapp/tests/e2e/shared/feature-flags.ts
@@ -18,7 +18,12 @@ export async function setFeatureFlagOverride(
 			const KEY = "ff:overrides";
 			let current: Record<string, boolean> = {};
 			try {
-				current = JSON.parse(window.localStorage.getItem(KEY) ?? "{}");
+				const parsed: unknown = JSON.parse(
+					window.localStorage.getItem(KEY) ?? "{}",
+				);
+				if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+					current = parsed as Record<string, boolean>;
+				}
 			} catch {
 				current = {};
 			}

--- a/src/webapp/tests/e2e/shared/feature-flags.ts
+++ b/src/webapp/tests/e2e/shared/feature-flags.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Force a feature flag on/off in the browser for the lifetime of the test.
+ *
+ * Mirrors `src/lib/feature-flags/overrides.ts`: seeds the `ff:overrides`
+ * localStorage entry that `FeatureFlagsProvider` merges over the server
+ * response. Must be called BEFORE `page.goto(...)` — `addInitScript` runs on
+ * every navigation, before app code. Only effective in non-live environments.
+ */
+export async function setFeatureFlagOverride(
+	page: Page,
+	name: string,
+	value: boolean,
+): Promise<void> {
+	await page.addInitScript(
+		({ name, value }) => {
+			const KEY = "ff:overrides";
+			let current: Record<string, boolean> = {};
+			try {
+				current = JSON.parse(window.localStorage.getItem(KEY) ?? "{}");
+			} catch {
+				current = {};
+			}
+			current[name] = value;
+			window.localStorage.setItem(KEY, JSON.stringify(current));
+		},
+		{ name, value },
+	);
+}


### PR DESCRIPTION
Re-lands the feature-flags **implementation** onto `main`. PR #625 was merged into the `feat/623-waffle-setup` branch (not `main`), and that branch was deleted before reaching `main` — so only MR1 (#624: waffle dep + settings + ADR-0009) actually landed. This PR brings the rest in, on top of `main`.

### Contents
- **Backend** `GET /api/v1/flags/` — `FlagsViewSet` (`AllowAny`), `PUBLIC_FEATURE_FLAGS` allowlist, typed `Record<string,boolean>`, IoC wiring, OpenAPI spec, `test_flags.py`.
- **Frontend** `src/lib/feature-flags/` — provider + `useFeatureFlag`/`useFeatureFlags`, wired in `__root.tsx`, demo `fe_test_header` → "Test" in header, client-side override layer (`overrides.ts` + console helpers + Playwright helper), `renderWithProviders` `flags` option.
- **Docs** `docs/feature-flags.md` + `AGENTS.md` references (backend + webapp).
- **CodeRabbit fixes** (from #625 review): refetch flags on auth identity change (per-user eval); `isReady` true once the request settles (success OR error) so consumers fall back to default-off instead of getting stuck.

### Verify
- Backend: ruff clean, OpenAPI spec regenerates with no diff, flags tests pass.
- Frontend: `tsc` clean, Biome clean, **249/249** vitest pass.

Cherry-picked from the original MR2 commits onto current `main` (which already has MR1). Closes #623.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public `GET /api/v1/flags/` endpoint returning the current user’s enabled feature flags.
  * Introduced app-wide feature-flag support in the web UI with a readiness gate to avoid UI flicker.
  * Added a new header “Test” label that appears when the corresponding test flag is enabled.

* **Bug Fixes**
  * Ensures only allowlisted flags are exposed and missing/unavailable flags default safely to off.
  * Prevents flag values from carrying over across users/sessions, and disables caching for the flags response.

* **Documentation / Tests**
  * Expanded feature-flag documentation and added integration/unit/e2e coverage for the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->