### PR TITLE
ci(#622): flush redis cache (+preserve sessions option)

### DIFF
--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -181,11 +181,13 @@ apply_nginx_config() {
 
 flush_cache() {
   echo "Flushing Redis cache"
+  cd "$SOURCE_CODE"
+
   local backend_container
-  backend_container=$(sudo docker ps --format "{{.Names}}" | grep backend | head -n1)
+  backend_container=$(compose_cmd "$WEBAPP_IMAGE_TAG" "$BACKEND_IMAGE_TAG" ps -q backend)
 
   if [[ -z "$backend_container" ]]; then
-    echo "Warning: backend container not found, skipping cache flush"
+    echo "Warning: prod backend container not found, skipping cache flush"
     return 0
   fi
 
@@ -197,8 +199,8 @@ flush_cache() {
 
 cleanup_on_success() {
   echo "Services are up and healthy"
-  flush_cache
   apply_nginx_config
+  flush_cache
 
   rm -rf "$BACKUP_DIR"
   rm -f "$TMP_DIR/prev_tags.env"

--- a/scripts/ci/deploy.sh
+++ b/scripts/ci/deploy.sh
@@ -179,8 +179,25 @@ apply_nginx_config() {
   echo "Nginx config applied and reloaded"
 }
 
+flush_cache() {
+  echo "Flushing Redis cache"
+  local backend_container
+  backend_container=$(sudo docker ps --format "{{.Names}}" | grep backend | head -n1)
+
+  if [[ -z "$backend_container" ]]; then
+    echo "Warning: backend container not found, skipping cache flush"
+    return 0
+  fi
+
+  # clear, skip on failure - cache entries expire on their own after TTL
+  if ! sudo docker exec "$backend_container" uv run python manage.py manage_cache --clear; then
+    echo "Warning: cache flush failed, continuing"
+  fi
+}
+
 cleanup_on_success() {
   echo "Services are up and healthy"
+  flush_cache
   apply_nginx_config
 
   rm -rf "$BACKUP_DIR"

--- a/src/backend/rateukma/caching/cache_manager.py
+++ b/src/backend/rateukma/caching/cache_manager.py
@@ -12,6 +12,9 @@ logger = structlog.get_logger(__name__)
 
 
 JSON_Serializable = int | float | str | bool | list[Any] | dict[str, Any] | None
+KeyType = str | bytes | bytearray | memoryview
+
+SESSION_KEY_MARKER = "django.contrib.sessions"
 
 
 class ICacheManager(Protocol):
@@ -26,7 +29,7 @@ class ICacheManager(Protocol):
 
     def invalidate(self, key: str) -> bool: ...
 
-    def invalidate_pattern(self, pattern: str) -> int: ...
+    def invalidate_pattern(self, pattern: str, skip_keys: list[str] | None = None) -> int: ...
 
     def get_version(self, namespace: str) -> int: ...
 
@@ -86,7 +89,7 @@ class RedisCacheManager(ICacheManager):
             self._handle_error("delete", e)
             return False
 
-    def invalidate_pattern(self, pattern: str) -> int:
+    def invalidate_pattern(self, pattern: str, skip_keys: list[str] | None = None) -> int:
         logger.info("invalidating_pattern", pattern=pattern)
         try:
             full_pattern = self._make_key(pattern)
@@ -95,6 +98,9 @@ class RedisCacheManager(ICacheManager):
 
             while True:
                 cursor, keys = self.redis_client.scan(cursor, match=full_pattern, count=100)
+
+                if skip_keys:
+                    keys = [key for key in keys if not self._matches_marker(key, skip_keys)]
 
                 if keys:
                     deleted += int(self.redis_client.delete(*keys))  # cast
@@ -108,6 +114,10 @@ class RedisCacheManager(ICacheManager):
         except RedisError as e:
             self._handle_error("invalidate_pattern", e)
             return 0
+
+    def _matches_marker(self, raw_key: KeyType, markers: list[str]) -> bool:
+        key = raw_key if isinstance(raw_key, str) else bytes(raw_key).decode("utf-8")
+        return any(marker in key for marker in markers)
 
     def get_version(self, namespace: str) -> int:
         version_key = self._make_version_key(namespace)
@@ -213,9 +223,13 @@ class InMemoryCacheManager(ICacheManager):
             return True
         return False
 
-    def invalidate_pattern(self, pattern: str) -> int:
+    def invalidate_pattern(self, pattern: str, skip_keys: list[str] | None = None) -> int:
         pattern_base = pattern.replace("*", "")
         keys_to_remove = [k for k in self._store if pattern_base in k]
+        if skip_keys:
+            keys_to_remove = [
+                k for k in keys_to_remove if not any(marker in k for marker in skip_keys)
+            ]
         for key in keys_to_remove:
             del self._store[key]
         return len(keys_to_remove)

--- a/src/backend/rateukma/caching/test_cache.py
+++ b/src/backend/rateukma/caching/test_cache.py
@@ -281,6 +281,50 @@ class TestRCachedComponents:
         mock_redis_client.expire.assert_called_with("test:version:courses:list", 60 * 60 * 24 * 30)
 
 
+@pytest.mark.integration
+class TestInvalidatePatternSkipKeys:
+    SESSION_MARKER = "django.contrib.sessions"
+
+    def test_redis_skip_keys_preserves_session_keys(self):
+        app_key = b"rateukma:CourseService.get_course|1"
+        version_key = b"rateukma:version:courses:list"
+        session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
+
+        client = Mock()
+        client.scan.return_value = (0, [app_key, version_key, session_key])
+        client.delete.return_value = 2
+        manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
+
+        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
+
+        # session key is excluded; only app + version keys are deleted
+        client.delete.assert_called_once_with(app_key, version_key)
+        assert deleted == 2
+
+    def test_redis_skip_keys_no_delete_when_all_skipped(self):
+        session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
+
+        client = Mock()
+        client.scan.return_value = (0, [session_key])
+        manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
+
+        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
+
+        client.delete.assert_not_called()
+        assert deleted == 0
+
+    def test_inmemory_skip_keys_preserves_session_keys(self):
+        manager = InMemoryCacheManager()
+        manager.set("course:1", 1)
+        manager.set("1:django.contrib.sessions.cache<abc123>", "session-data")
+
+        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
+
+        assert deleted == 1
+        assert manager.get("course:1") is None
+        assert manager.get("1:django.contrib.sessions.cache<abc123>") == "session-data"
+
+
 class TestCacheInvalidation:
     class _TestService:
         pass

--- a/src/backend/rating_app/management/commands/manage_cache.py
+++ b/src/backend/rating_app/management/commands/manage_cache.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand
 
+from rateukma.caching.cache_manager import SESSION_KEY_MARKER
 from rateukma.caching.instances import redis_cache_manager
 
 
@@ -18,21 +19,38 @@ class Command(BaseCommand):
         parser.add_argument(
             "--clear",
             action="store_true",
-            help="Clear all cache keys",
+            help="Clear application cache keys (sessions preserved by default)",
+        )
+        parser.add_argument(
+            "--with-sessions",
+            action="store_true",
+            help="With --clear, also delete session keys",
         )
 
     def handle(self, *args, **options):
         keys_count = options.get("keys", 0)
         should_clear = options.get("clear", False)
+        with_sessions = options.get("with_sessions", False)
 
         cache_manager = redis_cache_manager()
 
         if should_clear:
-            self.stdout.write("Clearing all cache keys...")
-            cleared_count = cache_manager.invalidate_pattern("*")
+            if with_sessions:
+                self.stdout.write("Clearing all cache keys, including sessions...")
+                cleared_count = cache_manager.invalidate_pattern("*")
+            else:
+                self.stdout.write("Clearing application cache keys (sessions preserved)...")
+                cleared_count = cache_manager.invalidate_pattern(
+                    "*", skip_keys=[SESSION_KEY_MARKER]
+                )
+
             self.stdout.write(
                 self.style.SUCCESS(f"Successfully cleared {cleared_count} cache keys")  # type: ignore
             )
+            return
+
+        if with_sessions:
+            self.stderr.write("--with-sessions has no effect without --clear")
             return
 
         stats = cache_manager.get_stats()


### PR DESCRIPTION
## Summary
Added redis cache flushing after successful deployment
Resolves #622 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--with-sessions` option to the cache management command to optionally clear session-related cache entries.

* **Bug Fixes**
  * Improved cache-clearing to preserve session keys by default, while still clearing application cache entries.
  * Enhanced invalidation to support excluding specific keys from bulk pattern invalidation.

* **Tests**
  * Added integration coverage to verify skip-key behavior for both Redis-backed and in-memory caching.

* **Chores**
  * Updated deployment flow to clear cached backend data after successful rollout, with safe warnings when cache clearing isn’t possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->