### PR TITLE
fix(scraper): correct program_start derivation + catalog snapshot diff tooling

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">87%</text>
-        <text x="80" y="14">87%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">86%</text>
+        <text x="80" y="14">86%</text>
     </g>
 </svg>

--- a/src/backend/scraper/management/commands/diff_catalog_snapshots.py
+++ b/src/backend/scraper/management/commands/diff_catalog_snapshots.py
@@ -1,0 +1,126 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+EXAMPLES_LIMIT = 30
+VALUE_PREVIEW_LIMIT = 120
+
+
+def _fmt(value) -> str:
+    text = " ".join(str(value).split())
+    if len(text) > VALUE_PREVIEW_LIMIT:
+        text = text[:VALUE_PREVIEW_LIMIT] + "…"
+    return text
+
+
+def diff_sections(before: dict, after: dict) -> dict:
+    result = {}
+    for section in before.keys() | after.keys():
+        before_records = before.get(section, {})
+        after_records = after.get(section, {})
+
+        added = sorted(after_records.keys() - before_records.keys())
+        removed = sorted(before_records.keys() - after_records.keys())
+        changed = {}
+        for key in before_records.keys() & after_records.keys():
+            field_changes = {
+                field: {"before": before_records[key].get(field), "after": value}
+                for field, value in after_records[key].items()
+                if before_records[key].get(field) != value
+            }
+            if field_changes:
+                changed[key] = field_changes
+
+        result[section] = {"added": added, "removed": removed, "changed": changed}
+    return result
+
+
+def render_report(diff: dict, full: bool) -> str:
+    lines = [
+        "# Catalog snapshot diff",
+        "",
+        "| Section | Added | Removed | Changed |",
+        "|---|---|---|---|",
+    ]
+    for section, d in sorted(diff.items()):
+        lines.append(
+            f"| {section} | {len(d['added'])} | {len(d['removed'])} | {len(d['changed'])} |"
+        )
+    lines.append("")
+
+    limit = None if full else EXAMPLES_LIMIT
+    for section, d in sorted(diff.items()):
+        if not (d["added"] or d["removed"] or d["changed"]):
+            continue
+        lines.append(f"## {section}")
+        if d["changed"]:
+            field_counts = Counter(field for fields in d["changed"].values() for field in fields)
+            frequency = ", ".join(
+                f"{field}: {count}" for field, count in field_counts.most_common()
+            )
+            lines.append(f"Changed fields: {frequency}")
+            lines.append("")
+        for kind in ("added", "removed"):
+            keys = d[kind]
+            if not keys:
+                continue
+            lines.append(f"### {kind} ({len(keys)})")
+            lines.extend(f"- {_fmt(key)}" for key in keys[:limit])
+            if limit and len(keys) > limit:
+                lines.append(f"- … and {len(keys) - limit} more")
+        if d["changed"]:
+            lines.append(f"### changed ({len(d['changed'])})")
+            for key, fields in sorted(d["changed"].items())[:limit]:
+                lines.append(f"- {_fmt(key)}")
+                for field, values in fields.items():
+                    lines.append(f"  - {field}: {_fmt(values['before'])} → {_fmt(values['after'])}")
+            if limit and len(d["changed"]) > limit:
+                lines.append(f"- … and {len(d['changed']) - limit} more")
+        lines.append("")
+    return "\n".join(lines)
+
+
+class Command(BaseCommand):
+    help = "Diff two catalog snapshots (see snapshot_catalog) into a markdown report"
+
+    def add_arguments(self, parser):
+        parser.add_argument("before", type=str, help="Snapshot JSON taken before ingestion")
+        parser.add_argument("after", type=str, help="Snapshot JSON taken after ingestion")
+        parser.add_argument(
+            "--out",
+            type=str,
+            default=None,
+            help="Write capped report to file plus an uncapped <name>.full.md (default: stdout)",
+        )
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help="Print all diff entries to stdout instead of capping examples",
+        )
+
+    def handle(self, *args, **options):
+        before_path = Path(options["before"])
+        after_path = Path(options["after"])
+        for path in (before_path, after_path):
+            if not path.exists():
+                raise CommandError(f"Snapshot file not found: {path}")
+
+        before = json.loads(before_path.read_text(encoding="utf-8"))
+        after = json.loads(after_path.read_text(encoding="utf-8"))
+
+        diff = diff_sections(before, after)
+
+        if options["out"]:
+            out_path = Path(options["out"])
+            out_path.write_text(render_report(diff, full=False), encoding="utf-8")
+            full_path = out_path.with_suffix(".full.md")
+            full_path.write_text(render_report(diff, full=True), encoding="utf-8")
+            logger.info("diff_report_saved", path=str(out_path), full_path=str(full_path))
+        else:
+            self.stdout.write(render_report(diff, full=options["full"]))

--- a/src/backend/scraper/management/commands/diff_catalog_snapshots.py
+++ b/src/backend/scraper/management/commands/diff_catalog_snapshots.py
@@ -29,10 +29,12 @@ def diff_sections(before: dict, after: dict) -> dict:
         removed = sorted(before_records.keys() - after_records.keys())
         changed = {}
         for key in before_records.keys() & after_records.keys():
+            before_fields = before_records[key]
+            after_fields = after_records[key]
             field_changes = {
-                field: {"before": before_records[key].get(field), "after": value}
-                for field, value in after_records[key].items()
-                if before_records[key].get(field) != value
+                field: {"before": before_fields.get(field), "after": after_fields.get(field)}
+                for field in before_fields.keys() | after_fields.keys()
+                if before_fields.get(field) != after_fields.get(field)
             }
             if field_changes:
                 changed[key] = field_changes

--- a/src/backend/scraper/management/commands/snapshot_catalog.py
+++ b/src/backend/scraper/management/commands/snapshot_catalog.py
@@ -1,0 +1,228 @@
+import json
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+import structlog
+
+from rating_app.models import (
+    Course,
+    CourseOffering,
+    CourseOfferingTerm,
+    Department,
+    Enrollment,
+    Faculty,
+    Semester,
+    Speciality,
+    Student,
+)
+from rating_app.models.course_offering_speciality import CourseOfferingSpeciality
+
+logger = structlog.get_logger(__name__)
+
+
+def _student_key(email: str, first_name: str, last_name: str, patronymic: str) -> str:
+    if email:
+        return email.lower()
+    return f"{last_name}|{first_name}|{patronymic}"
+
+
+def _snapshot_faculties() -> dict:
+    return {name: {} for name in Faculty.objects.values_list("name", flat=True)}
+
+
+def _snapshot_departments() -> dict:
+    rows = Department.objects.values("name", "faculty__name")
+    return {f"{r['faculty__name']}|{r['name']}": {} for r in rows}
+
+
+def _snapshot_specialities() -> dict:
+    rows = Speciality.objects.values("name", "faculty__name")
+    return {r["name"]: {"faculty": r["faculty__name"]} for r in rows}
+
+
+def _snapshot_semesters() -> dict:
+    rows = Semester.objects.values("year", "term")
+    return {f"{r['year']}-{r['term']}": {} for r in rows}
+
+
+def _snapshot_courses() -> dict:
+    rows = Course.objects.values(
+        "title",
+        "education_level",
+        "status",
+        "description",
+        "department__name",
+        "department__faculty__name",
+    )
+    return {
+        f"{r['title']}|{r['department__name']}|{r['education_level']}": {
+            "faculty": r["department__faculty__name"],
+            "status": r["status"],
+            "description": r["description"],
+        }
+        for r in rows
+    }
+
+
+def _snapshot_offerings() -> dict:
+    rows = CourseOffering.objects.values(
+        "code",
+        "course__title",
+        "course__department__name",
+        "course__education_level",
+        "semester__year",
+        "semester__term",
+        "credits",
+        "weekly_hours",
+        "study_year",
+        "lecture_count",
+        "practice_count",
+        "practice_type",
+        "exam_type",
+        "max_students",
+        "max_groups",
+        "group_size_min",
+        "group_size_max",
+    )
+    return {
+        r["code"]: {
+            "course": (
+                f"{r['course__title']}|{r['course__department__name']}"
+                f"|{r['course__education_level']}"
+            ),
+            "semester": f"{r['semester__year']}-{r['semester__term']}",
+            "credits": str(r["credits"]),
+            "weekly_hours": r["weekly_hours"],
+            "study_year": r["study_year"],
+            "lecture_count": r["lecture_count"],
+            "practice_count": r["practice_count"],
+            "practice_type": r["practice_type"],
+            "exam_type": r["exam_type"],
+            "max_students": r["max_students"],
+            "max_groups": r["max_groups"],
+            "group_size_min": r["group_size_min"],
+            "group_size_max": r["group_size_max"],
+        }
+        for r in rows.iterator()
+    }
+
+
+def _snapshot_offering_terms() -> dict:
+    rows = CourseOfferingTerm.objects.values(
+        "offering__code",
+        "semester__year",
+        "semester__term",
+        "credits",
+        "weekly_hours",
+        "exam_type",
+        "lecture_count",
+        "practice_count",
+        "practice_type",
+    )
+    return {
+        f"{r['offering__code']}|{r['semester__year']}-{r['semester__term']}": {
+            "credits": str(r["credits"]),
+            "weekly_hours": r["weekly_hours"],
+            "exam_type": r["exam_type"],
+            "lecture_count": r["lecture_count"],
+            "practice_count": r["practice_count"],
+            "practice_type": r["practice_type"],
+        }
+        for r in rows.iterator()
+    }
+
+
+def _snapshot_offering_specialities() -> dict:
+    rows = CourseOfferingSpeciality.objects.values(
+        "offering__code", "speciality__name", "type_kind"
+    )
+    return {
+        f"{r['offering__code']}|{r['speciality__name']}": {"type_kind": r["type_kind"]}
+        for r in rows.iterator()
+    }
+
+
+def _snapshot_students() -> dict:
+    rows = Student.objects.values(
+        "email",
+        "first_name",
+        "last_name",
+        "patronymic",
+        "education_level",
+        "speciality__name",
+        "program_start_academic_year_start",
+    )
+    return {
+        _student_key(r["email"], r["first_name"], r["last_name"], r["patronymic"]): {
+            "name": f"{r['last_name']} {r['first_name']} {r['patronymic']}".strip(),
+            "education_level": r["education_level"],
+            "speciality": r["speciality__name"],
+            "program_start": r["program_start_academic_year_start"],
+        }
+        for r in rows.iterator()
+    }
+
+
+def _snapshot_enrollments() -> dict:
+    rows = Enrollment.objects.values(
+        "offering__code",
+        "status",
+        "student__email",
+        "student__first_name",
+        "student__last_name",
+        "student__patronymic",
+    )
+    return {
+        "{}|{}".format(
+            r["offering__code"],
+            _student_key(
+                r["student__email"],
+                r["student__first_name"],
+                r["student__last_name"],
+                r["student__patronymic"],
+            ),
+        ): {"status": r["status"]}
+        for r in rows.iterator()
+    }
+
+
+SECTION_SNAPSHOTTERS = {
+    "faculties": _snapshot_faculties,
+    "departments": _snapshot_departments,
+    "specialities": _snapshot_specialities,
+    "semesters": _snapshot_semesters,
+    "courses": _snapshot_courses,
+    "offerings": _snapshot_offerings,
+    "offering_terms": _snapshot_offering_terms,
+    "offering_specialities": _snapshot_offering_specialities,
+    "students": _snapshot_students,
+    "enrollments": _snapshot_enrollments,
+}
+
+
+class Command(BaseCommand):
+    help = "Snapshot catalog tables into a JSON file keyed by natural keys (for ingestion diff)"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--out",
+            type=str,
+            default=str(settings.SCRAPER_STATE_DIR / "catalog_snapshot.json"),
+            help="Output JSON file",
+        )
+
+    def handle(self, *args, **options):
+        out_path = Path(options["out"])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+        snapshot = {}
+        for section, snapshotter in SECTION_SNAPSHOTTERS.items():
+            snapshot[section] = snapshotter()
+            logger.info("section_snapshotted", section=section, records=len(snapshot[section]))
+
+        with out_path.open("w", encoding="utf-8") as file:
+            json.dump(snapshot, file, ensure_ascii=False)
+
+        logger.info("catalog_snapshot_saved", path=str(out_path))

--- a/src/backend/scraper/management/commands/snapshot_catalog.py
+++ b/src/backend/scraper/management/commands/snapshot_catalog.py
@@ -22,10 +22,30 @@ from rating_app.models.course_offering_speciality import CourseOfferingSpecialit
 logger = structlog.get_logger(__name__)
 
 
-def _student_key(email: str, first_name: str, last_name: str, patronymic: str) -> str:
+def _student_key(
+    email: str,
+    first_name: str,
+    last_name: str,
+    patronymic: str,
+    education_level: str,
+    speciality: str | None,
+) -> str:
     if email:
         return email.lower()
-    return f"{last_name}|{first_name}|{patronymic}"
+    return f"{last_name}|{first_name}|{patronymic}|{education_level}|{speciality or ''}"
+
+
+def _collect_keyed(rows, build_key, build_value, section: str) -> dict:
+    result = {}
+    collisions = 0
+    for row in rows:
+        key = build_key(row)
+        if key in result:
+            collisions += 1
+        result[key] = build_value(row)
+    if collisions:
+        logger.warning("snapshot_key_collisions", section=section, collisions=collisions)
+    return result
 
 
 def _snapshot_faculties() -> dict:
@@ -154,15 +174,24 @@ def _snapshot_students() -> dict:
         "speciality__name",
         "program_start_academic_year_start",
     )
-    return {
-        _student_key(r["email"], r["first_name"], r["last_name"], r["patronymic"]): {
+    return _collect_keyed(
+        rows.iterator(),
+        lambda r: _student_key(
+            r["email"],
+            r["first_name"],
+            r["last_name"],
+            r["patronymic"],
+            r["education_level"],
+            r["speciality__name"],
+        ),
+        lambda r: {
             "name": f"{r['last_name']} {r['first_name']} {r['patronymic']}".strip(),
             "education_level": r["education_level"],
             "speciality": r["speciality__name"],
             "program_start": r["program_start_academic_year_start"],
-        }
-        for r in rows.iterator()
-    }
+        },
+        section="students",
+    )
 
 
 def _snapshot_enrollments() -> dict:
@@ -173,19 +202,25 @@ def _snapshot_enrollments() -> dict:
         "student__first_name",
         "student__last_name",
         "student__patronymic",
+        "student__education_level",
+        "student__speciality__name",
     )
-    return {
-        "{}|{}".format(
+    return _collect_keyed(
+        rows.iterator(),
+        lambda r: "{}|{}".format(
             r["offering__code"],
             _student_key(
                 r["student__email"],
                 r["student__first_name"],
                 r["student__last_name"],
                 r["student__patronymic"],
+                r["student__education_level"],
+                r["student__speciality__name"],
             ),
-        ): {"status": r["status"]}
-        for r in rows.iterator()
-    }
+        ),
+        lambda r: {"status": r["status"]},
+        section="enrollments",
+    )
 
 
 SECTION_SNAPSHOTTERS = {

--- a/src/backend/scraper/management/commands/test_diff_catalog_snapshots.py
+++ b/src/backend/scraper/management/commands/test_diff_catalog_snapshots.py
@@ -32,6 +32,15 @@ def test_diff_sections_added_removed_changed():
     }
 
 
+def test_diff_sections_detects_removed_fields():
+    before = {"offerings": {"123456": {"credits": "3.0", "max_groups": 2}}}
+    after = {"offerings": {"123456": {"credits": "3.0"}}}
+
+    diff = diff_sections(before, after)
+
+    assert diff["offerings"]["changed"] == {"123456": {"max_groups": {"before": 2, "after": None}}}
+
+
 def test_diff_sections_handles_missing_section():
     diff = diff_sections({}, {"faculties": {"FI": {}}})
 

--- a/src/backend/scraper/management/commands/test_diff_catalog_snapshots.py
+++ b/src/backend/scraper/management/commands/test_diff_catalog_snapshots.py
@@ -1,0 +1,50 @@
+from scraper.management.commands.diff_catalog_snapshots import diff_sections, render_report
+
+
+def test_diff_sections_identical_snapshots():
+    snapshot = {"courses": {"a|dep|BP": {"status": "ANNOUNCED"}}}
+
+    diff = diff_sections(snapshot, snapshot)
+
+    assert diff["courses"] == {"added": [], "removed": [], "changed": {}}
+
+
+def test_diff_sections_added_removed_changed():
+    before = {
+        "courses": {
+            "kept|dep|BP": {"status": "ANNOUNCED"},
+            "gone|dep|BP": {"status": "ANNOUNCED"},
+        }
+    }
+    after = {
+        "courses": {
+            "kept|dep|BP": {"status": "CONDUCTED"},
+            "new|dep|BP": {"status": "ANNOUNCED"},
+        }
+    }
+
+    diff = diff_sections(before, after)
+
+    assert diff["courses"]["added"] == ["new|dep|BP"]
+    assert diff["courses"]["removed"] == ["gone|dep|BP"]
+    assert diff["courses"]["changed"] == {
+        "kept|dep|BP": {"status": {"before": "ANNOUNCED", "after": "CONDUCTED"}}
+    }
+
+
+def test_diff_sections_handles_missing_section():
+    diff = diff_sections({}, {"faculties": {"FI": {}}})
+
+    assert diff["faculties"]["added"] == ["FI"]
+
+
+def test_render_report_contains_summary_and_details():
+    diff = diff_sections(
+        {"faculties": {"FI": {}}},
+        {"faculties": {"FI": {}, "FEN": {}}},
+    )
+
+    report = render_report(diff, full=False)
+
+    assert "| faculties | 1 | 0 | 0 |" in report
+    assert "- FEN" in report

--- a/src/backend/scraper/services/db_ingestion/injector.py
+++ b/src/backend/scraper/services/db_ingestion/injector.py
@@ -395,6 +395,9 @@ class CourseDbInjector(IDbInjector):
         )
         cached = self._student_cache.get(key)
         if cached:
+            self._merge_cached_program_start(
+                cached, student_data.program_start_academic_year_start
+            )
             return cached
 
         student_input = StudentInput(
@@ -417,6 +420,15 @@ class CourseDbInjector(IDbInjector):
 
         self._student_cache[key] = student
         return student
+
+    def _merge_cached_program_start(self, student: Student, incoming_year: int | None) -> None:
+        if incoming_year is None:
+            return
+        existing_year = student.program_start_academic_year_start
+        if existing_year is not None and existing_year <= incoming_year:
+            return
+        student.program_start_academic_year_start = incoming_year
+        student.save(update_fields=["program_start_academic_year_start"])
 
     def _get_or_create_speciality(self, speciality_name: str) -> Speciality | None:
         cached = self._speciality_cache.get(speciality_name)

--- a/src/backend/scraper/services/db_ingestion/injector.py
+++ b/src/backend/scraper/services/db_ingestion/injector.py
@@ -395,9 +395,7 @@ class CourseDbInjector(IDbInjector):
         )
         cached = self._student_cache.get(key)
         if cached:
-            self._merge_cached_program_start(
-                cached, student_data.program_start_academic_year_start
-            )
+            self._merge_cached_program_start(cached, student_data.program_start_academic_year_start)
             return cached
 
         student_input = StudentInput(

--- a/src/backend/scraper/services/deduplication/extractors.py
+++ b/src/backend/scraper/services/deduplication/extractors.py
@@ -126,9 +126,6 @@ class SemesterExtractor(Extractor[ParsedCourseDetails, list[DeduplicatedSemester
 
 
 class StudentExtractor(Extractor[ParsedCourseDetails, list[DeduplicatedEnrollment]]):
-    def __init__(self, *, reference_academic_year_start: int | None = None) -> None:
-        self.reference_academic_year_start = reference_academic_year_start
-
     def extract(self, data: ParsedCourseDetails) -> list[DeduplicatedEnrollment]:
         if not data.students:
             logger.debug(
@@ -164,14 +161,12 @@ class StudentExtractor(Extractor[ParsedCourseDetails, list[DeduplicatedEnrollmen
             index = getattr(student_row, "index", None)
             email = getattr(student_row, "email", None)
             specialty = getattr(student_row, "specialty", None)
-            course_year = getattr(student_row, "course", None)
             group = getattr(student_row, "group", None)
         elif isinstance(student_row, dict):
             name = student_row.get("name", "")
             index = student_row.get("index")
             email = student_row.get("email")
             specialty = student_row.get("specialty")
-            course_year = student_row.get("course")
             group = student_row.get("group")
         else:
             logger.warning("invalid_student_data_format", student_data=type(student_row))
@@ -199,9 +194,8 @@ class StudentExtractor(Extractor[ParsedCourseDetails, list[DeduplicatedEnrollmen
             email=email or "",
             speciality=specialty or "",
             education_level=self._extract_education_level(course_data.education_level),
-            program_start_academic_year_start=self._extract_program_start_year(
-                course_year=course_year,
-                academic_year=course_data.academic_year,
+            program_start_academic_year_start=self._extract_academic_year_start(
+                course_data.academic_year
             ),
             group=group or "",
         )
@@ -210,31 +204,6 @@ class StudentExtractor(Extractor[ParsedCourseDetails, list[DeduplicatedEnrollmen
 
     def _extract_education_level(self, raw_level: str | None) -> EducationLevel | None:
         return _parse_education_level(raw_level)
-
-    def _extract_program_start_year(
-        self,
-        *,
-        course_year: str | int | None,
-        academic_year: str | None,
-    ) -> int | None:
-        if not course_year:
-            return None
-
-        course_year_match = re.search(r"(\d+)", str(course_year))
-        if course_year_match is None:
-            return None
-
-        numeric_course_year = int(course_year_match.group(1))
-        if numeric_course_year <= 0:
-            return None
-
-        reference_year = self._extract_academic_year_start(academic_year)
-        if reference_year is None:
-            reference_year = self.reference_academic_year_start
-        if reference_year is None:
-            return None
-
-        return reference_year - (numeric_course_year - 1)
 
     def _extract_academic_year_start(self, academic_year: str | None) -> int | None:
         if not academic_year:

--- a/src/backend/scraper/services/deduplication/test_extractors.py
+++ b/src/backend/scraper/services/deduplication/test_extractors.py
@@ -164,7 +164,7 @@ def test_student_extractor_empty_students():
 
 
 def test_student_extractor_preserves_speciality_email_and_program_start_year():
-    extractor = StudentExtractor(reference_academic_year_start=2025)
+    extractor = StudentExtractor()
     course = ParsedCourseDetails(
         url="https://my.ukma.edu.ua/course/1",
         title="Test",
@@ -191,11 +191,11 @@ def test_student_extractor_preserves_speciality_email_and_program_start_year():
     assert student.speciality == "Комп`ютерні науки"
     assert student.email == "a.valenia@ukma.edu.ua"
     assert student.education_level == EducationLevel.BACHELOR
-    assert student.program_start_academic_year_start == 2023
+    assert student.program_start_academic_year_start == 2025
 
 
 def test_student_extractor_uses_course_academic_year_for_historical_offerings():
-    extractor = StudentExtractor(reference_academic_year_start=2025)
+    extractor = StudentExtractor()
     course = ParsedCourseDetails(
         url="https://my.ukma.edu.ua/course/2",
         title="Historical Course",
@@ -218,7 +218,7 @@ def test_student_extractor_uses_course_academic_year_for_historical_offerings():
     result = extractor.extract(course)
 
     assert len(result) == 1
-    assert result[0].student.program_start_academic_year_start == 2021
+    assert result[0].student.program_start_academic_year_start == 2023
 
 
 def test_specialty_extractor_success(sample_course):


### PR DESCRIPTION
## What

1. **Fix `program_start_academic_year_start` derivation.** SAZ's student "курс" column shows the student's *current* study year (frozen at final year for alumni), not their year at the time of the offering. The old formula `offering_academic_year - (курс - 1)` therefore produced wrong start years for anyone with multi-year history, and which wrong value stuck was first-record-wins. New rule: per-record value = the course page's academic year; the injector min-merges across records (including student-cache hits), so a student's start year converges to their earliest enrollment academic year.

2. **New catalog snapshot diff tooling** to review what an ingestion would change before applying it:
   - `manage.py snapshot_catalog --out file.json` — dumps all ingestion-touched tables (faculties, departments, specialities, semesters, courses, offerings, terms, offering-specialities, students, enrollments) keyed by natural keys (~2s on a prod-size DB)
   - `manage.py diff_catalog_snapshots before.json after.json --out report.md` — markdown report: per-section added/removed/changed counts, changed-field frequency, field-level before→after; writes a capped report plus an uncapped `.full.md`

## Verification

- Rehearsed end-to-end on a restored copy of the production DB: fresh full scrape (24k course pages → 7.2k grouped entries) → ingestion → snapshot diff reviewed section by section
- Fix verified against known-correct cases: affected students' start years converge to their earliest enrollment academic year; ~6.4k students corrected on the rehearsal copy (dominant deltas +1..+3 years, matching the old formula's over-subtraction)
- Ratings/comments/users byte-identical before vs after ingestion (ingestion is upsert-only, no deletes)
- `pytest scraper`: 207 passed; ruff check/format clean

## Note for deploy

Existing DB values were produced by the old formula and are lower than the truth, so min-merge alone won't heal them. A one-time backfill (recompute from each student's earliest enrollment semester) must run once after the next prod ingestion — SQL is in the deploy runbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to snapshot catalog data into a single JSON file and to compare two snapshots with a readable Markdown diff report.
  * Diff reports include a capped example view by default, with an option to generate the full detailed report.

* **Bug Fixes**
  * Improved student “program start” year handling to preserve the earliest known value and reconcile cached entries consistently.
  * Updated student extraction to compute program start from course academic year for more consistent results.

* **Tests**
  * Added/updated tests to cover snapshot diff output and revised program start year expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->