### PR TITLE
chore(#628): add scraper/ to pyright include and fix type errors

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -140,7 +140,7 @@ skips = ["B108"]
 
 # Run via `uv run pyright`; see AGENTS.md
 [tool.pyright]
-include = ["rating_app", "rateukma"]
+include = ["rating_app", "rateukma", "scraper"]
 exclude = [
     "**/migrations",
     "**/test_*.py",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -145,6 +145,7 @@ exclude = [
     "**/migrations",
     "**/test_*.py",
     "**/tests",
+    "**/conftest.py",
     "rating_app/management/commands/generate_mock_data.py",
 ]
 typeCheckingMode = "standard"

--- a/src/backend/scraper/parsers/catalog.py
+++ b/src/backend/scraper/parsers/catalog.py
@@ -1,19 +1,19 @@
-import logging
 import re
 from collections.abc import Iterator
 from urllib.parse import parse_qs, urljoin, urlparse
 
+import structlog
 from bs4 import BeautifulSoup, Tag
 
 from .base import BaseParser
 
 COURSE_LINK_SELECTOR = "a[href^='/course/']"
 COURSE_PATH_PATTERN = re.compile(r"^/course/(\d+)$")
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class CourseLinkParser(BaseParser):
-    def parse(self, html: str, base_url: str) -> list[str]:
+    def parse(self, html: str, base_url: str = "", **kwargs) -> list[str]:
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string")
 
@@ -72,7 +72,7 @@ class CatalogParser(BaseParser):
     def __init__(self):
         self.course_link_parser = CourseLinkParser()
 
-    def parse(self, html: str, base_url: str) -> tuple[list[str], int | None]:
+    def parse(self, html: str, base_url: str = "", **kwargs) -> tuple[list[str], int | None]:
         if not base_url or not isinstance(base_url, str):
             raise ValueError("base_url must be a non-empty string")
 

--- a/src/backend/scraper/services/db_ingestion/injector.py
+++ b/src/backend/scraper/services/db_ingestion/injector.py
@@ -67,6 +67,10 @@ class IDbInjector(IOperation[[Sequence[_T]]]):
 
     def execute(self, models: Sequence[_T]) -> None: ...
 
+    def reset_state(self) -> None: ...
+
+    def set_batch_number(self, batch_number: int) -> None: ...
+
 
 class CourseDbInjector(IDbInjector):
     def __init__(
@@ -193,7 +197,9 @@ class CourseDbInjector(IDbInjector):
                 title=course_data.title,
                 description=course_data.description or "",
                 status=CourseStatus(course_data.status.value),
-                education_level=course_data.education_level,
+                education_level=EducationLevel(course_data.education_level.value)
+                if course_data.education_level
+                else None,
                 department=str(department.id),
                 department_name=department.name,
                 faculty=str(faculty.id),

--- a/src/backend/scraper/services/deduplication/grouper.py
+++ b/src/backend/scraper/services/deduplication/grouper.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from typing import Any
+
 import structlog
 
 from ...models import ParsedCourseDetails
@@ -5,9 +8,12 @@ from ...models.deduplicated import (
     DeduplicatedCourse,
     DeduplicatedCourseOffering,
     DeduplicatedCourseOfferingTerm,
+    DeduplicatedSemester,
+    ExamType,
+    PracticeType,
     SemesterTerm,
 )
-from .base import DataValidationError, DeduplicationComponent
+from .base import DataValidationError, DeduplicationComponent, Extractor
 from .extractors import (
     CourseLimitsExtractor,
     CreditsExtractor,
@@ -63,9 +69,25 @@ def get_course_grouping_key(course: ParsedCourseDetails) -> tuple[str, str, str,
     return (title, faculty, specialty_info, education_level)
 
 
+@dataclass(frozen=True)
+class OfferingTermDetails:
+    credits: float
+    weekly_hours: int
+    lecture_count: int | None
+    practice_count: int | None
+    exam_type: ExamType
+    practice_type: PracticeType | None
+
+
+@dataclass(frozen=True)
+class TermDetail:
+    semester: DeduplicatedSemester
+    details: OfferingTermDetails
+
+
 class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[DeduplicatedCourse]]):
     def __init__(self):
-        self.extractors = {
+        self.extractors: dict[str, Extractor[ParsedCourseDetails, Any]] = {
             "title": RequiredFieldExtractor("title"),
             "description": DescriptionExtractor(),
             "status": StatusExtractor(),
@@ -249,20 +271,20 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
                 continue
 
             representative_term = self._select_representative_term(term_details)
-            representative_details = representative_term["details"]
-            representative_semester = representative_term["semester"]
+            representative_details = representative_term.details
+            representative_semester = representative_term.semester
 
             offering = DeduplicatedCourseOffering(
                 code=self.extractors["code"].extract(course),
                 semester=representative_semester,
                 credits=self._resolve_total_offering_credits(course, term_details),
-                weekly_hours=representative_details["weekly_hours"],
+                weekly_hours=representative_details.weekly_hours,
                 study_year=course.year,
                 enrollments=self.extractors["enrollments"].extract(course),
-                exam_type=representative_details["exam_type"],
-                lecture_count=representative_details["lecture_count"],
-                practice_count=representative_details["practice_count"],
-                practice_type=representative_details["practice_type"],
+                exam_type=representative_details.exam_type,
+                lecture_count=representative_details.lecture_count,
+                practice_count=representative_details.practice_count,
+                practice_type=representative_details.practice_type,
                 max_students=limits["max_students"],
                 max_groups=limits["max_groups"],
                 group_size_min=limits["group_size_min"],
@@ -270,13 +292,13 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
                 specialities=course_specialities,
                 terms=[
                     DeduplicatedCourseOfferingTerm(
-                        semester=item["semester"],
-                        credits=item["details"]["credits"],
-                        weekly_hours=item["details"]["weekly_hours"],
-                        lecture_count=item["details"]["lecture_count"],
-                        practice_count=item["details"]["practice_count"],
-                        practice_type=item["details"]["practice_type"],
-                        exam_type=item["details"]["exam_type"],
+                        semester=item.semester,
+                        credits=item.details.credits,
+                        weekly_hours=item.details.weekly_hours,
+                        lecture_count=item.details.lecture_count,
+                        practice_count=item.details.practice_count,
+                        practice_type=item.details.practice_type,
+                        exam_type=item.details.exam_type,
                     )
                     for item in term_details
                 ],
@@ -288,42 +310,24 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
     def _build_term_details(
         self,
         course: ParsedCourseDetails,
-        semesters,
-    ) -> list[dict[str, object]]:
-        term_details: list[dict[str, object]] = []
+        semesters: list[DeduplicatedSemester],
+    ) -> list[TermDetail]:
+        term_details: list[TermDetail] = []
         for semester in semesters:
             offering_details = self._build_offering_details(course, semester)
-            term_credits = offering_details["credits"]
-
-            if term_credits is None or term_credits <= 0:
-                logger.warning(
-                    "offering_term_creation_skipped",
-                    reason="invalid_offering_credits",
-                    course_id=course.id,
-                    course_title=course.title,
-                    semester_term=semester.term.value,
-                    semester_year=semester.year,
-                    credits=term_credits,
-                )
+            if offering_details is None:
                 continue
 
-            term_details.append(
-                {
-                    "semester": semester,
-                    "details": offering_details,
-                }
-            )
+            term_details.append(TermDetail(semester=semester, details=offering_details))
 
         return term_details
 
-    def _select_representative_term(
-        self, term_details: list[dict[str, object]]
-    ) -> dict[str, object]:
+    def _select_representative_term(self, term_details: list[TermDetail]) -> TermDetail:
         return max(
             term_details,
             key=lambda item: (
-                item["semester"].year,
-                self._term_rank(item["semester"].term),
+                item.semester.year,
+                self._term_rank(item.semester.term),
             ),
         )
 
@@ -337,13 +341,13 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
     def _resolve_total_offering_credits(
         self,
         course: ParsedCourseDetails,
-        term_details: list[dict[str, object]],
+        term_details: list[TermDetail],
     ) -> float:
         total_credits = self.extractors["credits"].extract(course)
         if total_credits and total_credits > 0:
             return total_credits
 
-        return float(sum(item["details"]["credits"] for item in term_details))
+        return float(sum(item.details.credits for item in term_details))
 
     def _validate_course_for_transformation(self, course: ParsedCourseDetails) -> None:
         if not course.academic_year:
@@ -352,8 +356,8 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
     def _build_offering_details(
         self,
         course: ParsedCourseDetails,
-        semester,
-    ) -> dict[str, object]:
+        semester: DeduplicatedSemester,
+    ) -> OfferingTermDetails | None:
         season_info = self._get_season_info(course, semester.term)
         course_credits = self.extractors["credits"].extract(course)
         season_credits = season_info.credits if season_info else None
@@ -377,14 +381,26 @@ class CourseGrouper(DeduplicationComponent[list[ParsedCourseDetails], list[Dedup
             else self.extractors["practice_type"].extract(course)
         )
 
-        return {
-            "credits": resolved_credits,
-            "weekly_hours": weekly_hours,
-            "lecture_count": season_info.lecture_hours if season_info else None,
-            "practice_count": season_info.practice_hours if season_info else None,
-            "exam_type": exam_type,
-            "practice_type": practice_type,
-        }
+        if resolved_credits is None or resolved_credits <= 0:
+            logger.warning(
+                "offering_term_creation_skipped",
+                reason="invalid_offering_credits",
+                course_id=course.id,
+                course_title=course.title,
+                semester_term=semester.term.value,
+                semester_year=semester.year,
+                credits=resolved_credits,
+            )
+            return None
+
+        return OfferingTermDetails(
+            credits=resolved_credits,
+            weekly_hours=weekly_hours,
+            lecture_count=season_info.lecture_hours if season_info else None,
+            practice_count=season_info.practice_hours if season_info else None,
+            exam_type=exam_type,
+            practice_type=practice_type,
+        )
 
     def _get_season_info(self, course: ParsedCourseDetails, term: SemesterTerm):
         if not course.season_details:


### PR DESCRIPTION
## What

Extends pyright coverage (adopted in #628) to the `scraper` package: `include = ["rating_app", "rateukma", "scraper"]`, and fixes the 26 errors it surfaced:

- **catalog parser** — was using stdlib `logging` with structlog-style kwargs (`logger.debug("...", err=exc, href=...)`), which raises `TypeError` at runtime when those except-paths fire. Switched to structlog like every other scraper module. Also aligned `parse()` overrides with the `BaseParser` signature.
- **grouper** — term details were passed around as `dict[str, object]` bags; replaced with frozen dataclasses `OfferingTermDetails` / `TermDetail`. Credits validation moved into `_build_offering_details` (returns `None` for invalid terms) — same logging, same skip behavior, now type-safe. Extractor registry annotated explicitly.
- **injector** — scraper's `EducationLevel` enum was passed where rating_app's `EducationLevel` is expected (worked at runtime via str-enum value equality, invisible to the type checker); now converted explicitly. `reset_state`/`set_batch_number` declared on the `IDbInjector` protocol — the composite already calls them behind `hasattr` guards.

## Verification

- `uv run pyright`: 0 errors, 0 warnings (was 26 errors with scraper included)
- Full backend suite: 609 passed
- ruff check + format: clean

No behavior changes intended; the only observable difference is the catalog parser's debug/warning logs no longer being a latent TypeError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course data import and deduplication so course credits and education-level values are handled more consistently.
  * Fixed parsing behavior for catalog pages to better support course links and related page data.
* **Refactor**
  * Streamlined internal course grouping and parsing logic, which should make the scraper more reliable and easier to maintain.
* **Chores**
  * Expanded project analysis coverage to include the scraper package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->