### PR TITLE
docs(#623): correct the waffle CLI, drop the unused test flag

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -3,6 +3,30 @@
 How to add, toggle, and remove feature flags in rate-ukma. The rationale lives
 in [ADR-0009](architecture/decisions/0009-feature-flags.md); this is the how-to.
 
+## When a flag is worth it
+
+A flag is debt with a deletion date, not a default. A client-facing one costs an
+allowlist entry, a branch in the frontend, both states to test, and a cleanup PR
+later; a server-only one costs the branch and the cleanup. Reach for either only
+when the change is genuinely hard to land in a single safe step:
+
+- **Trunk-based development** — the work merges to `main` in several PRs and is
+  half-finished in between. The flag keeps the unfinished half invisible so the
+  branch never has to live for weeks.
+- **A large or risky change to existing behaviour** — a rewritten form, a new
+  write path, a schema migration with a backfill behind it. The flag lets you
+  deploy the code and turn it on separately, and turn it off without a rollback.
+- **You need to see it in production before everyone else does** — target
+  yourself or a few accounts, look at real data, then widen.
+
+Do **not** add a flag for a self-contained change that is safe once merged, a
+bug fix, copy or styling, or anything you would never realistically turn back
+off. Ship those normally. A flag nobody will ever flip is a permanent `if` in
+the code and a row nobody dares delete.
+
+Rule of thumb: if you cannot say what would make you turn it **off** again, you
+do not need it.
+
 ## Model in one minute
 
 - Backend uses [**django-waffle**](https://waffle.readthedocs.io/). Flags are DB
@@ -36,17 +60,27 @@ it ships with a deploy. **Toggling** an already-exposed flag is runtime-only
 1. **Allowlist it** — add the name to `PUBLIC_FEATURE_FLAGS` in
    `src/backend/rateukma/settings/_base.py`:
    ```python
-   PUBLIC_FEATURE_FLAGS = ["fe_test_header", "fe_my_new_flag"]
+   PUBLIC_FEATURE_FLAGS = ["fe_my_new_flag"]
    ```
    No new endpoint, serializer, or OpenAPI regen needed — the response schema is
    a dynamic `Record<string, boolean>`, so it does not change when flags are
    added.
 
-2. **Create the `Flag` row** in each environment (default off): Django admin
-   (Waffle ▸ Flags) or CLI —
+2. **Create the `Flag` row** in each environment: Django admin (Waffle ▸ Flags)
+   or CLI —
    ```bash
-   .venv/bin/python manage.py waffle_flag fe_my_new_flag --everyone off
+   .venv/bin/python manage.py waffle_flag fe_my_new_flag --create
    ```
+   `--create` is required; without it the command errors on a flag that does not
+   exist yet. A fresh row has `everyone = NULL`, which means "decide per user"
+   and evaluates to off for everyone until you target someone.
+
+   The row is **not** needed to deploy with the feature off. A missing flag
+   falls back to `WAFFLE_FLAG_DEFAULT`, which this project leaves unset, so
+   waffle's own default of `False` applies and `/api/v1/flags/` reports it as
+   `false`. Create the row when you want the switch to exist, not to keep the
+   feature hidden.
+
    For a reproducible demo across envs, ship a data migration that creates it.
 
 3. **Gate the UI** in the frontend:
@@ -91,13 +125,36 @@ Runtime, no deploy. Django admin (Waffle ▸ Flags) or CLI. A `Flag` supports:
 - `staff` / `superusers` / `authenticated` — role targeting.
 
 ```bash
-.venv/bin/python manage.py waffle_flag fe_my_new_flag --everyone on
+.venv/bin/python manage.py waffle_flag -l                    # current state
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --user me@ukma.edu.ua
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --user you@ukma.edu.ua --append
 .venv/bin/python manage.py waffle_flag fe_my_new_flag --percent 25
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --everyone     # on for all
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --deactivate   # off for all
 ```
 
-> Live env runs `sudo docker exec <backend-container> ...`; dump the DB before
-> any write. Anonymous users get waffle's `AnonymousUser` defaults
-> (`WAFFLE_FLAG_DEFAULT`, currently off).
+Two things that bite:
+
+- **`--user` replaces the whole list** unless you pass `--append`. Same for
+  `--group`. Adding a second tester without `--append` silently removes the
+  first.
+- **`--everyone` and `--deactivate` take no argument.** They set `everyone` to
+  true and false. Leaving it `NULL` is the third state, and the only one where
+  the per-user and per-group lists are consulted at all — setting `--everyone`
+  or `--deactivate` overrides them for everybody.
+
+The usual rollout: create the row, target yourself, verify against real
+production data, widen to a group or a percentage, then `--everyone`.
+
+```bash
+.venv/bin/python manage.py waffle_flag fe_my_new_flag --create --user me@ukma.edu.ua
+```
+
+> Live env runs `sudo docker exec <container> python manage.py ...` (the image
+> has Python on PATH, no venv prefix); dump the
+> DB before any write. Anonymous users get waffle's `AnonymousUser` defaults
+> (`WAFFLE_FLAG_DEFAULT`, currently off), so a per-user flag is invisible to
+> logged-out visitors regardless of the list.
 
 ## Override a flag in the browser (QA / Playwright)
 
@@ -144,6 +201,9 @@ Cover both variants by setting the flag on in one spec and off in another (see
       ...
   ```
   Always test **both** states. See `src/backend/rating_app/views/test_flags.py`.
+
+The flag gates what the UI renders, not what the API accepts: the backend does
+not check it, so a rating can carry instructor links while the flag is off.
 - **Frontend** — pass `flags` to `renderWithProviders`, which seeds the
   `FeatureFlagsContext` directly (no network, no mock):
   ```tsx
@@ -155,9 +215,15 @@ Cover both variants by setting the flag on in one spec and off in another (see
 
 ## Remove a flag (do not skip)
 
-Flags are temporary debt. Once a feature is fully rolled out or dropped:
+Flags are temporary debt, and the deletion is the part everyone skips. Once a
+feature is fully rolled out or dropped:
 
 1. Delete the consumer code on both sides (the `flag_is_active` /
    `useFeatureFlag` call and the dead branch).
 2. Remove the name from `PUBLIC_FEATURE_FLAGS`.
-3. Delete the `Flag` row in each environment.
+3. Delete the `Flag` row in each environment (Django admin, or the ORM — there
+   is no `waffle_flag --delete`).
+
+Do steps 1 and 2 together in one PR. A row left behind with no consumer is
+harmless; an allowlisted name with no consumer is a permanently `false` entry in
+every `/api/v1/flags/` response.

--- a/src/backend/rateukma/settings/_base.py
+++ b/src/backend/rateukma/settings/_base.py
@@ -319,4 +319,4 @@ PARSE_BASE_URL = "https://my.ukma.edu.ua"
 # ONLY when added to this allowlist in a reviewed PR — the endpoint fails closed,
 # so server-only flags can never leak through a naming mistake. `fe_` is a soft
 # naming convention for client-facing flags, not the security boundary.
-PUBLIC_FEATURE_FLAGS = ["fe_test_header", "fe_instructor_multiselect"]
+PUBLIC_FEATURE_FLAGS = ["fe_instructor_multiselect"]

--- a/src/backend/rating_app/views/test_flags.py
+++ b/src/backend/rating_app/views/test_flags.py
@@ -7,41 +7,41 @@ FLAGS_URL = "/api/v1/flags/"
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_flags_accessible_anonymously(api_client, settings):
-    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_example"]
 
     response = api_client.get(FLAGS_URL)
 
     assert response.status_code == 200
-    assert "fe_test_header" in response.json()["flags"]
+    assert "fe_example" in response.json()["flags"]
 
 
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_flags_reflect_active_state(api_client, settings):
-    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
-    Flag.objects.create(name="fe_test_header", everyone=True)
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_example"]
+    Flag.objects.create(name="fe_example", everyone=True)
 
     response = api_client.get(FLAGS_URL)
 
     assert response.status_code == 200
-    assert response.json()["flags"]["fe_test_header"] is True
+    assert response.json()["flags"]["fe_example"] is True
 
 
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_flags_default_to_false_when_not_created(api_client, settings):
-    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_example"]
 
     response = api_client.get(FLAGS_URL)
 
     assert response.status_code == 200
-    assert response.json()["flags"]["fe_test_header"] is False
+    assert response.json()["flags"]["fe_example"] is False
 
 
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_flags_response_is_not_cacheable(api_client, settings):
-    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_example"]
 
     response = api_client.get(FLAGS_URL)
 
@@ -52,7 +52,7 @@ def test_flags_response_is_not_cacheable(api_client, settings):
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_non_allowlisted_flag_is_never_exposed(api_client, settings):
-    settings.PUBLIC_FEATURE_FLAGS = ["fe_test_header"]
+    settings.PUBLIC_FEATURE_FLAGS = ["fe_example"]
     Flag.objects.create(name="fe_secret_internal", everyone=True)
 
     response = api_client.get(FLAGS_URL)

--- a/src/webapp/src/components/Header/Header.tsx
+++ b/src/webapp/src/components/Header/Header.tsx
@@ -6,7 +6,6 @@ import { useTheme } from "@/components/ThemeProvider";
 import { NotificationBell } from "@/features/notifications/components/NotificationBell";
 import { useAuth } from "@/lib/auth";
 import { lockBodyScroll } from "@/lib/body-scroll-lock";
-import { useFeatureFlag } from "@/lib/feature-flags";
 import { testIds } from "@/lib/test-ids";
 import { HeaderNav } from "./HeaderNav";
 import { MobileMenu } from "./MobileMenu";
@@ -21,7 +20,6 @@ export default function Header() {
 	const { status, user, logout } = useAuth();
 	const { theme, setTheme } = useTheme();
 	const isAuthenticated = status === "authenticated";
-	const showTestFlag = useFeatureFlag("fe_test_header");
 
 	useEffect(() => {
 		if (typeof document === "undefined") {
@@ -59,15 +57,6 @@ export default function Header() {
 			>
 				<div className="container mx-auto px-6 max-w-7xl flex h-16 items-center justify-between">
 					<Logo />
-
-					{showTestFlag && (
-						<span
-							className="ml-2 text-sm font-medium text-muted-foreground"
-							data-testid={testIds.header.testFlag}
-						>
-							Test
-						</span>
-					)}
 
 					<div className="flex items-center justify-center flex-1">
 						<HeaderNav

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -46,14 +46,14 @@ describe("feature flags", () => {
 		localStorage.clear(); // drop any ff:overrides leaked from other tests
 		authState.current = { status: "unauthenticated", user: null };
 		mockUseFlagsList.mockReturnValue({
-			data: { flags: { fe_test_header: true } },
+			data: { flags: { fe_example: true } },
 			isSuccess: true,
 			isError: false,
 		});
 	});
 
 	it("returns true for an enabled flag", () => {
-		const { result } = renderHook(() => useFeatureFlag("fe_test_header"), {
+		const { result } = renderHook(() => useFeatureFlag("fe_example"), {
 			wrapper,
 		});
 		expect(result.current).toBe(true);
@@ -72,7 +72,7 @@ describe("feature flags", () => {
 			isSuccess: false,
 			isError: false,
 		});
-		const { result } = renderHook(() => useFeatureFlagState("fe_test_header"), {
+		const { result } = renderHook(() => useFeatureFlagState("fe_example"), {
 			wrapper,
 		});
 		expect(result.current).toEqual({ enabled: false, isReady: false });
@@ -111,7 +111,7 @@ describe("feature flags", () => {
 	});
 
 	it("throws when used outside the provider", () => {
-		expect(() => renderHook(() => useFeatureFlag("fe_test_header"))).toThrow(
+		expect(() => renderHook(() => useFeatureFlag("fe_example"))).toThrow(
 			/within a FeatureFlagsProvider/,
 		);
 	});

--- a/src/webapp/src/lib/test-ids.ts
+++ b/src/webapp/src/lib/test-ids.ts
@@ -90,7 +90,6 @@ export const testIds = {
 		userMenu: "header-user-menu",
 		userMenuTrigger: "header-user-menu-trigger",
 		logoutButton: "header-logout-button",
-		testFlag: "header-test-flag",
 	},
 
 	// Courses page


### PR DESCRIPTION
The CLI recipe in `docs/feature-flags.md` did not work: `--everyone off` takes no
argument, and creating a row needs `--create`.

Adds a short section on when a flag is worth its debt, documents per-user
targeting and the `--append` trap, and records that a `Flag` row is not needed to
deploy with a feature off.

Also removes `fe_test_header`. It was allowlisted and rendered a span in the
header, but no environment ever had a `Flag` row for it, so it always evaluated
false and shipped in every `/api/v1/flags/` response. `fe_instructor_multiselect`
is now the only public flag.

Refs #623
