### PR TITLE
fix(#654): education level courses filter

### DIFF
--- a/src/backend/rating_app/repositories/course_repository.py
+++ b/src/backend/rating_app/repositories/course_repository.py
@@ -282,6 +282,9 @@ class CourseRepository(
         if filters.name:
             courses = self._apply_name_filter(courses, filters.name)
 
+        if filters.education_level:
+            course_filters["education_level"] = filters.education_level
+
         if filters.faculty:
             course_filters["department__faculty_id"] = filters.faculty
 

--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -44,6 +44,24 @@ def test_filter_by_instructor_returns_only_assigned_courses(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_filter_by_education_level_returns_correct_courses(repo):
+    # Arrange
+    master_course = CourseFactory(education_level = EducationLevel.MASTER)
+    _bachelor_course = CourseFactory(education_level = EducationLevel.BACHELOR)
+
+    # Act
+    filters = CourseFilterCriteriaInternal(education_level=EducationLevel.MASTER)
+    result = repo.filter(filters)
+
+    # Assert
+    assert len(result) == 1
+    returned_ids = {course.id for course in result}
+    assert returned_ids == {str(master_course.id)}
+    assert result[0].title == master_course.title
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_filter_by_semester_limits_to_matching_courses(repo):
     # Arrange
     fall_semester = SemesterFactory(term=SemesterTerm.FALL, year=2024)

--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -46,8 +46,8 @@ def test_filter_by_instructor_returns_only_assigned_courses(repo):
 @pytest.mark.integration
 def test_filter_by_education_level_returns_correct_courses(repo):
     # Arrange
-    master_course = CourseFactory(education_level = EducationLevel.MASTER)
-    _bachelor_course = CourseFactory(education_level = EducationLevel.BACHELOR)
+    master_course = CourseFactory(education_level=EducationLevel.MASTER)
+    _bachelor_course = CourseFactory(education_level=EducationLevel.BACHELOR)
 
     # Act
     filters = CourseFilterCriteriaInternal(education_level=EducationLevel.MASTER)


### PR DESCRIPTION
## Summary
Courses were not filtered by education level. The fix is simple: add filtering by education level on repo level.
Resolves #654

## Testing
Run `test_filter_by_education_level_returns_correct_courses`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course filtering now correctly limits results by the selected education level.
  * Selecting a master’s-level filter no longer returns bachelor’s-level courses.

* **Tests**
  * Added coverage to verify education-level filtering returns only matching courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->