### PR TITLE
feat(#642): initial feed UI

### DIFF
--- a/src/webapp/pnpm-lock.yaml
+++ b/src/webapp/pnpm-lock.yaml
@@ -26,7 +26,7 @@ overrides:
   yaml@<2.0.0: 1.10.3
   yaml@>=2.0.0 <3.0.0: 2.8.3
   markdown-it: 14.2.0
-  fast-uri: 3.1.5
+  fast-uri: 3.1.7
   brace-expansion: 5.0.9
   js-yaml: 4.3.1
   postcss: 8.5.23
@@ -3134,8 +3134,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6866,7 +6866,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7433,7 +7433,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:

--- a/src/webapp/pnpm-workspace.yaml
+++ b/src/webapp/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ overrides:
   yaml@<2.0.0: 1.10.3
   yaml@>=2.0.0 <3.0.0: 2.8.3
   markdown-it: 14.2.0
-  fast-uri: 3.1.5
+  fast-uri: 3.1.7
   brace-expansion: 5.0.9
   js-yaml: 4.3.1
   postcss: 8.5.23

--- a/src/webapp/src/features/feed/components/FeedPromoItem.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedPromoItem.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { FeedPromoItem as FeedPromoItemType } from "../feedTypes";
+import { FeedPromoItem } from "./FeedPromoItem";
+
+const baseItem: FeedPromoItemType = {
+	kind: "promo",
+	id: "p1",
+	createdAt: new Date().toISOString(),
+	title: "Хакатон факультету інформатики",
+	body: "48 годин, 12–14 вересня.",
+	label: "Подія",
+	ctaLabel: "Зареєструватися",
+	ctaHref: "https://example.com/hack",
+	accent: "info",
+};
+
+describe("FeedPromoItem", () => {
+	it("renders the label, title, body and CTA link", () => {
+		render(<FeedPromoItem item={baseItem} />);
+
+		expect(screen.getByText("Подія")).toBeInTheDocument();
+		expect(
+			screen.getByText("Хакатон факультету інформатики"),
+		).toBeInTheDocument();
+		expect(screen.getByText("48 годин, 12–14 вересня.")).toBeInTheDocument();
+
+		const cta = screen.getByRole("link", { name: /Зареєструватися/ });
+		expect(cta).toHaveAttribute("href", "https://example.com/hack");
+	});
+
+	it("falls back to the default label when none is provided", () => {
+		render(<FeedPromoItem item={{ ...baseItem, label: undefined }} />);
+
+		expect(screen.getByText("Оголошення")).toBeInTheDocument();
+	});
+
+	it("omits the CTA when there is no ctaLabel", () => {
+		render(<FeedPromoItem item={{ ...baseItem, ctaLabel: undefined }} />);
+
+		expect(screen.queryByRole("link")).not.toBeInTheDocument();
+	});
+});

--- a/src/webapp/src/features/feed/components/FeedPromoItem.tsx
+++ b/src/webapp/src/features/feed/components/FeedPromoItem.tsx
@@ -1,0 +1,103 @@
+import { ArrowRight, Megaphone } from "lucide-react";
+
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { cn } from "@/lib/utils";
+import type {
+	FeedPromoAccent,
+	FeedPromoItem as FeedPromoItemType,
+} from "../feedTypes";
+
+/**
+ * Accent -> color treatment. Manual content is deliberately louder than the
+ * review stream: tinted background, colored left rail, and an explicit label
+ * badge so it never gets mistaken for organic activity.
+ */
+const ACCENT_STYLES: Record<
+	FeedPromoAccent,
+	{ container: string; rail: string; badge: string }
+> = {
+	brand: {
+		container: "bg-primary/5 border-primary/20",
+		rail: "bg-primary",
+		badge: "bg-primary text-primary-foreground",
+	},
+	info: {
+		container:
+			"bg-blue-50 border-blue-200 dark:bg-blue-950/40 dark:border-blue-900",
+		rail: "bg-blue-500",
+		badge: "bg-blue-500 text-white",
+	},
+	warning: {
+		container:
+			"bg-amber-50 border-amber-200 dark:bg-amber-950/40 dark:border-amber-900",
+		rail: "bg-amber-500",
+		badge: "bg-amber-500 text-white",
+	},
+};
+
+interface FeedPromoItemProps {
+	readonly item: FeedPromoItemType;
+	/** `banner` is wider/horizontal for top-of-page placement. */
+	readonly variant?: "card" | "banner";
+}
+
+export function FeedPromoItem({ item, variant = "card" }: FeedPromoItemProps) {
+	const accent = ACCENT_STYLES[item.accent ?? "brand"];
+	const label = item.label ?? "Оголошення";
+	const isBanner = variant === "banner";
+
+	return (
+		<article
+			className={cn(
+				"relative overflow-hidden rounded-xl border shadow-sm",
+				accent.container,
+				isBanner
+					? "flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between"
+					: "p-5",
+			)}
+		>
+			<span
+				className={cn("absolute inset-y-0 left-0 w-1", accent.rail)}
+				aria-hidden
+			/>
+
+			<div className={cn("min-w-0", isBanner ? "flex-1 pl-2" : "pl-2")}>
+				<div className="flex items-center gap-2">
+					<Badge
+						className={cn(
+							"gap-1 border-transparent text-[10px] uppercase tracking-wide",
+							accent.badge,
+						)}
+					>
+						<Megaphone className="size-3" />
+						{label}
+					</Badge>
+				</div>
+
+				<h3 className="mt-3 font-semibold leading-tight tracking-tight">
+					{item.title}
+				</h3>
+				<p
+					className={cn(
+						"mt-2 text-sm text-muted-foreground",
+						isBanner ? "" : "line-clamp-2",
+					)}
+				>
+					{item.body}
+				</p>
+			</div>
+
+			{item.ctaLabel && (
+				<div className={cn(isBanner ? "shrink-0 pl-2 sm:pl-0" : "mt-4 pl-2")}>
+					<Button asChild size="sm" className="gap-1.5">
+						<a href={item.ctaHref ?? "#"}>
+							{item.ctaLabel}
+							<ArrowRight className="size-4" />
+						</a>
+					</Button>
+				</div>
+			)}
+		</article>
+	);
+}

--- a/src/webapp/src/features/feed/components/FeedPromoItem.tsx
+++ b/src/webapp/src/features/feed/components/FeedPromoItem.tsx
@@ -9,30 +9,28 @@ import type {
 } from "../feedTypes";
 
 /**
- * Accent -> color treatment. Manual content is deliberately louder than the
- * review stream: tinted background, colored left rail, and an explicit label
- * badge so it never gets mistaken for organic activity.
+ * Accent -> color treatment.
  */
+type BadgeVariant = "default" | "secondary" | "destructive";
+
 const ACCENT_STYLES: Record<
 	FeedPromoAccent,
-	{ container: string; rail: string; badge: string }
+	{ container: string; rail: string; badge: BadgeVariant }
 > = {
 	brand: {
 		container: "bg-primary/5 border-primary/20",
 		rail: "bg-primary",
-		badge: "bg-primary text-primary-foreground",
+		badge: "default",
 	},
 	info: {
-		container:
-			"bg-blue-50 border-blue-200 dark:bg-blue-950/40 dark:border-blue-900",
-		rail: "bg-blue-500",
-		badge: "bg-blue-500 text-white",
+		container: "bg-accent border-border",
+		rail: "bg-muted-foreground",
+		badge: "secondary",
 	},
 	warning: {
-		container:
-			"bg-amber-50 border-amber-200 dark:bg-amber-950/40 dark:border-amber-900",
-		rail: "bg-amber-500",
-		badge: "bg-amber-500 text-white",
+		container: "bg-destructive/5 border-destructive/20",
+		rail: "bg-destructive",
+		badge: "destructive",
 	},
 };
 
@@ -54,7 +52,7 @@ export function FeedPromoItem({ item, variant = "card" }: FeedPromoItemProps) {
 				accent.container,
 				isBanner
 					? "flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between"
-					: "p-5",
+					: "flex h-full flex-col p-5",
 			)}
 		>
 			<span
@@ -65,10 +63,8 @@ export function FeedPromoItem({ item, variant = "card" }: FeedPromoItemProps) {
 			<div className={cn("min-w-0", isBanner ? "flex-1 pl-2" : "pl-2")}>
 				<div className="flex items-center gap-2">
 					<Badge
-						className={cn(
-							"gap-1 border-transparent text-[10px] uppercase tracking-wide",
-							accent.badge,
-						)}
+						variant={accent.badge}
+						className="gap-1 text-[10px] uppercase tracking-wide"
 					>
 						<Megaphone className="size-3" />
 						{label}
@@ -89,7 +85,11 @@ export function FeedPromoItem({ item, variant = "card" }: FeedPromoItemProps) {
 			</div>
 
 			{item.ctaLabel && (
-				<div className={cn(isBanner ? "shrink-0 pl-2 sm:pl-0" : "mt-4 pl-2")}>
+				<div
+					className={cn(
+						isBanner ? "shrink-0 pl-2 sm:pl-0" : "mt-auto pl-2 pt-4",
+					)}
+				>
 					<Button asChild size="sm" className="gap-1.5">
 						<a href={item.ctaHref ?? "#"}>
 							{item.ctaLabel}

--- a/src/webapp/src/features/feed/components/FeedReviewItem.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedReviewItem.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react";
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { FeedReviewItem as FeedReviewItemType } from "../feedTypes";
+import { FeedReviewItem } from "./FeedReviewItem";
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({
+			to,
+			params,
+			children,
+			className,
+		}: {
+			to: string;
+			params?: Record<string, string>;
+			children: ReactNode;
+			className?: string;
+		}) => (
+			<a href={to} data-params={JSON.stringify(params)} className={className}>
+				{children}
+			</a>
+		),
+	};
+});
+
+const baseItem: FeedReviewItemType = {
+	kind: "review",
+	id: "r1",
+	createdAt: new Date().toISOString(),
+	courseId: "course-1",
+	courseTitle: "Алгоритми та структури даних",
+	studentName: "Олена Ковальчук",
+	isAnonymous: false,
+	difficulty: 4.2,
+	usefulness: 4.8,
+	comment: "Складно, але корисно.",
+	semesterYear: 2025,
+	semesterTerm: "FALL",
+};
+
+describe("FeedReviewItem", () => {
+	it("leads with the course as a link to the course page", () => {
+		render(<FeedReviewItem item={baseItem} />);
+
+		expect(screen.getByText(/Новий відгук на/)).toBeInTheDocument();
+		const link = screen.getByRole("link", {
+			name: "Алгоритми та структури даних",
+		});
+		expect(link).toHaveAttribute("href", "/courses/$courseId");
+		expect(link).toHaveAttribute(
+			"data-params",
+			JSON.stringify({ courseId: "course-1" }),
+		);
+	});
+
+	it("does not show the student name, even when the review is not anonymous", () => {
+		render(
+			<FeedReviewItem
+				item={{ ...baseItem, isAnonymous: false, studentName: "Іван Петренко" }}
+			/>,
+		);
+
+		expect(screen.queryByText(/Олена Ковальчук/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/Іван Петренко/)).not.toBeInTheDocument();
+	});
+
+	it("renders difficulty, usefulness and the comment", () => {
+		render(<FeedReviewItem item={baseItem} />);
+
+		expect(screen.getByText("4.2")).toBeInTheDocument();
+		expect(screen.getByText("4.8")).toBeInTheDocument();
+		expect(screen.getByText("Складно, але корисно.")).toBeInTheDocument();
+	});
+
+	it("omits the comment paragraph when there is no comment", () => {
+		render(<FeedReviewItem item={{ ...baseItem, comment: null }} />);
+
+		expect(screen.queryByText("Складно, але корисно.")).not.toBeInTheDocument();
+	});
+});

--- a/src/webapp/src/features/feed/components/FeedReviewItem.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedReviewItem.test.tsx
@@ -1,32 +1,13 @@
-import type { ReactNode } from "react";
-
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { FeedReviewItem as FeedReviewItemType } from "../feedTypes";
 import { FeedReviewItem } from "./FeedReviewItem";
 
-vi.mock("@tanstack/react-router", async () => {
-	const actual = await vi.importActual("@tanstack/react-router");
-	return {
-		...actual,
-		Link: ({
-			to,
-			params,
-			children,
-			className,
-		}: {
-			to: string;
-			params?: Record<string, string>;
-			children: ReactNode;
-			className?: string;
-		}) => (
-			<a href={to} data-params={JSON.stringify(params)} className={className}>
-				{children}
-			</a>
-		),
-	};
-});
+vi.mock("@tanstack/react-router", async () => ({
+	...(await vi.importActual("@tanstack/react-router")),
+	Link: (await import("@/test-utils/router")).MockLink,
+}));
 
 const baseItem: FeedReviewItemType = {
 	kind: "review",

--- a/src/webapp/src/features/feed/components/FeedReviewItem.tsx
+++ b/src/webapp/src/features/feed/components/FeedReviewItem.tsx
@@ -1,0 +1,92 @@
+import { Link } from "@tanstack/react-router";
+
+import { UserAvatar } from "@/components/UserAvatar";
+import {
+	getDifficultyTone,
+	getSemesterDisplay,
+	getUsefulnessTone,
+} from "@/features/courses/courseFormatting";
+import { formatRelativeTime } from "@/features/notifications/notificationFormatting";
+import { cn } from "@/lib/utils";
+import type { FeedReviewItem as FeedReviewItemType } from "../feedTypes";
+
+interface FeedReviewItemProps {
+	readonly item: FeedReviewItemType;
+}
+
+/**
+ * Auto-populated feed entry: a compact summary of a recent rating. Kept
+ * intentionally quiet (no border, muted meta) so it reads as ambient activity
+ * next to the louder promo cards.
+ */
+export function FeedReviewItem({ item }: FeedReviewItemProps) {
+	const semesterLabel =
+		item.semesterYear != null && item.semesterTerm
+			? getSemesterDisplay(item.semesterYear, item.semesterTerm)
+			: undefined;
+
+	return (
+		<article className="flex gap-3 py-4">
+			<UserAvatar
+				name={item.studentName}
+				avatarUrl={item.avatarUrl}
+				isAnonymous={item.isAnonymous}
+				className="h-8 w-8 shrink-0 text-xs font-semibold"
+			/>
+			<div className="min-w-0 flex-1">
+				<p className="text-sm leading-snug">
+					<span className="font-medium">{item.studentName}</span>
+					<span className="text-muted-foreground"> оцінив(ла) </span>
+					<Link
+						to="/courses/$courseId"
+						params={{ courseId: item.courseId }}
+						className="font-medium text-foreground transition-colors hover:text-primary hover:underline"
+					>
+						{item.courseTitle}
+					</Link>
+				</p>
+
+				<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
+					<span className="flex items-center gap-1">
+						<span className="text-muted-foreground">Складність</span>
+						<span
+							className={cn(
+								"font-semibold tabular-nums",
+								getDifficultyTone(item.difficulty),
+							)}
+						>
+							{item.difficulty.toFixed(1)}
+						</span>
+					</span>
+					<span className="flex items-center gap-1">
+						<span className="text-muted-foreground">Корисність</span>
+						<span
+							className={cn(
+								"font-semibold tabular-nums",
+								getUsefulnessTone(item.usefulness),
+							)}
+						>
+							{item.usefulness.toFixed(1)}
+						</span>
+					</span>
+				</div>
+
+				{item.comment && (
+					<p className="mt-2.5 line-clamp-2 text-sm text-muted-foreground">
+						{item.comment}
+					</p>
+				)}
+
+				<div className="mt-2.5 flex items-center gap-2 text-xs text-muted-foreground">
+					<time>{formatRelativeTime(item.createdAt)}</time>
+					{semesterLabel && (
+						<>
+							<span aria-hidden>·</span>
+							<span>{semesterLabel}</span>
+						</>
+					)}
+				</div>
+			</div>
+		</article>
+	);
+}

--- a/src/webapp/src/features/feed/components/FeedReviewItem.tsx
+++ b/src/webapp/src/features/feed/components/FeedReviewItem.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@tanstack/react-router";
+import { MessageSquareText } from "lucide-react";
 
-import { UserAvatar } from "@/components/UserAvatar";
 import {
 	getDifficultyTone,
 	getSemesterDisplay,
@@ -15,9 +15,8 @@ interface FeedReviewItemProps {
 }
 
 /**
- * Auto-populated feed entry: a compact summary of a recent rating. Kept
- * intentionally quiet (no border, muted meta) so it reads as ambient activity
- * next to the louder promo cards.
+ * Auto-populated feed entry: a compact summary of a recent rating.
+ * Reviews are anonymous in the feed.
  */
 export function FeedReviewItem({ item }: FeedReviewItemProps) {
 	const semesterLabel =
@@ -27,16 +26,15 @@ export function FeedReviewItem({ item }: FeedReviewItemProps) {
 
 	return (
 		<article className="flex gap-3 py-4">
-			<UserAvatar
-				name={item.studentName}
-				avatarUrl={item.avatarUrl}
-				isAnonymous={item.isAnonymous}
-				className="h-8 w-8 shrink-0 text-xs font-semibold"
-			/>
+			<span
+				className="flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground"
+				aria-hidden
+			>
+				<MessageSquareText className="size-4" />
+			</span>
 			<div className="min-w-0 flex-1">
 				<p className="text-sm leading-snug">
-					<span className="font-medium">{item.studentName}</span>
-					<span className="text-muted-foreground"> оцінив(ла) </span>
+					<span className="text-muted-foreground">Новий відгук на </span>
 					<Link
 						to="/courses/$courseId"
 						params={{ courseId: item.courseId }}

--- a/src/webapp/src/features/feed/components/FeedStrip.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.test.tsx
@@ -1,31 +1,13 @@
-import type { ReactNode } from "react";
-
 import { describe, expect, it, vi } from "vitest";
 
-import { FEED_FLAG } from "../feedFlags";
 import { renderWithProviders, screen } from "@/test-utils/render";
+import { FEED_FLAG } from "../feedFlags";
 import { FeedStrip } from "./FeedStrip";
 
-vi.mock("@tanstack/react-router", async () => {
-	const actual = await vi.importActual("@tanstack/react-router");
-	return {
-		...actual,
-		Link: ({
-			to,
-			children,
-			className,
-			...rest
-		}: {
-			to: string;
-			children: ReactNode;
-			className?: string;
-		}) => (
-			<a href={to} className={className} {...rest}>
-				{children}
-			</a>
-		),
-	};
-});
+vi.mock("@tanstack/react-router", async () => ({
+	...(await vi.importActual("@tanstack/react-router")),
+	Link: (await import("@/test-utils/router")).MockLink,
+}));
 
 describe("FeedStrip", () => {
 	it("renders nothing when the feed flag is off", () => {

--- a/src/webapp/src/features/feed/components/FeedStrip.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.test.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { FEED_FLAG } from "../feedFlags";
+import { renderWithProviders, screen } from "@/test-utils/render";
+import { FeedStrip } from "./FeedStrip";
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({
+			to,
+			children,
+			className,
+			...rest
+		}: {
+			to: string;
+			children: ReactNode;
+			className?: string;
+		}) => (
+			<a href={to} className={className} {...rest}>
+				{children}
+			</a>
+		),
+	};
+});
+
+describe("FeedStrip", () => {
+	it("renders nothing when the feed flag is off", () => {
+		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: false } });
+
+		expect(screen.queryByText("Стрічка оновлень")).not.toBeInTheDocument();
+	});
+
+	it("renders nothing until the flags have resolved", () => {
+		renderWithProviders(<FeedStrip />, {
+			flags: { [FEED_FLAG]: true },
+			flagsReady: false,
+		});
+
+		expect(screen.queryByText("Стрічка оновлень")).not.toBeInTheDocument();
+	});
+
+	it("renders the feed and links to /feed when the flag is on", () => {
+		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: true } });
+
+		expect(screen.getByText("Стрічка оновлень")).toBeInTheDocument();
+		expect(screen.getByRole("link", { name: /Уся стрічка/ })).toHaveAttribute(
+			"href",
+			"/feed",
+		);
+		expect(
+			screen.getByRole("link", { name: /Переглянути всю стрічку/ }),
+		).toHaveAttribute("href", "/feed");
+	});
+
+	it("orders pinned content ahead of unpinned content", () => {
+		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: true } });
+
+		const pinned = screen.getByText("Хакатон факультету інформатики");
+		const unpinned = screen.getByText("Реєстрація на вибіркові відкрита");
+
+		// pinned promo (later by recency) should appear before the unpinned one.
+		expect(
+			pinned.compareDocumentPosition(unpinned) &
+				Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+});

--- a/src/webapp/src/features/feed/components/FeedStrip.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.tsx
@@ -1,6 +1,8 @@
 import { ArrowRight, Newspaper } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
+import { useFeatureFlagState } from "@/lib/feature-flags";
+import { FEED_FLAG } from "../feedFlags";
 import { MOCK_FEED_ITEMS } from "../feedMockData";
 import { isPromoItem } from "../feedTypes";
 import { FeedPromoItem } from "./FeedPromoItem";
@@ -18,7 +20,12 @@ import { FeedReviewItem } from "./FeedReviewItem";
  * scroll, which isn't obvious on its own.
  */
 export function FeedStrip() {
+	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
 	const items = MOCK_FEED_ITEMS;
+
+	// Gate on the flag, and stay hidden until it resolves so the feed never
+	// flashes in before a disabled flag lands.
+	if (!isReady || !enabled) return null;
 
 	return (
 		<section aria-label="Стрічка оновлень" className="space-y-3">

--- a/src/webapp/src/features/feed/components/FeedStrip.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.tsx
@@ -1,10 +1,11 @@
-import { ArrowRight, Newspaper } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Newspaper, Pin } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import { useFeatureFlagState } from "@/lib/feature-flags";
 import { FEED_FLAG } from "../feedFlags";
 import { MOCK_FEED_ITEMS } from "../feedMockData";
-import { isPromoItem } from "../feedTypes";
+import { isPromoItem, orderFeedItems } from "../feedTypes";
 import { FeedPromoItem } from "./FeedPromoItem";
 import { FeedReviewItem } from "./FeedReviewItem";
 
@@ -16,8 +17,8 @@ import { FeedReviewItem } from "./FeedReviewItem";
  * so ads and review activity flow through the same carousel.
  *
  * Older entries are reached via the trailing "view all" tile and the header
- * link (a future `/feed` route) rather than by discovering the horizontal
- * scroll, which isn't obvious on its own.
+ * link (the `/feed` route) rather than by discovering the horizontal scroll,
+ * which isn't obvious on its own.
  */
 export function FeedStrip() {
 	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
@@ -40,39 +41,45 @@ export function FeedStrip() {
 					size="sm"
 					className="h-8 gap-1 text-muted-foreground hover:text-foreground"
 				>
-					<a href="#">
+					<Link to="/feed">
 						Уся стрічка
 						<ArrowRight className="size-4" />
-					</a>
+					</Link>
 				</Button>
 			</div>
 
-			<div className="-mx-1 flex snap-x snap-mandatory gap-3 overflow-x-auto px-1 pb-2">
-				{items.map((item) => (
+			{/* Scrollbar hidden and snapping dropped so the row reads as a quiet
+			    strip rather than an attention-grabbing carousel; the header link
+			    and trailing tile carry discoverability of older items. */}
+			<div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+				{orderFeedItems(items).map((item) => (
 					<div
 						key={item.id}
-						className="w-[280px] shrink-0 snap-start sm:w-[300px]"
+						className="relative w-[260px] shrink-0 sm:w-[280px]"
 					>
+						{item.pinned && (
+							<span className="absolute right-2 top-2 z-10 inline-flex items-center gap-1 rounded-full border bg-background/90 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm backdrop-blur">
+								<Pin className="size-3" />
+							</span>
+						)}
 						{isPromoItem(item) ? (
 							<FeedPromoItem item={item} />
 						) : (
-							<div className="h-full rounded-xl border bg-card px-3 shadow-sm">
+							<div className="h-full rounded-lg border bg-card/60 px-3">
 								<FeedReviewItem item={item} />
 							</div>
 						)}
 					</div>
 				))}
 
-				{/* Trailing tile makes it explicit that more (older) items exist
-				    beyond the visible cards. */}
-				<a
-					href="#"
+				<Link
+					to="/feed"
 					aria-label="Переглянути всю стрічку"
-					className="flex w-[160px] shrink-0 snap-start flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-card/50 px-3 text-center text-sm font-medium text-muted-foreground transition-colors hover:border-solid hover:text-foreground"
+					className="flex w-[140px] shrink-0 flex-col items-center justify-center gap-2 rounded-lg border border-dashed px-3 text-center text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
 				>
 					<ArrowRight className="size-5" />
 					Переглянути всі
-				</a>
+				</Link>
 			</div>
 		</section>
 	);

--- a/src/webapp/src/features/feed/components/FeedStrip.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.tsx
@@ -1,0 +1,72 @@
+import { ArrowRight, Newspaper } from "lucide-react";
+
+import { Button } from "@/components/ui/Button";
+import { MOCK_FEED_ITEMS } from "../feedMockData";
+import { isPromoItem } from "../feedTypes";
+import { FeedPromoItem } from "./FeedPromoItem";
+import { FeedReviewItem } from "./FeedReviewItem";
+
+/**
+ * Top "updates" strip.
+ *
+ * A full-width, horizontally scrolling row placed above the courses table.
+ * Each item is a fixed-width card; promos keep their accent treatment inline
+ * so ads and review activity flow through the same carousel.
+ *
+ * Older entries are reached via the trailing "view all" tile and the header
+ * link (a future `/feed` route) rather than by discovering the horizontal
+ * scroll, which isn't obvious on its own.
+ */
+export function FeedStrip() {
+	const items = MOCK_FEED_ITEMS;
+
+	return (
+		<section aria-label="Стрічка оновлень" className="space-y-3">
+			<div className="flex items-center justify-between gap-2">
+				<div className="flex items-center gap-2">
+					<Newspaper className="size-4 text-muted-foreground" />
+					<h2 className="text-sm font-semibold">Стрічка оновлень</h2>
+				</div>
+				<Button
+					asChild
+					variant="ghost"
+					size="sm"
+					className="h-8 gap-1 text-muted-foreground hover:text-foreground"
+				>
+					<a href="#">
+						Уся стрічка
+						<ArrowRight className="size-4" />
+					</a>
+				</Button>
+			</div>
+
+			<div className="-mx-1 flex snap-x snap-mandatory gap-3 overflow-x-auto px-1 pb-2">
+				{items.map((item) => (
+					<div
+						key={item.id}
+						className="w-[280px] shrink-0 snap-start sm:w-[300px]"
+					>
+						{isPromoItem(item) ? (
+							<FeedPromoItem item={item} />
+						) : (
+							<div className="h-full rounded-xl border bg-card px-3 shadow-sm">
+								<FeedReviewItem item={item} />
+							</div>
+						)}
+					</div>
+				))}
+
+				{/* Trailing tile makes it explicit that more (older) items exist
+				    beyond the visible cards. */}
+				<a
+					href="#"
+					aria-label="Переглянути всю стрічку"
+					className="flex w-[160px] shrink-0 snap-start flex-col items-center justify-center gap-2 rounded-xl border border-dashed bg-card/50 px-3 text-center text-sm font-medium text-muted-foreground transition-colors hover:border-solid hover:text-foreground"
+				>
+					<ArrowRight className="size-5" />
+					Переглянути всі
+				</a>
+			</div>
+		</section>
+	);
+}

--- a/src/webapp/src/features/feed/feedFlags.ts
+++ b/src/webapp/src/features/feed/feedFlags.ts
@@ -1,0 +1,9 @@
+/**
+ * Waffle flag that gates the homepage feed.
+ *
+ * Opt-in, following the `fe_`-prefixed convention: the feed renders only when
+ * the flag resolves on, so it ships dark and can be disabled on demand by
+ * turning the flag off (server-side, or via the `featureFlags` console helper
+ * in non-live builds).
+ */
+export const FEED_FLAG = "fe_feed";

--- a/src/webapp/src/features/feed/feedMockData.ts
+++ b/src/webapp/src/features/feed/feedMockData.ts
@@ -1,0 +1,112 @@
+import type { FeedItem } from "./feedTypes";
+
+/**
+ * Placeholder feed content used while the feed API is not wired yet.
+ *
+ * `review` items stand in for the auto-populated stream (recent ratings);
+ * `promo` items stand in for admin-configured announcements. Replace with a
+ * real query once the backend endpoint exists — the components only depend on
+ * the {@link FeedItem} shape, not on this array. Manual content can later bind
+ * to the existing `usePromoBannerList` endpoint.
+ */
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const now = Date.now();
+const ago = (ms: number) => new Date(now - ms).toISOString();
+
+export const MOCK_FEED_ITEMS: readonly FeedItem[] = [
+	{
+		kind: "promo",
+		id: "promo-1",
+		createdAt: ago(30 * MINUTE),
+		accent: "brand",
+		label: "Оголошення",
+		title: "Реєстрація на вибіркові відкрита",
+		body: "Оберіть дисципліни до 20 вересня.",
+		ctaLabel: "Детальніше",
+		ctaHref: "#",
+	},
+	{
+		kind: "review",
+		id: "review-1",
+		createdAt: ago(45 * MINUTE),
+		courseId: "00000000-0000-0000-0000-000000000001",
+		courseTitle: "Алгоритми та структури даних",
+		studentName: "Олена Ковальчук",
+		isAnonymous: false,
+		difficulty: 4.2,
+		usefulness: 4.8,
+		comment: "Складно, але корисно. Практика допомагає.",
+		semesterYear: 2025,
+		semesterTerm: "FALL",
+	},
+	{
+		kind: "review",
+		id: "review-2",
+		createdAt: ago(2 * HOUR),
+		courseId: "00000000-0000-0000-0000-000000000002",
+		courseTitle: "Вступ до машинного навчання",
+		studentName: "Анонім",
+		isAnonymous: true,
+		difficulty: 3.6,
+		usefulness: 4.5,
+		comment: "Пояснює доступно, сучасні приклади.",
+		semesterYear: 2025,
+		semesterTerm: "FALL",
+	},
+	{
+		kind: "promo",
+		id: "promo-2",
+		createdAt: ago(5 * HOUR),
+		accent: "info",
+		label: "Подія",
+		title: "Хакатон факультету інформатики",
+		body: "48 годин, 12–14 вересня. Призовий фонд.",
+		ctaLabel: "Зареєструватися",
+		ctaHref: "#",
+	},
+	{
+		kind: "review",
+		id: "review-3",
+		createdAt: ago(8 * HOUR),
+		courseId: "00000000-0000-0000-0000-000000000003",
+		courseTitle: "Мікроекономіка",
+		studentName: "Дмитро Савченко",
+		isAnonymous: false,
+		difficulty: 2.9,
+		usefulness: 3.4,
+		comment: "Базовий курс, оцінювання прозоре.",
+		semesterYear: 2025,
+		semesterTerm: "SPRING",
+	},
+	{
+		kind: "review",
+		id: "review-4",
+		createdAt: ago(1 * DAY),
+		courseId: "00000000-0000-0000-0000-000000000004",
+		courseTitle: "Історія української культури",
+		studentName: "Марія Ткаченко",
+		isAnonymous: false,
+		difficulty: 2.1,
+		usefulness: 3.9,
+		comment: null,
+		semesterYear: 2025,
+		semesterTerm: "SPRING",
+	},
+	{
+		kind: "review",
+		id: "review-5",
+		createdAt: ago(2 * DAY),
+		courseId: "00000000-0000-0000-0000-000000000005",
+		courseTitle: "Функціональне програмування",
+		studentName: "Анонім",
+		isAnonymous: true,
+		difficulty: 4.6,
+		usefulness: 4.9,
+		comment: "Найкращий курс на факультеті.",
+		semesterYear: 2025,
+		semesterTerm: "FALL",
+	},
+];

--- a/src/webapp/src/features/feed/feedMockData.ts
+++ b/src/webapp/src/features/feed/feedMockData.ts
@@ -60,6 +60,7 @@ export const MOCK_FEED_ITEMS: readonly FeedItem[] = [
 		kind: "promo",
 		id: "promo-2",
 		createdAt: ago(5 * HOUR),
+		pinned: true,
 		accent: "info",
 		label: "Подія",
 		title: "Хакатон факультету інформатики",

--- a/src/webapp/src/features/feed/feedTypes.test.ts
+++ b/src/webapp/src/features/feed/feedTypes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { type FeedItem, isPromoItem, orderFeedItems } from "./feedTypes";
+
+function review(id: string, pinned?: boolean): FeedItem {
+	return {
+		kind: "review",
+		id,
+		createdAt: "2025-01-01T00:00:00.000Z",
+		pinned,
+		courseId: `course-${id}`,
+		courseTitle: `Course ${id}`,
+		studentName: "Student",
+		isAnonymous: false,
+		difficulty: 3,
+		usefulness: 3,
+	};
+}
+
+function promo(id: string, pinned?: boolean): FeedItem {
+	return {
+		kind: "promo",
+		id,
+		createdAt: "2025-01-01T00:00:00.000Z",
+		pinned,
+		title: `Promo ${id}`,
+		body: "body",
+	};
+}
+
+describe("orderFeedItems", () => {
+	it("moves pinned items to the front", () => {
+		const items = [
+			review("1"),
+			promo("2", true),
+			review("3"),
+			promo("4", true),
+		];
+
+		expect(orderFeedItems(items).map((i) => i.id)).toEqual([
+			"2",
+			"4",
+			"1",
+			"3",
+		]);
+	});
+
+	it("keeps relative order stable within the pinned and unpinned groups", () => {
+		const items = [
+			review("a"),
+			review("b", true),
+			review("c"),
+			review("d", true),
+		];
+
+		expect(orderFeedItems(items).map((i) => i.id)).toEqual([
+			"b",
+			"d",
+			"a",
+			"c",
+		]);
+	});
+
+	it("treats a missing pinned flag as not pinned", () => {
+		const items = [review("1"), promo("2", true)];
+
+		expect(orderFeedItems(items).map((i) => i.id)).toEqual(["2", "1"]);
+	});
+
+	it("returns a new array without mutating the input", () => {
+		const items = [review("1"), promo("2", true)];
+		const ordered = orderFeedItems(items);
+
+		expect(ordered).not.toBe(items);
+		expect(items.map((i) => i.id)).toEqual(["1", "2"]);
+	});
+});
+
+describe("isPromoItem", () => {
+	it("distinguishes promo items from reviews", () => {
+		expect(isPromoItem(promo("1"))).toBe(true);
+		expect(isPromoItem(review("1"))).toBe(false);
+	});
+});

--- a/src/webapp/src/features/feed/feedTypes.ts
+++ b/src/webapp/src/features/feed/feedTypes.ts
@@ -1,0 +1,50 @@
+/**
+ * The feed mixes two content sources that must stay visually distinguishable:
+ *
+ * - `review` — auto-populated activity, generated from real rating events.
+ * - `promo`  — manually configured content (ads / announcements) authored in
+ *              the admin panel.
+ *
+ * Both share `id` and `createdAt` so a single feed list can sort/interleave
+ * them, but each renders through its own component.
+ */
+export type FeedItem = FeedReviewItem | FeedPromoItem;
+
+export interface FeedReviewItem {
+	readonly kind: "review";
+	readonly id: string;
+	readonly createdAt: string;
+	readonly courseId: string;
+	readonly courseTitle: string;
+	readonly studentName: string;
+	readonly isAnonymous: boolean;
+	readonly avatarUrl?: string | null;
+	readonly difficulty: number;
+	readonly usefulness: number;
+	readonly comment?: string | null;
+	readonly semesterYear?: number;
+	readonly semesterTerm?: string;
+}
+
+/**
+ * Accent controls the promo card's color treatment so admins can visually
+ * prioritise announcements without touching code.
+ */
+export type FeedPromoAccent = "brand" | "info" | "warning";
+
+export interface FeedPromoItem {
+	readonly kind: "promo";
+	readonly id: string;
+	readonly createdAt: string;
+	readonly title: string;
+	readonly body: string;
+	readonly label?: string;
+	readonly ctaLabel?: string;
+	readonly ctaHref?: string;
+	readonly imageUrl?: string | null;
+	readonly accent?: FeedPromoAccent;
+}
+
+export function isPromoItem(item: FeedItem): item is FeedPromoItem {
+	return item.kind === "promo";
+}

--- a/src/webapp/src/features/feed/feedTypes.ts
+++ b/src/webapp/src/features/feed/feedTypes.ts
@@ -7,6 +7,10 @@
  *
  * Both share `id` and `createdAt` so a single feed list can sort/interleave
  * them, but each renders through its own component.
+ *
+ * `pinned` is the orthogonal "static vs dynamic" axis the admin controls:
+ * pinned items ("static content") lead the feed and hold their place; the rest
+ * ("dynamic content") flow after in recency order. Any item kind can be pinned.
  */
 export type FeedItem = FeedReviewItem | FeedPromoItem;
 
@@ -14,6 +18,7 @@ export interface FeedReviewItem {
 	readonly kind: "review";
 	readonly id: string;
 	readonly createdAt: string;
+	readonly pinned?: boolean;
 	readonly courseId: string;
 	readonly courseTitle: string;
 	readonly studentName: string;
@@ -36,6 +41,7 @@ export interface FeedPromoItem {
 	readonly kind: "promo";
 	readonly id: string;
 	readonly createdAt: string;
+	readonly pinned?: boolean;
 	readonly title: string;
 	readonly body: string;
 	readonly label?: string;
@@ -47,4 +53,15 @@ export interface FeedPromoItem {
 
 export function isPromoItem(item: FeedItem): item is FeedPromoItem {
 	return item.kind === "promo";
+}
+
+/**
+ * Pinned ("static") items first, in their given order, then the rest
+ * ("dynamic") unchanged. Stable, so items keep their relative order within
+ * each group.
+ */
+export function orderFeedItems(items: readonly FeedItem[]): FeedItem[] {
+	return [...items].sort(
+		(a, b) => Number(b.pinned ?? false) - Number(a.pinned ?? false),
+	);
 }

--- a/src/webapp/src/routeTree.gen.ts
+++ b/src/webapp/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ConnectionErrorRouteImport } from './routes/connection-error'
 import { Route as ExploreRouteImport } from './routes/explore'
+import { Route as FeedRouteImport } from './routes/feed'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as MyRatingsRouteImport } from './routes/my-ratings'
 import { Route as CoursesCourseIdRouteImport } from './routes/courses.$courseId'
@@ -31,6 +32,11 @@ const ConnectionErrorRoute = ConnectionErrorRouteImport.update({
 const ExploreRoute = ExploreRouteImport.update({
   id: '/explore',
   path: '/explore',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FeedRoute = FeedRouteImport.update({
+  id: '/feed',
+  path: '/feed',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -63,6 +69,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/connection-error': typeof ConnectionErrorRoute
   '/explore': typeof ExploreRoute
+  '/feed': typeof FeedRoute
   '/login': typeof LoginRouteWithChildren
   '/my-ratings': typeof MyRatingsRoute
   '/courses/$courseId': typeof CoursesCourseIdRoute
@@ -73,6 +80,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/connection-error': typeof ConnectionErrorRoute
   '/explore': typeof ExploreRoute
+  '/feed': typeof FeedRoute
   '/my-ratings': typeof MyRatingsRoute
   '/courses/$courseId': typeof CoursesCourseIdRoute
   '/login/failed': typeof LoginFailedRoute
@@ -83,6 +91,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/connection-error': typeof ConnectionErrorRoute
   '/explore': typeof ExploreRoute
+  '/feed': typeof FeedRoute
   '/login': typeof LoginRouteWithChildren
   '/my-ratings': typeof MyRatingsRoute
   '/courses/$courseId': typeof CoursesCourseIdRoute
@@ -95,6 +104,7 @@ export interface FileRouteTypes {
     | '/'
     | '/connection-error'
     | '/explore'
+    | '/feed'
     | '/login'
     | '/my-ratings'
     | '/courses/$courseId'
@@ -105,6 +115,7 @@ export interface FileRouteTypes {
     | '/'
     | '/connection-error'
     | '/explore'
+    | '/feed'
     | '/my-ratings'
     | '/courses/$courseId'
     | '/login/failed'
@@ -114,6 +125,7 @@ export interface FileRouteTypes {
     | '/'
     | '/connection-error'
     | '/explore'
+    | '/feed'
     | '/login'
     | '/my-ratings'
     | '/courses/$courseId'
@@ -125,6 +137,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ConnectionErrorRoute: typeof ConnectionErrorRoute
   ExploreRoute: typeof ExploreRoute
+  FeedRoute: typeof FeedRoute
   LoginRoute: typeof LoginRouteWithChildren
   MyRatingsRoute: typeof MyRatingsRoute
   CoursesCourseIdRoute: typeof CoursesCourseIdRoute
@@ -151,6 +164,13 @@ declare module '@tanstack/react-router' {
       path: '/explore'
       fullPath: '/explore'
       preLoaderRoute: typeof ExploreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/feed': {
+      id: '/feed'
+      path: '/feed'
+      fullPath: '/feed'
+      preLoaderRoute: typeof FeedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -207,6 +227,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ConnectionErrorRoute: ConnectionErrorRoute,
   ExploreRoute: ExploreRoute,
+  FeedRoute: FeedRoute,
   LoginRoute: LoginRouteWithChildren,
   MyRatingsRoute: MyRatingsRoute,
   CoursesCourseIdRoute: CoursesCourseIdRoute,

--- a/src/webapp/src/routes/feed.test.tsx
+++ b/src/webapp/src/routes/feed.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { FEED_FLAG } from "@/features/feed/feedFlags";
+import { renderWithProviders, screen } from "@/test-utils/render";
+import { FeedRoute } from "./feed";
+
+vi.mock("@/components/Layout", () => ({
+	default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+	const actual = await vi.importActual("@tanstack/react-router");
+	return {
+		...actual,
+		Link: ({
+			to,
+			children,
+			className,
+			...rest
+		}: {
+			to: string;
+			children: ReactNode;
+			className?: string;
+		}) => (
+			<a href={to} className={className} {...rest}>
+				{children}
+			</a>
+		),
+	};
+});
+
+describe("FeedRoute", () => {
+	it("shows an unavailable message when the feed flag is off", () => {
+		renderWithProviders(<FeedRoute />, { flags: { [FEED_FLAG]: false } });
+
+		expect(screen.getByText("Стрічка наразі недоступна.")).toBeInTheDocument();
+	});
+
+	it("renders the heading and feed items when the flag is on", () => {
+		renderWithProviders(<FeedRoute />, { flags: { [FEED_FLAG]: true } });
+
+		expect(
+			screen.getByRole("heading", { name: /Стрічка оновлень/ }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Хакатон факультету інформатики"),
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText("Стрічка наразі недоступна."),
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/webapp/src/routes/feed.test.tsx
+++ b/src/webapp/src/routes/feed.test.tsx
@@ -10,26 +10,10 @@ vi.mock("@/components/Layout", () => ({
 	default: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("@tanstack/react-router", async () => {
-	const actual = await vi.importActual("@tanstack/react-router");
-	return {
-		...actual,
-		Link: ({
-			to,
-			children,
-			className,
-			...rest
-		}: {
-			to: string;
-			children: ReactNode;
-			className?: string;
-		}) => (
-			<a href={to} className={className} {...rest}>
-				{children}
-			</a>
-		),
-	};
-});
+vi.mock("@tanstack/react-router", async () => ({
+	...(await vi.importActual("@tanstack/react-router")),
+	Link: (await import("@/test-utils/router")).MockLink,
+}));
 
 describe("FeedRoute", () => {
 	it("shows an unavailable message when the feed flag is off", () => {

--- a/src/webapp/src/routes/feed.tsx
+++ b/src/webapp/src/routes/feed.tsx
@@ -1,0 +1,59 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Newspaper, Pin } from "lucide-react";
+
+import Layout from "@/components/Layout";
+import { FeedPromoItem } from "@/features/feed/components/FeedPromoItem";
+import { FeedReviewItem } from "@/features/feed/components/FeedReviewItem";
+import { FEED_FLAG } from "@/features/feed/feedFlags";
+import { MOCK_FEED_ITEMS } from "@/features/feed/feedMockData";
+import { isPromoItem, orderFeedItems } from "@/features/feed/feedTypes";
+import { withAuth } from "@/lib/auth";
+import { useFeatureFlagState } from "@/lib/feature-flags";
+
+function FeedRoute() {
+	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
+	const items = orderFeedItems(MOCK_FEED_ITEMS);
+
+	return (
+		<Layout>
+			<div className="mx-auto max-w-2xl space-y-6">
+				<header className="space-y-1">
+					<h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
+						<Newspaper className="size-6 text-muted-foreground" />
+						Стрічка оновлень
+					</h1>
+					<p className="text-muted-foreground">
+						Останні відгуки та оголошення Могилянки
+					</p>
+				</header>
+
+				{!isReady ? null : !enabled ? (
+					<p className="text-muted-foreground">Стрічка наразі недоступна.</p>
+				) : (
+					<div className="space-y-3">
+						{items.map((item) => (
+							<div key={item.id} className="relative">
+								{item.pinned && (
+									<span className="absolute right-3 top-3 z-10 inline-flex items-center rounded-full border bg-background/90 p-1 text-muted-foreground shadow-sm backdrop-blur">
+										<Pin className="size-3" />
+									</span>
+								)}
+								{isPromoItem(item) ? (
+									<FeedPromoItem item={item} variant="banner" />
+								) : (
+									<div className="rounded-xl border bg-card px-4 shadow-sm">
+										<FeedReviewItem item={item} />
+									</div>
+								)}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		</Layout>
+	);
+}
+
+export const Route = createFileRoute("/feed")({
+	component: withAuth(FeedRoute),
+});

--- a/src/webapp/src/routes/feed.tsx
+++ b/src/webapp/src/routes/feed.tsx
@@ -10,7 +10,7 @@ import { isPromoItem, orderFeedItems } from "@/features/feed/feedTypes";
 import { withAuth } from "@/lib/auth";
 import { useFeatureFlagState } from "@/lib/feature-flags";
 
-function FeedRoute() {
+export function FeedRoute() {
 	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
 	const items = orderFeedItems(MOCK_FEED_ITEMS);
 

--- a/src/webapp/src/routes/index.test.tsx
+++ b/src/webapp/src/routes/index.test.tsx
@@ -35,6 +35,13 @@ vi.mock("@/features/promo/components/PromoBanner", () => {
 	};
 });
 
+// Covered by its own test; stubbed here so this file needs no flags provider.
+vi.mock("@/features/feed/components/FeedStrip", () => {
+	return {
+		FeedStrip: () => null,
+	};
+});
+
 vi.mock("@/features/courses/courseFiltersParams", async () => {
 	const actual = await vi.importActual<
 		typeof import("@/features/courses/courseFiltersParams")

--- a/src/webapp/src/routes/index.tsx
+++ b/src/webapp/src/routes/index.tsx
@@ -12,6 +12,7 @@ import {
 	DIFFICULTY_RANGE,
 	USEFULNESS_RANGE,
 } from "@/features/courses/courseFormatting";
+import { FeedStrip } from "@/features/feed/components/FeedStrip";
 import { PromoBanner } from "@/features/promo/components/PromoBanner";
 import type { CoursesListParams } from "@/lib/api/generated";
 import { useCoursesList } from "@/lib/api/generated";
@@ -70,6 +71,7 @@ export function CoursesRoute() {
 		<Layout>
 			<div className="space-y-8">
 				<PromoBanner />
+				<FeedStrip />
 				{isError ? (
 					<CoursesErrorState onRetry={handleRetry} />
 				) : (

--- a/src/webapp/src/test-utils/router.tsx
+++ b/src/webapp/src/test-utils/router.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+interface MockLinkProps {
+	to: string;
+	params?: Record<string, string>;
+	children: ReactNode;
+	className?: string;
+}
+
+/**
+ * TanStack Router's `<Link>` rendered as a plain anchor, for component tests
+ * that don't mount a real router. Shared so the mock isn't duplicated per file:
+ *
+ *   vi.mock("@tanstack/react-router", async () => ({
+ *     ...(await vi.importActual("@tanstack/react-router")),
+ *     Link: (await import("@/test-utils/router")).MockLink,
+ *   }));
+ */
+export function MockLink({
+	to,
+	params,
+	children,
+	className,
+	...rest
+}: MockLinkProps) {
+	return (
+		<a
+			href={to}
+			data-params={params ? JSON.stringify(params) : undefined}
+			className={className}
+			{...rest}
+		>
+			{children}
+		</a>
+	);
+}


### PR DESCRIPTION
## Summary
Adds a feed strip above the courses table showing recent reviews (auto) and admin-configured announcements, gated behind the fe_feed flag.

- Reviews are anonymised, pinned "static" content leads, dynamic content follows
- "Уся стрічка" → new /feed route
- On mock data for now (swaps to the feed API later)
- unit + component tests included

Resolves #642 

<img width="1851" height="898" alt="image" src="https://github.com/user-attachments/assets/81cccb9e-5751-46e8-b5b6-9a31a4212162" />

<img width="1891" height="960" alt="image" src="https://github.com/user-attachments/assets/86fe5910-2e2f-4d6b-9c7c-9415d6267bda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added an updates feed to the courses page with horizontally scrollable announcements and review activity.
* Added a dedicated updates feed page with pinned items displayed first.
* Added announcement cards with labels, descriptions, styling, and optional call-to-action links.
* Added anonymous course review cards showing ratings, comments, course links, and relative timestamps.
* Added placeholder content for announcements and recent course reviews.
* The feed is available only when enabled by the feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->