### PR TITLE
feat(#662): type-safe feature flag names on the frontend

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -3202,12 +3202,11 @@ components:
       type: object
       properties:
         flags:
-          type: object
-          additionalProperties:
-            type: boolean
-          readOnly: true
-          description: Map of public feature flag name to its enabled state for the
-            current user.
+          allOf:
+          - $ref: '#/components/schemas/PublicFeatureFlags'
+          description: Enabled state of each public feature flag for the current user.
+      required:
+      - flags
     FilterOptions:
       type: object
       properties:
@@ -3578,6 +3577,15 @@ components:
           readOnly: true
           nullable: true
           description: The active promo banner, or null when none is configured.
+    PublicFeatureFlags:
+      type: object
+      properties:
+        fe_instructor_multiselect:
+          type: boolean
+          description: Whether `fe_instructor_multiselect` is enabled for the current
+            user.
+      required:
+      - fe_instructor_multiselect
     RatingCreateRequest:
       properties:
         course_offering:

--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -3584,7 +3584,11 @@ components:
           type: boolean
           description: Whether `fe_instructor_multiselect` is enabled for the current
             user.
+        fe_feed:
+          type: boolean
+          description: Whether `fe_feed` is enabled for the current user.
       required:
+      - fe_feed
       - fe_instructor_multiselect
     RatingCreateRequest:
       properties:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -62,9 +62,14 @@ it ships with a deploy. **Toggling** an already-exposed flag is runtime-only
    ```python
    PUBLIC_FEATURE_FLAGS = ["fe_my_new_flag"]
    ```
-   No new endpoint, serializer, or OpenAPI regen needed — the response schema is
-   a dynamic `Record<string, boolean>`, so it does not change when flags are
-   added.
+   The flag names are emitted as explicit fields of the `/api/v1/flags/` schema,
+   so regenerate the spec and the client so the name type-checks:
+   ```bash
+   (cd src/backend && uv run python manage.py spectacular --file ../../docs/api/openapi-generated.yaml)
+   (cd src/webapp && pnpm generate-api)
+   ```
+   `useFeatureFlag` accepts only `FeatureFlagName` (the keys of the generated
+   `PublicFeatureFlags` type), so an unlisted name fails `tsc`.
 
 2. **Create the `Flag` row** in each environment: Django admin (Waffle ▸ Flags)
    or CLI —
@@ -220,7 +225,9 @@ feature is fully rolled out or dropped:
 
 1. Delete the consumer code on both sides (the `flag_is_active` /
    `useFeatureFlag` call and the dead branch).
-2. Remove the name from `PUBLIC_FEATURE_FLAGS`.
+2. Remove the name from `PUBLIC_FEATURE_FLAGS`, regenerate the spec and
+   `pnpm generate-api`; `tsc` then fails on every stale `useFeatureFlag`
+   consumer you missed in step 1.
 3. Delete the `Flag` row in each environment (Django admin, or the ORM — there
    is no `waffle_flag --delete`).
 

--- a/src/backend/rateukma/settings/_base.py
+++ b/src/backend/rateukma/settings/_base.py
@@ -319,4 +319,4 @@ PARSE_BASE_URL = "https://my.ukma.edu.ua"
 # ONLY when added to this allowlist in a reviewed PR — the endpoint fails closed,
 # so server-only flags can never leak through a naming mistake. `fe_` is a soft
 # naming convention for client-facing flags, not the security boundary.
-PUBLIC_FEATURE_FLAGS = ["fe_instructor_multiselect"]
+PUBLIC_FEATURE_FLAGS = ["fe_instructor_multiselect", "fe_feed"]

--- a/src/backend/rating_app/serializers/feature_flags.py
+++ b/src/backend/rating_app/serializers/feature_flags.py
@@ -3,8 +3,11 @@ from rest_framework import serializers
 
 
 class PublicFeatureFlagsSerializer(serializers.Serializer):
-    # Built per call, not at import, so settings overrides in tests are honoured.
     def get_fields(self):
+        """Build one BooleanField per allowlisted flag.
+
+        Read at call time, not import, so settings overrides in tests are honoured.
+        """
         return {
             name: serializers.BooleanField(
                 help_text=f"Whether `{name}` is enabled for the current user."

--- a/src/backend/rating_app/serializers/feature_flags.py
+++ b/src/backend/rating_app/serializers/feature_flags.py
@@ -1,9 +1,19 @@
+from django.conf import settings
 from rest_framework import serializers
 
 
+class PublicFeatureFlagsSerializer(serializers.Serializer):
+    # Built per call, not at import, so settings overrides in tests are honoured.
+    def get_fields(self):
+        return {
+            name: serializers.BooleanField(
+                help_text=f"Whether `{name}` is enabled for the current user."
+            )
+            for name in settings.PUBLIC_FEATURE_FLAGS
+        }
+
+
 class FeatureFlagsSerializer(serializers.Serializer):
-    flags = serializers.DictField(
-        child=serializers.BooleanField(),
-        read_only=True,
-        help_text="Map of public feature flag name to its enabled state for the current user.",
+    flags = PublicFeatureFlagsSerializer(
+        help_text="Enabled state of each public feature flag for the current user.",
     )

--- a/src/webapp/src/features/feed/components/FeedStrip.test.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders, screen } from "@/test-utils/render";
-import { FEED_FLAG } from "../feedFlags";
 import { FeedStrip } from "./FeedStrip";
 
 vi.mock("@tanstack/react-router", async () => ({
@@ -11,14 +10,14 @@ vi.mock("@tanstack/react-router", async () => ({
 
 describe("FeedStrip", () => {
 	it("renders nothing when the feed flag is off", () => {
-		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: false } });
+		renderWithProviders(<FeedStrip />, { flags: { fe_feed: false } });
 
 		expect(screen.queryByText("Стрічка оновлень")).not.toBeInTheDocument();
 	});
 
 	it("renders nothing until the flags have resolved", () => {
 		renderWithProviders(<FeedStrip />, {
-			flags: { [FEED_FLAG]: true },
+			flags: { fe_feed: true },
 			flagsReady: false,
 		});
 
@@ -26,7 +25,7 @@ describe("FeedStrip", () => {
 	});
 
 	it("renders the feed and links to /feed when the flag is on", () => {
-		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: true } });
+		renderWithProviders(<FeedStrip />, { flags: { fe_feed: true } });
 
 		expect(screen.getByText("Стрічка оновлень")).toBeInTheDocument();
 		expect(screen.getByRole("link", { name: /Уся стрічка/ })).toHaveAttribute(
@@ -39,7 +38,7 @@ describe("FeedStrip", () => {
 	});
 
 	it("orders pinned content ahead of unpinned content", () => {
-		renderWithProviders(<FeedStrip />, { flags: { [FEED_FLAG]: true } });
+		renderWithProviders(<FeedStrip />, { flags: { fe_feed: true } });
 
 		const pinned = screen.getByText("Хакатон факультету інформатики");
 		const unpinned = screen.getByText("Реєстрація на вибіркові відкрита");

--- a/src/webapp/src/features/feed/components/FeedStrip.tsx
+++ b/src/webapp/src/features/feed/components/FeedStrip.tsx
@@ -3,7 +3,6 @@ import { ArrowRight, Newspaper, Pin } from "lucide-react";
 
 import { Button } from "@/components/ui/Button";
 import { useFeatureFlagState } from "@/lib/feature-flags";
-import { FEED_FLAG } from "../feedFlags";
 import { MOCK_FEED_ITEMS } from "../feedMockData";
 import { isPromoItem, orderFeedItems } from "../feedTypes";
 import { FeedPromoItem } from "./FeedPromoItem";
@@ -21,7 +20,7 @@ import { FeedReviewItem } from "./FeedReviewItem";
  * which isn't obvious on its own.
  */
 export function FeedStrip() {
-	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
+	const { enabled, isReady } = useFeatureFlagState("fe_feed");
 	const items = MOCK_FEED_ITEMS;
 
 	// Gate on the flag, and stay hidden until it resolves so the feed never

--- a/src/webapp/src/features/feed/feedFlags.ts
+++ b/src/webapp/src/features/feed/feedFlags.ts
@@ -1,9 +1,0 @@
-/**
- * Waffle flag that gates the homepage feed.
- *
- * Opt-in, following the `fe_`-prefixed convention: the feed renders only when
- * the flag resolves on, so it ships dark and can be disabled on demand by
- * turning the flag off (server-side, or via the `featureFlags` console helper
- * in non-live builds).
- */
-export const FEED_FLAG = "fe_feed";

--- a/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
+++ b/src/webapp/src/lib/feature-flags/FeatureFlagsContext.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FeatureFlagsProvider } from "./FeatureFlagsContext";
 import {
+	type FeatureFlagName,
 	useFeatureFlag,
 	useFeatureFlags,
 	useFeatureFlagState,
@@ -12,6 +13,9 @@ import {
 
 const FLAGS_QUERY_KEY = ["/api/v1/flags/"];
 const mockUseFlagsList = vi.fn();
+// Fixture names, cast so the test does not depend on the live allowlist.
+const FE_EXAMPLE = "fe_example" as FeatureFlagName;
+const FE_MISSING = "fe_missing" as FeatureFlagName;
 
 const { authState } = vi.hoisted(() => ({
 	authState: {
@@ -46,21 +50,21 @@ describe("feature flags", () => {
 		localStorage.clear(); // drop any ff:overrides leaked from other tests
 		authState.current = { status: "unauthenticated", user: null };
 		mockUseFlagsList.mockReturnValue({
-			data: { flags: { fe_example: true } },
+			data: { flags: { [FE_EXAMPLE]: true } },
 			isSuccess: true,
 			isError: false,
 		});
 	});
 
 	it("returns true for an enabled flag", () => {
-		const { result } = renderHook(() => useFeatureFlag("fe_example"), {
+		const { result } = renderHook(() => useFeatureFlag(FE_EXAMPLE), {
 			wrapper,
 		});
 		expect(result.current).toBe(true);
 	});
 
 	it("returns false for an unknown flag", () => {
-		const { result } = renderHook(() => useFeatureFlag("fe_missing"), {
+		const { result } = renderHook(() => useFeatureFlag(FE_MISSING), {
 			wrapper,
 		});
 		expect(result.current).toBe(false);
@@ -72,7 +76,7 @@ describe("feature flags", () => {
 			isSuccess: false,
 			isError: false,
 		});
-		const { result } = renderHook(() => useFeatureFlagState("fe_example"), {
+		const { result } = renderHook(() => useFeatureFlagState(FE_EXAMPLE), {
 			wrapper,
 		});
 		expect(result.current).toEqual({ enabled: false, isReady: false });
@@ -111,7 +115,7 @@ describe("feature flags", () => {
 	});
 
 	it("throws when used outside the provider", () => {
-		expect(() => renderHook(() => useFeatureFlag("fe_example"))).toThrow(
+		expect(() => renderHook(() => useFeatureFlag(FE_EXAMPLE))).toThrow(
 			/within a FeatureFlagsProvider/,
 		);
 	});

--- a/src/webapp/src/lib/feature-flags/index.ts
+++ b/src/webapp/src/lib/feature-flags/index.ts
@@ -7,6 +7,7 @@ export {
 	readFeatureFlagOverrides,
 	setFeatureFlagOverride,
 } from "./overrides";
+export type { FeatureFlagName } from "./useFeatureFlag";
 export {
 	useFeatureFlag,
 	useFeatureFlags,

--- a/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
+++ b/src/webapp/src/lib/feature-flags/useFeatureFlag.ts
@@ -1,6 +1,10 @@
 import { useContext } from "react";
 
+import type { PublicFeatureFlags } from "../api/generated";
 import { FeatureFlagsContext } from "./FeatureFlagsContext";
+
+/** Allowlisted flag names, derived from the generated `/api/v1/flags/` schema. */
+export type FeatureFlagName = keyof PublicFeatureFlags;
 
 export function useFeatureFlags() {
 	const context = useContext(FeatureFlagsContext);
@@ -12,7 +16,7 @@ export function useFeatureFlags() {
 	return context;
 }
 
-export function useFeatureFlag(name: string): boolean {
+export function useFeatureFlag(name: FeatureFlagName): boolean {
 	return useFeatureFlags().flags[name] ?? false;
 }
 
@@ -21,7 +25,7 @@ export function useFeatureFlag(name: string): boolean {
  * wrong variant. `useFeatureFlag` alone reports an unresolved flag as `false`,
  * which is indistinguishable from "off".
  */
-export function useFeatureFlagState(name: string): {
+export function useFeatureFlagState(name: FeatureFlagName): {
 	enabled: boolean;
 	isReady: boolean;
 } {

--- a/src/webapp/src/routes/feed.test.tsx
+++ b/src/webapp/src/routes/feed.test.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { FEED_FLAG } from "@/features/feed/feedFlags";
 import { renderWithProviders, screen } from "@/test-utils/render";
 import { FeedRoute } from "./feed";
 
@@ -17,13 +16,13 @@ vi.mock("@tanstack/react-router", async () => ({
 
 describe("FeedRoute", () => {
 	it("shows an unavailable message when the feed flag is off", () => {
-		renderWithProviders(<FeedRoute />, { flags: { [FEED_FLAG]: false } });
+		renderWithProviders(<FeedRoute />, { flags: { fe_feed: false } });
 
 		expect(screen.getByText("Стрічка наразі недоступна.")).toBeInTheDocument();
 	});
 
 	it("renders the heading and feed items when the flag is on", () => {
-		renderWithProviders(<FeedRoute />, { flags: { [FEED_FLAG]: true } });
+		renderWithProviders(<FeedRoute />, { flags: { fe_feed: true } });
 
 		expect(
 			screen.getByRole("heading", { name: /Стрічка оновлень/ }),

--- a/src/webapp/src/routes/feed.tsx
+++ b/src/webapp/src/routes/feed.tsx
@@ -4,14 +4,13 @@ import { Newspaper, Pin } from "lucide-react";
 import Layout from "@/components/Layout";
 import { FeedPromoItem } from "@/features/feed/components/FeedPromoItem";
 import { FeedReviewItem } from "@/features/feed/components/FeedReviewItem";
-import { FEED_FLAG } from "@/features/feed/feedFlags";
 import { MOCK_FEED_ITEMS } from "@/features/feed/feedMockData";
 import { isPromoItem, orderFeedItems } from "@/features/feed/feedTypes";
 import { withAuth } from "@/lib/auth";
 import { useFeatureFlagState } from "@/lib/feature-flags";
 
 export function FeedRoute() {
-	const { enabled, isReady } = useFeatureFlagState(FEED_FLAG);
+	const { enabled, isReady } = useFeatureFlagState("fe_feed");
 	const items = orderFeedItems(MOCK_FEED_ITEMS);
 
 	return (


### PR DESCRIPTION
`useFeatureFlag(name: string)` accepted any string, so a flag never added to `PUBLIC_FEATURE_FLAGS` compiled fine and silently stayed off (see #657, `fe_feed`).

`FeatureFlagsSerializer.flags` was a `DictField`, which erased the keys in the OpenAPI spec. It is now a nested serializer whose boolean fields are built from `settings.PUBLIC_FEATURE_FLAGS` in `get_fields()` (call time, so the `test_flags.py` settings overrides keep working). The regenerated spec lists the names as required keys, and `useFeatureFlag` / `useFeatureFlagState` take `FeatureFlagName = keyof PublicFeatureFlags`, so an unlisted name fails `tsc` and removing a flag from the allowlist flags every stale consumer. Runtime response shape is unchanged. Rebasing onto #657 made `tsc` reject `fe_feed` immediately, so it is now allowlisted as that PR intended (ships dark, off until the Flag row is targeted).

Verification: `uv run pytest rating_app/views/test_flags.py` (exit 0, 5 passed), `uv run ruff format` + `ruff check` on the changed files (exit 0), `uv run python manage.py spectacular --file ../../docs/api/openapi-generated.yaml` (exit 0), `pnpm generate-api` (exit 0), `pnpm check` (exit 0), `pnpm test` (exit 0, 311 passed). Throwaway `useFeatureFlag("fe_nope")` fails `tsc` with TS2345 (exit 1), reverted.

Resolves #662
