### PR TITLE
test(#230): cover CourseRepository.filter pagination

### DIFF
--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -148,27 +148,34 @@ def test_filter_returns_domain_models(repo):
     assert isinstance(found_course.specialities, list)
 
 
+@pytest.fixture
+def five_courses_out_of_order():
+    # Insertion order differs from the alphabetical order the repository must apply.
+    return [CourseFactory(title=f"Course {letter}") for letter in "DBEAC"]
+
+
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_filter_without_pagination_returns_plain_list_of_all_matching_courses(repo):
-    # Arrange
-    courses = [CourseFactory(title=f"Course {letter}") for letter in "ABCDE"]
-
+def test_filter_without_pagination_returns_plain_list_of_all_matching_courses(
+    repo, five_courses_out_of_order
+):
     # Act
     result = repo.filter(CourseFilterCriteriaInternal())
 
     # Assert
     assert isinstance(result, list)
-    assert [c.title for c in result] == [c.title for c in courses]
+    assert [c.title for c in result] == [
+        "Course A",
+        "Course B",
+        "Course C",
+        "Course D",
+        "Course E",
+    ]
 
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_filter_with_pagination_returns_first_page_and_metadata(repo):
-    # Arrange
-    for letter in "ABCDE":
-        CourseFactory(title=f"Course {letter}")
-
+def test_filter_with_pagination_returns_first_page_and_metadata(repo, five_courses_out_of_order):
     # Act
     result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=1, page_size=2))
 
@@ -182,11 +189,9 @@ def test_filter_with_pagination_returns_first_page_and_metadata(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_filter_with_pagination_last_page_returns_remaining_courses(repo):
-    # Arrange
-    for letter in "ABCDE":
-        CourseFactory(title=f"Course {letter}")
-
+def test_filter_with_pagination_last_page_returns_remaining_courses(
+    repo, five_courses_out_of_order
+):
     # Act
     result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=3, page_size=2))
 
@@ -198,11 +203,9 @@ def test_filter_with_pagination_last_page_returns_remaining_courses(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_filter_with_pagination_page_beyond_range_clamps_to_last_page(repo):
-    # Arrange
-    for letter in "ABCDE":
-        CourseFactory(title=f"Course {letter}")
-
+def test_filter_with_pagination_page_beyond_range_clamps_to_last_page(
+    repo, five_courses_out_of_order
+):
     # Act
     result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=99, page_size=2))
 

--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -3,7 +3,7 @@ import pytest
 from rating_app.application_schemas.course import CourseFilterCriteriaInternal, CourseInput
 from rating_app.models import Course
 from rating_app.models.choices import CourseStatus, EducationLevel, SemesterTerm
-from rating_app.pagination import GenericQuerysetPaginator
+from rating_app.pagination import GenericQuerysetPaginator, PaginationFilters
 from rating_app.repositories.course_repository import CourseRepository
 from rating_app.repositories.to_domain_mappers import CourseMapper
 from rating_app.tests.factories import (
@@ -146,6 +146,71 @@ def test_filter_returns_domain_models(repo):
     assert found_course is not None
     assert found_course.title == course.title
     assert isinstance(found_course.specialities, list)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_without_pagination_returns_plain_list_of_all_matching_courses(repo):
+    # Arrange
+    courses = [CourseFactory(title=f"Course {letter}") for letter in "ABCDE"]
+
+    # Act
+    result = repo.filter(CourseFilterCriteriaInternal())
+
+    # Assert
+    assert isinstance(result, list)
+    assert [c.title for c in result] == [c.title for c in courses]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_with_pagination_returns_first_page_and_metadata(repo):
+    # Arrange
+    for letter in "ABCDE":
+        CourseFactory(title=f"Course {letter}")
+
+    # Act
+    result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=1, page_size=2))
+
+    # Assert
+    assert [c.title for c in result.page_objects] == ["Course A", "Course B"]
+    assert result.metadata.total == 5
+    assert result.metadata.total_pages == 3
+    assert result.metadata.page == 1
+    assert result.metadata.page_size == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_with_pagination_last_page_returns_remaining_courses(repo):
+    # Arrange
+    for letter in "ABCDE":
+        CourseFactory(title=f"Course {letter}")
+
+    # Act
+    result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=3, page_size=2))
+
+    # Assert
+    assert [c.title for c in result.page_objects] == ["Course E"]
+    assert result.metadata.page == 3
+    assert result.metadata.total_pages == 3
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_with_pagination_page_beyond_range_clamps_to_last_page(repo):
+    # Arrange
+    for letter in "ABCDE":
+        CourseFactory(title=f"Course {letter}")
+
+    # Act
+    result = repo.filter(CourseFilterCriteriaInternal(), PaginationFilters(page=99, page_size=2))
+
+    # Assert
+    assert [c.title for c in result.page_objects] == ["Course E"]
+    assert result.metadata.page == 3
+    assert result.metadata.total_pages == 3
+    assert result.metadata.total == 5
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Resolves #230

Adds four `CourseRepository.filter` tests: no pagination returns a plain list in repo ordering; `PaginationFilters(page=1, page_size=2)` on 5 courses returns 2 objects with total=5/total_pages=3; last page returns the remaining course; page=99 clamps to the last page (Django `Paginator.get_page` behaviour, asserted on observed output).

```
$ uv run pytest rating_app/repositories/test_course_repository.py -q
..............                                                           [100%]
14 passed in 0.20s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for course list pagination.
  * Verified unpaginated results, first and last pages, pagination metadata, and requests beyond the available page range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->