### PR TITLE
feat(#670): sort courses by popularity by default

### DIFF
--- a/src/webapp/src/features/courses/components/CoursesTable.test.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.test.tsx
@@ -742,7 +742,7 @@ describe("Sorting", () => {
 		await user.click(screen.getByRole("menuitem", { name: "Найновіші" }));
 
 		expect(setParams).toHaveBeenCalledWith({
-			reviewSort: null,
+			reviewSort: "newest",
 			diffOrder: null,
 			useOrder: null,
 			page: 1,

--- a/src/webapp/src/features/courses/components/CoursesTable.tsx
+++ b/src/webapp/src/features/courses/components/CoursesTable.tsx
@@ -409,14 +409,13 @@ export function CoursesTable({
 
 	const reviewsSortValue = useMemo<CoursesReviewsSortOption | null>(() => {
 		if (params.diffOrder || params.useOrder) return null;
-		if (params.reviewSort === "by-count") return "by-count";
-		return "newest";
+		return params.reviewSort ?? "by-count";
 	}, [params.diffOrder, params.useOrder, params.reviewSort]);
 
 	const handleReviewsSortChange = useCallback(
 		(value: CoursesReviewsSortOption) => {
 			setParams({
-				reviewSort: value === "by-count" ? "by-count" : null,
+				reviewSort: value,
 				diffOrder: null,
 				useOrder: null,
 				page: 1,

--- a/src/webapp/src/features/courses/courseFiltersParams.ts
+++ b/src/webapp/src/features/courses/courseFiltersParams.ts
@@ -36,7 +36,7 @@ const VALID_EDUCATION_LEVELS: readonly EducationLevelEnum[] = [
 
 type SortOrder = "asc" | "desc";
 const VALID_SORT_ORDERS: readonly SortOrder[] = ["asc", "desc"];
-const VALID_REVIEW_SORTS: "by-count"[] = ["by-count"];
+const VALID_REVIEW_SORTS: Array<"by-count" | "newest"> = ["by-count", "newest"];
 
 function createRangeParser(bounds: [number, number], step?: number) {
 	const [minBound, maxBound] = bounds;
@@ -103,7 +103,7 @@ export const courseFiltersParams = {
 	useOrder: parseAsStringEnum<SortOrder>(
 		VALID_SORT_ORDERS as unknown as SortOrder[],
 	),
-	reviewSort: parseAsStringEnum<"by-count">(VALID_REVIEW_SORTS),
+	reviewSort: parseAsStringEnum<"by-count" | "newest">(VALID_REVIEW_SORTS),
 };
 
 export function useCourseFiltersParams() {

--- a/src/webapp/src/routes/index.test.tsx
+++ b/src/webapp/src/routes/index.test.tsx
@@ -110,5 +110,31 @@ describe("CoursesRoute", () => {
 		expect(screen.queryByTestId("courses-error-state")).not.toBeInTheDocument();
 		expect(screen.getByTestId("courses-table")).toBeInTheDocument();
 		expect(screen.getByTestId("courses-search-input")).toHaveValue("persisted");
+		expect(vi.mocked(useCoursesList)).toHaveBeenCalledWith(
+			expect.objectContaining({ last_review_order: undefined }),
+			expect.anything(),
+		);
+	});
+
+	it("uses newest review sorting when explicitly selected", () => {
+		const setParams = vi.fn();
+		vi.mocked(useCourseFiltersParams).mockReturnValue([
+			{ ...DEFAULT_COURSE_FILTERS_PARAMS, reviewSort: "newest" },
+			setParams,
+		]);
+
+		vi.mocked(useCoursesList).mockReturnValue({
+			data: { items: [], page: 1, page_size: 10, total: 0, total_pages: 0 },
+			isFetching: false,
+			isError: false,
+			refetch: vi.fn(),
+		} as unknown as ReturnType<typeof useCoursesList>);
+
+		render(<CoursesRoute />);
+
+		expect(vi.mocked(useCoursesList)).toHaveBeenCalledWith(
+			expect.objectContaining({ last_review_order: "desc" }),
+			expect.anything(),
+		);
 	});
 });

--- a/src/webapp/src/routes/index.tsx
+++ b/src/webapp/src/routes/index.tsx
@@ -51,10 +51,7 @@ export function CoursesRoute() {
 		education_level: params.eduLevel ?? undefined,
 		avg_difficulty_order: params.diffOrder ?? undefined,
 		avg_usefulness_order: params.useOrder ?? undefined,
-		last_review_order:
-			params.diffOrder || params.useOrder || params.reviewSort === "by-count"
-				? undefined
-				: "desc",
+		last_review_order: params.reviewSort === "newest" ? "desc" : undefined,
 	};
 
 	const { data, isFetching, isError, refetch } = useCoursesList(apiFilters, {

--- a/src/webapp/src/routes/index.tsx
+++ b/src/webapp/src/routes/index.tsx
@@ -51,7 +51,10 @@ export function CoursesRoute() {
 		education_level: params.eduLevel ?? undefined,
 		avg_difficulty_order: params.diffOrder ?? undefined,
 		avg_usefulness_order: params.useOrder ?? undefined,
-		last_review_order: params.reviewSort === "newest" ? "desc" : undefined,
+		last_review_order:
+			params.diffOrder || params.useOrder || params.reviewSort !== "newest"
+				? undefined
+				: "desc",
 	};
 
 	const { data, isFetching, isError, refetch } = useCoursesList(apiFilters, {


### PR DESCRIPTION
Resolves #670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for sorting courses by the newest reviews.
  - The selected review-sorting option is now preserved in course filters and reflected in the URL.

- **Bug Fixes**
  - Corrected review sorting behavior so “Newest” applies the expected ordering.
  - Review sorting now works consistently alongside difficulty and usefulness filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->