### PR TITLE
test(#230): codify backend test conventions and unify pytest style

### DIFF
--- a/docs/testing/backend-tests.md
+++ b/docs/testing/backend-tests.md
@@ -1,0 +1,65 @@
+# Backend Test Conventions
+
+Rules for pytest code under `src/backend`. `docs/testing/testing-strategy.md` covers the pyramid and coverage targets; this file covers how a single test is written. Older files may predate a rule: follow the rule, not the neighbour, and mention the contradiction in the PR.
+
+The mechanical half of these rules is enforced by ruff's `PT` (flake8-pytest-style) rule set, enabled in `src/backend/pyproject.toml`.
+
+## Layout
+
+- Tests live next to the code they test: `rating_app/repositories/course_repository.py` is tested by `rating_app/repositories/test_course_repository.py`. `rating_app/tests/` holds only `factories.py`.
+- Shared fixtures and factory shortcuts (`token_client`, `course_factory`, ...) live in `src/backend/conftest.py`. Add a fixture there only when a second test file needs it.
+
+## Structure
+
+- Module-level `def test_*` functions. No `class Test*` groups and no `unittest.TestCase`. Group related tests by file and share setup through module-level `@pytest.fixture` (no parentheses) and private `_make_*` helpers.
+- One behaviour per test. Name it after the unit and the outcome: `test_<method>_<expected>_when_<condition>`. The name carries the intent; add a docstring only when it states non-obvious rationale (a boundary, an invariant, a trap the test guards).
+- Body in three blocks separated by blank lines: arrange, act, assert. `# Arrange` / `# Act` / `# Assert` comments are optional; keep them consistent within a file.
+- `pytest.mark.parametrize` takes a tuple of names, not a comma-separated string. Use it for the same path with different inputs, not for unrelated behaviours.
+
+## Markers
+
+`pytest.ini` registers two markers: `integration` and `e2e`. There is no `unit` marker; a test without markers is a unit test.
+
+- Every test that touches the database carries both `@pytest.mark.django_db` and `@pytest.mark.integration`, in that order, directly above the function. A file where every test hits the database may declare `pytestmark = [pytest.mark.django_db, pytest.mark.integration]` once at module level.
+- `@pytest.mark.e2e` is reserved for Playwright flows in `src/webapp`; backend tests do not use it.
+
+## Test data by layer
+
+| Layer | Data source | Reason |
+| --- | --- | --- |
+| Repositories, mappers, views | `rating_app.tests.factories` (`CourseFactory`, ...) via `conftest.py` fixtures or direct import | The contract is the query and the serialized shape; only a real database proves it. |
+| Services, event listeners, adapters | `MagicMock` / `SimpleNamespace` standing in for repository and service protocols | Services are wired through `rateukma.ioc` protocols; a unit test asserts the calls the service makes, not the ORM. |
+| Scraper parsers and dedup | Inline fixtures and sample payloads | Pure functions over parsed HTML; no database. |
+
+Rules that apply to all layers:
+
+- Never create fixtures in the order the assertion expects. Ordering tests must insert out of order so a dropped `order_by` fails the test (see `test_course_repository.py::five_courses_out_of_order`).
+- Assert on what a consumer observes: returned DTOs, response JSON, raised exception, repository calls. Do not assert a mock echoing its own input, `hasattr`, or `len(result) > 0`.
+- Query-count invariants use `django_assert_num_queries`; that is the only place where implementation detail is asserted on purpose.
+- Values that look like production data (real names, emails, ids) never appear in tests; invent them or use `faker`.
+
+## Exceptions
+
+- Pass `match=` with a stable fragment of the real message. Bare `pytest.raises(ValueError)` accepts any `ValueError`, including one raised by a typo in the arrange block. When the exception carries no message (a bare domain error such as `InvalidCursorError`), a bare `pytest.raises` is acceptable.
+- Never assert inside an `except` block; a test that never raises would pass silently.
+
+## Running
+
+```bash
+cd src/backend
+uv sync --extra test --extra linting   # pytest and ruff are extras, not base dependencies
+cp ../.env.sample .env                 # settings read DJANGO_SECRET_KEY even under settings.testing
+uv run pytest rating_app/repositories/test_course_repository.py -q
+uv run pytest -m integration -q        # DB-backed tests only
+uv run ruff check --select PT .        # pytest-style lint
+```
+
+`settings.testing` swaps the database for in-memory SQLite, so PostgreSQL-only behaviour (collation, JSON operators) is not covered by the suite. `--reuse-db` is on by default in `pytest.ini`; pass `--create-db` after changing migrations.
+
+## Sources
+
+- pytest: [Good integration practices](https://docs.pytest.org/en/stable/explanation/goodpractices.html), [How to use fixtures](https://docs.pytest.org/en/stable/how-to/fixtures.html)
+- pytest-django: [Database access](https://pytest-django.readthedocs.io/en/latest/database.html), [Helpers](https://pytest-django.readthedocs.io/en/latest/helpers.html)
+- ruff: [flake8-pytest-style (PT)](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt)
+- factory_boy: [Using factories](https://factoryboy.readthedocs.io/en/stable/introduction.html)
+- Arrange-Act-Assert (Bill Wake) and "Software Engineering at Google", ch. 12 (test behaviours, not methods; clarity over deduplication in tests)

--- a/docs/testing/backend-tests.md
+++ b/docs/testing/backend-tests.md
@@ -21,6 +21,7 @@ The mechanical half of these rules is enforced by ruff's `PT` (flake8-pytest-sty
 `pytest.ini` registers two markers: `integration` and `e2e`. There is no `unit` marker; a test without markers is a unit test.
 
 - Every test that touches the database carries both `@pytest.mark.django_db` and `@pytest.mark.integration`, in that order, directly above the function. A file where every test hits the database may declare `pytestmark = [pytest.mark.django_db, pytest.mark.integration]` once at module level.
+- The converse does not hold: the cache-layer tests in `rateukma/caching/test_cache.py` carry `integration` without touching the database (they exercise the cache layer against a mocked redis client).
 - `@pytest.mark.e2e` is reserved for Playwright flows in `src/webapp`; backend tests do not use it.
 
 ## Test data by layer
@@ -50,7 +51,7 @@ cd src/backend
 uv sync --extra test --extra linting   # pytest and ruff are extras, not base dependencies
 cp ../.env.sample .env                 # settings read DJANGO_SECRET_KEY even under settings.testing
 uv run pytest rating_app/repositories/test_course_repository.py -q
-uv run pytest -m integration -q        # DB-backed tests only
+uv run pytest -m integration -q        # integration-marked tests (mostly, not only, DB-backed)
 uv run ruff check --select PT .        # pytest-style lint
 ```
 

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -54,6 +54,8 @@ Validate critical user journeys
 - pytest-cov
 - factory_boy (test fixtures)
 
+Conventions for writing backend tests: [backend-tests.md](backend-tests.md).
+
 ### Frontend Testing
 
 - Vitest

--- a/src/backend/AGENTS.md
+++ b/src/backend/AGENTS.md
@@ -53,6 +53,16 @@ Escapes are a last resort, in order of preference:
 
 Don't widen a shared type (protocol return, DTO field) to make one implementer pass — fix the implementer or remove the false inheritance.
 
+## Tests
+
+Full conventions: [docs/testing/backend-tests.md](../../docs/testing/backend-tests.md). The rules that are cheapest to get wrong:
+
+- Module-level `def test_*` functions next to the code under test; no `class Test*`. Shared setup is a module-level `@pytest.fixture` or a `_make_*` helper.
+- Database access needs `@pytest.mark.django_db` and `@pytest.mark.integration`, in that order. Repositories and views run against factories from `rating_app.tests.factories`; services and listeners are unit-tested against `MagicMock` protocols, and a service test that needs the ORM carries both markers like any other DB test.
+- Insert ordering fixtures out of order; a test whose fixtures already sit in the expected order passes without the `order_by` it claims to cover.
+- `pytest.raises` takes `match=` with a message fragment, unless the exception carries no message; ruff `PT` rules enforce the rest of the pytest style.
+- Run `uv run pytest <file> -q` from `src/backend`; needs `uv sync --extra test` and a `.env` copied from `src/.env.sample`.
+
 ## Logging style
 
 Start log calls with a snake_case event name, then pass structured context via keyword args so tools can parse them.

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -99,6 +99,7 @@ select = [
     "C4", # collections comprehensions
     "UP", # use more modern Python
     "N",  # naming conventions
+    "PT", # pytest style, see docs/testing/backend-tests.md
 ]
 
 [tool.ruff.format]

--- a/src/backend/rateukma/caching/test_cache.py
+++ b/src/backend/rateukma/caching/test_cache.py
@@ -48,349 +48,354 @@ def cache_key_context_provider() -> CacheKeyContextProvider:
     return CacheKeyContextProvider()
 
 
+@dataclass(frozen=True)
+class _TestData:
+    name: str
+    value: int
+    active: bool = True
+
+
+class _TestModel(BaseModel):
+    name: str
+    count: int
+    optional: str = "default"
+
+
+class _TestService:
+    pass
+
+
+_SESSION_MARKER = "django.contrib.sessions"
+
+
 @pytest.mark.usefixtures("cache_manager", "mock_redis_client", "cache_key_context_provider")
 @pytest.mark.integration
-class TestCachePrimitives:
-    @pytest.mark.parametrize(
-        "primitive_value, type",
-        [
-            (42, int),
-            ("hello", str),
-            (True, bool),
-            (False, bool),
-            ([1, 2, 3], list),
-            ({"key": "value"}, dict),
-        ],
-    )
-    def test_cache_primitives(self, primitive_value, type, cache_key_context_provider):
-        # Arrange
-        ext = TypeAdapterCacheExtension(cache_key_context_provider)
+@pytest.mark.parametrize(
+    ("primitive_value", "type"),
+    [
+        (42, int),
+        ("hello", str),
+        (True, bool),
+        (False, bool),
+        ([1, 2, 3], list),
+        ({"key": "value"}, dict),
+    ],
+)
+def test_cache_primitives(primitive_value, type, cache_key_context_provider):
+    # Arrange
+    ext = TypeAdapterCacheExtension(cache_key_context_provider)
 
-        # Act and Assert - serialize
-        result = ext.serialize(primitive_value, type)
-        assert result == primitive_value
+    # Act and Assert - serialize
+    result = ext.serialize(primitive_value, type)
+    assert result == primitive_value
 
-        # Act and Assert - deserialize
-        deserialized = ext.deserialize(result, type)
-        assert deserialized == primitive_value
-
-
-@pytest.mark.usefixtures("cache_manager", "mock_redis_client")
-@pytest.mark.integration
-class TestCacheDataclasses:
-    @dataclass(frozen=True)
-    class _TestData:
-        name: str
-        value: int
-        active: bool = True
-
-    def test_cache_dataclasses(self, cache_key_context_provider):
-        # Arrange
-        test_data = self._TestData(name="test", value=42, active=False)
-        ext = TypeAdapterCacheExtension(cache_key_context_provider)
-
-        # Act and Assert - serialize
-        result = ext.serialize(test_data, self._TestData)
-        expected = asdict(test_data)
-        assert result == expected
-
-        # Act and Assert - deserialize
-        deserialized = ext.deserialize(result, self._TestData)
-        assert isinstance(deserialized, self._TestData)
-        assert deserialized.name == test_data.name
-        assert deserialized.value == test_data.value
-        assert deserialized.active == test_data.active
-
-        # cache key generation
-        cache_key = ext.get_cache_key(lambda: None, (), {})
-        assert "lambda" in cache_key
+    # Act and Assert - deserialize
+    deserialized = ext.deserialize(result, type)
+    assert deserialized == primitive_value
 
 
 @pytest.mark.usefixtures("cache_manager", "mock_redis_client")
 @pytest.mark.integration
-class TestCacheDRFResponses:
-    @pytest.mark.parametrize(
-        "response, expected_result",
-        [
-            (
-                Response(
-                    {"data": "test"}, status=200, headers={"Content-Type": "application/json"}
-                ),
-                {
-                    "_wrapped": False,
-                    "data": "test",
-                    "status_code": 200,
-                    "headers": {"Content-Type": "application/json"},
-                },
-            ),
-            (
-                Response(
-                    ["item1", "item2"], status=200, headers={"Content-Type": "application/json"}
-                ),
-                {
-                    "_wrapped": True,
-                    "data": ["item1", "item2"],
-                    "status_code": 200,
-                    "headers": {"Content-Type": "application/json"},
-                },
-            ),
-        ],
-    )
-    def test_cache_drf_responses(self, response, expected_result, cache_key_context_provider):
-        # Arrange
-        ext = DRFResponseCacheTypeExtension(cache_key_context_provider)
+def test_cache_dataclasses(cache_key_context_provider):
+    # Arrange
+    test_data = _TestData(name="test", value=42, active=False)
+    ext = TypeAdapterCacheExtension(cache_key_context_provider)
 
-        mock_request = Mock(spec=Request)
-        mock_request.method = "GET"
-        mock_request.path = "/api/test"
-        mock_request.query_params = {"param": "value"}
-        mock_request.headers = {"Content-Type": "application/json"}
+    # Act and Assert - serialize
+    result = ext.serialize(test_data, _TestData)
+    expected = asdict(test_data)
+    assert result == expected
 
-        # Act and Assert - serialize
-        result = ext.serialize(response, Response)
-        assert result == expected_result
+    # Act and Assert - deserialize
+    deserialized = ext.deserialize(result, _TestData)
+    assert isinstance(deserialized, _TestData)
+    assert deserialized.name == test_data.name
+    assert deserialized.value == test_data.value
+    assert deserialized.active == test_data.active
 
-        # Act and Assert - deserialize
-        deserialized = ext.deserialize(result, Response)
-        assert isinstance(deserialized, Response)
-        assert deserialized.data == response.data
-        assert deserialized.status_code == response.status_code
-        assert deserialized.headers == response.headers
-
-        # Act and Assert - get cache key
-        cache_key = ext.get_cache_key(lambda: None, (mock_request,), {})
-        expected_func_pattern = (
-            f"{mock_request.method}:{mock_request.path}?{urlencode(mock_request.query_params)}"
-        )
-        assert expected_func_pattern in cache_key
+    # cache key generation
+    cache_key = ext.get_cache_key(lambda: None, (), {})
+    assert "lambda" in cache_key
 
 
 @pytest.mark.usefixtures("cache_manager", "mock_redis_client")
 @pytest.mark.integration
-class TestCacheBaseModels:
-    class _TestModel(BaseModel):
-        name: str
-        count: int
-        optional: str = "default"
+@pytest.mark.parametrize(
+    ("response", "expected_result"),
+    [
+        (
+            Response({"data": "test"}, status=200, headers={"Content-Type": "application/json"}),
+            {
+                "_wrapped": False,
+                "data": "test",
+                "status_code": 200,
+                "headers": {"Content-Type": "application/json"},
+            },
+        ),
+        (
+            Response(["item1", "item2"], status=200, headers={"Content-Type": "application/json"}),
+            {
+                "_wrapped": True,
+                "data": ["item1", "item2"],
+                "status_code": 200,
+                "headers": {"Content-Type": "application/json"},
+            },
+        ),
+    ],
+)
+def test_cache_drf_responses(response, expected_result, cache_key_context_provider):
+    # Arrange
+    ext = DRFResponseCacheTypeExtension(cache_key_context_provider)
 
-    def test_cache_base_models(self, cache_key_context_provider):
-        # Arrange
-        ext = TypeAdapterCacheExtension(cache_key_context_provider)
-        instance = self._TestModel(name="test model", count=100, optional="custom")
+    mock_request = Mock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.path = "/api/test"
+    mock_request.query_params = {"param": "value"}
+    mock_request.headers = {"Content-Type": "application/json"}
 
-        # Act and Assert - serialize
-        result = ext.serialize(instance, self._TestModel)
-        expected = instance.model_dump()
-        assert result == expected
+    # Act and Assert - serialize
+    result = ext.serialize(response, Response)
+    assert result == expected_result
 
-        # Act and Assert - deserialize
-        deserialized = ext.deserialize(result, self._TestModel)
-        assert isinstance(deserialized, self._TestModel)
-        assert deserialized.name == "test model"
-        assert deserialized.count == 100
-        assert deserialized.optional == "custom"
+    # Act and Assert - deserialize
+    deserialized = ext.deserialize(result, Response)
+    assert isinstance(deserialized, Response)
+    assert deserialized.data == response.data
+    assert deserialized.status_code == response.status_code
+    assert deserialized.headers == response.headers
 
-        # Act and Assert - get cache key
-        cache_key = ext.get_cache_key(lambda: None, (), {"param": "value"})
-        assert "param" in cache_key
-        assert "value" in cache_key
+    # Act and Assert - get cache key
+    cache_key = ext.get_cache_key(lambda: None, (mock_request,), {})
+    expected_func_pattern = (
+        f"{mock_request.method}:{mock_request.path}?{urlencode(mock_request.query_params)}"
+    )
+    assert expected_func_pattern in cache_key
+
+
+@pytest.mark.usefixtures("cache_manager", "mock_redis_client")
+@pytest.mark.integration
+def test_cache_base_models(cache_key_context_provider):
+    # Arrange
+    ext = TypeAdapterCacheExtension(cache_key_context_provider)
+    instance = _TestModel(name="test model", count=100, optional="custom")
+
+    # Act and Assert - serialize
+    result = ext.serialize(instance, _TestModel)
+    expected = instance.model_dump()
+    assert result == expected
+
+    # Act and Assert - deserialize
+    deserialized = ext.deserialize(result, _TestModel)
+    assert isinstance(deserialized, _TestModel)
+    assert deserialized.name == "test model"
+    assert deserialized.count == 100
+    assert deserialized.optional == "custom"
+
+    # Act and Assert - get cache key
+    cache_key = ext.get_cache_key(lambda: None, (), {"param": "value"})
+    assert "param" in cache_key
+    assert "value" in cache_key
 
 
 @pytest.mark.integration
-class TestRCachedComponents:
-    @pytest.mark.parametrize(
-        "primitive_value,expected_type",
-        [
-            (42, int),
-            ("hello world", str),
-            (True, bool),
-            (False, bool),
-            ([1, 2, 3], list),
-            ({"key": "value"}, dict),
-        ],
-    )
-    def test_rcached_decorator_with_primitives(
-        self, cache_manager, mock_redis_client, primitive_value, expected_type, settings
-    ):
-        settings.ENABLE_CACHE = True
-        with patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager):
-            # Arrange
-            @rcached(ttl=60, return_type=expected_type)
-            def get_primitive():
-                return primitive_value
-
-            mock_redis_client.get.return_value = None  # Cache miss
-
-            # Act and Assert - first call
-            result1 = get_primitive()
-            assert result1 == primitive_value
-            assert mock_redis_client.setex.called
-
-            # Arrange - reset mock for second call
-            mock_redis_client.reset_mock()
-
-            # Act and Assert - second call
-            cached_data = json.dumps(primitive_value).encode()
-            mock_redis_client.get.return_value = cached_data
-            result2 = get_primitive()
-            assert result2 == primitive_value
-
-    def test_cache_key_generation(self, cache_key_context_provider):
+@pytest.mark.parametrize(
+    ("primitive_value", "expected_type"),
+    [
+        (42, int),
+        ("hello world", str),
+        (True, bool),
+        (False, bool),
+        ([1, 2, 3], list),
+        ({"key": "value"}, dict),
+    ],
+)
+def test_rcached_decorator_with_primitives(
+    cache_manager, mock_redis_client, primitive_value, expected_type, settings
+):
+    settings.ENABLE_CACHE = True
+    with patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager):
         # Arrange
-        ext = TypeAdapterCacheExtension(cache_key_context_provider)
-        kwargs = {"param": "value"}
-        args1 = (1,)
-        args2 = (2,)
+        @rcached(ttl=60, return_type=expected_type)
+        def get_primitive():
+            return primitive_value
 
-        # Act and Assert
-        key1 = ext.get_cache_key(lambda x: x, args1, kwargs)
-        key2 = ext.get_cache_key(lambda x: x, args1, kwargs)
-        assert key1 == key2
+        mock_redis_client.get.return_value = None  # Cache miss
 
-        key3 = ext.get_cache_key(lambda x: x, args2, kwargs)
-        assert key1 != key3
+        # Act and Assert - first call
+        result1 = get_primitive()
+        assert result1 == primitive_value
+        assert mock_redis_client.setex.called
 
-        # Assert cache key contains args and kwargs
-        assert str(args1[0]) in key1
-        for key, value in kwargs.items():
-            assert f"{key}" in key1
-            assert f"{value}" in key1
+        # Arrange - reset mock for second call
+        mock_redis_client.reset_mock()
 
-    def test_rcached_decorator_with_versioned_namespace(self, settings):
-        settings.ENABLE_CACHE = True
-        cache_manager = InMemoryCacheManager()
-        calls = {"count": 0}
+        # Act and Assert - second call
+        cached_data = json.dumps(primitive_value).encode()
+        mock_redis_client.get.return_value = cached_data
+        result2 = get_primitive()
+        assert result2 == primitive_value
 
-        with patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager):
 
-            @rcached(ttl=60, return_type=int, versioned_by="courses:list")
-            def get_value():
-                calls["count"] += 1
-                return 42
+@pytest.mark.integration
+def test_cache_key_generation(cache_key_context_provider):
+    # Arrange
+    ext = TypeAdapterCacheExtension(cache_key_context_provider)
+    kwargs = {"param": "value"}
+    args1 = (1,)
+    args2 = (2,)
 
-            assert get_value() == 42
-            assert get_value() == 42
-            assert calls["count"] == 1
+    # Act and Assert
+    key1 = ext.get_cache_key(lambda x: x, args1, kwargs)
+    key2 = ext.get_cache_key(lambda x: x, args1, kwargs)
+    assert key1 == key2
 
-            cache_manager.bump_version("courses:list")
-            assert get_value() == 42
-            assert calls["count"] == 2
+    key3 = ext.get_cache_key(lambda x: x, args2, kwargs)
+    assert key1 != key3
 
-    def test_bump_version_sets_ttl(self, cache_manager, mock_redis_client):
+    # Assert cache key contains args and kwargs
+    assert str(args1[0]) in key1
+    for key, value in kwargs.items():
+        assert f"{key}" in key1
+        assert f"{value}" in key1
+
+
+@pytest.mark.integration
+def test_rcached_decorator_with_versioned_namespace(settings):
+    settings.ENABLE_CACHE = True
+    cache_manager = InMemoryCacheManager()
+    calls = {"count": 0}
+
+    with patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager):
+
+        @rcached(ttl=60, return_type=int, versioned_by="courses:list")
+        def get_value():
+            calls["count"] += 1
+            return 42
+
+        assert get_value() == 42
+        assert get_value() == 42
+        assert calls["count"] == 1
+
         cache_manager.bump_version("courses:list")
-        mock_redis_client.expire.assert_called_with("test:version:courses:list", 60 * 60 * 24 * 30)
+        assert get_value() == 42
+        assert calls["count"] == 2
 
 
 @pytest.mark.integration
-class TestInvalidatePatternSkipKeys:
-    SESSION_MARKER = "django.contrib.sessions"
-
-    def test_redis_skip_keys_preserves_session_keys(self):
-        app_key = b"rateukma:CourseService.get_course|1"
-        version_key = b"rateukma:version:courses:list"
-        session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
-
-        client = Mock()
-        client.scan.return_value = (0, [app_key, version_key, session_key])
-        client.delete.return_value = 2
-        manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
-
-        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
-
-        # session key is excluded; only app + version keys are deleted
-        client.delete.assert_called_once_with(app_key, version_key)
-        assert deleted == 2
-
-    def test_redis_skip_keys_no_delete_when_all_skipped(self):
-        session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
-
-        client = Mock()
-        client.scan.return_value = (0, [session_key])
-        manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
-
-        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
-
-        client.delete.assert_not_called()
-        assert deleted == 0
-
-    def test_inmemory_skip_keys_preserves_session_keys(self):
-        manager = InMemoryCacheManager()
-        manager.set("course:1", 1)
-        manager.set("1:django.contrib.sessions.cache<abc123>", "session-data")
-
-        deleted = manager.invalidate_pattern("*", skip_keys=[self.SESSION_MARKER])
-
-        assert deleted == 1
-        assert manager.get("course:1") is None
-        assert manager.get("1:django.contrib.sessions.cache<abc123>") == "session-data"
+def test_bump_version_sets_ttl(cache_manager, mock_redis_client):
+    cache_manager.bump_version("courses:list")
+    mock_redis_client.expire.assert_called_with("test:version:courses:list", 60 * 60 * 24 * 30)
 
 
-class TestCacheInvalidation:
-    class _TestService:
-        pass
+@pytest.mark.integration
+def test_redis_skip_keys_preserves_session_keys():
+    app_key = b"rateukma:CourseService.get_course|1"
+    version_key = b"rateukma:version:courses:list"
+    session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
 
-    def test_invalidate_cache_with_custom_pattern(self, cache_manager, mock_redis_client):
-        with (
-            patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
-            patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
-        ):
-            # Arrange
-            return_value = "executed"
-            pattern = "custom:*"
+    client = Mock()
+    client.scan.return_value = (0, [app_key, version_key, session_key])
+    client.delete.return_value = 2
+    manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
 
-            @invalidate_cache_for(patterns=pattern)
-            def test_operation():
-                return return_value
+    deleted = manager.invalidate_pattern("*", skip_keys=[_SESSION_MARKER])
 
-            # Act
-            result = test_operation()
+    # session key is excluded; only app + version keys are deleted
+    client.delete.assert_called_once_with(app_key, version_key)
+    assert deleted == 2
 
-            # Assert
-            assert result == return_value
-            mock_invalidate.assert_called_with(pattern)
 
-    def test_invalidate_cache_with_method_name(self, cache_manager, mock_redis_client):
-        service_instance = self._TestService()
+@pytest.mark.integration
+def test_redis_skip_keys_no_delete_when_all_skipped():
+    session_key = b"rateukma:1:django.contrib.sessions.cache<abc123>"
 
-        with (
-            patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
-            patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
-        ):
-            # Arrange
-            return_value = "executed"
-            method_name = "test_method"
-            expected_pattern = f"*{service_instance.__class__.__name__}.{method_name}*"
+    client = Mock()
+    client.scan.return_value = (0, [session_key])
+    manager = RedisCacheManager(redis_client=client, key_prefix="rateukma")
 
-            @invalidate_cache_for(method_name)
-            def test_operation(self):
-                return return_value
+    deleted = manager.invalidate_pattern("*", skip_keys=[_SESSION_MARKER])
 
-            # Act
-            result = test_operation(service_instance)
+    client.delete.assert_not_called()
+    assert deleted == 0
 
-            # Assert
-            assert result == return_value
-            mock_invalidate.assert_called_with(expected_pattern)
 
-    def test_invalidate_cache_with_multiple_patterns(self, cache_manager, mock_redis_client):
-        with (
-            patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
-            patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
-        ):
-            # Arrange
-            return_value = "executed"
-            patterns = ["pattern1:*", "pattern2:*", "*common*"]
+@pytest.mark.integration
+def test_inmemory_skip_keys_preserves_session_keys():
+    manager = InMemoryCacheManager()
+    manager.set("course:1", 1)
+    manager.set("1:django.contrib.sessions.cache<abc123>", "session-data")
 
-            @invalidate_cache_for(patterns=patterns)
-            def test_operation():
-                return return_value
+    deleted = manager.invalidate_pattern("*", skip_keys=[_SESSION_MARKER])
 
-            # Act
-            result = test_operation()
+    assert deleted == 1
+    assert manager.get("course:1") is None
+    assert manager.get("1:django.contrib.sessions.cache<abc123>") == "session-data"
 
-            # Assert
-            assert result == return_value
-            assert mock_invalidate.call_count == len(patterns)
-            mock_invalidate.assert_any_call("pattern1:*")
-            mock_invalidate.assert_any_call("pattern2:*")
-            mock_invalidate.assert_any_call("*common*")
+
+def test_invalidate_cache_with_custom_pattern(cache_manager, mock_redis_client):
+    with (
+        patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
+        patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
+    ):
+        # Arrange
+        return_value = "executed"
+        pattern = "custom:*"
+
+        @invalidate_cache_for(patterns=pattern)
+        def test_operation():
+            return return_value
+
+        # Act
+        result = test_operation()
+
+        # Assert
+        assert result == return_value
+        mock_invalidate.assert_called_with(pattern)
+
+
+def test_invalidate_cache_with_method_name(cache_manager, mock_redis_client):
+    service_instance = _TestService()
+
+    with (
+        patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
+        patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
+    ):
+        # Arrange
+        return_value = "executed"
+        method_name = "test_method"
+        expected_pattern = f"*{service_instance.__class__.__name__}.{method_name}*"
+
+        @invalidate_cache_for(method_name)
+        def test_operation(self):
+            return return_value
+
+        # Act
+        result = test_operation(service_instance)
+
+        # Assert
+        assert result == return_value
+        mock_invalidate.assert_called_with(expected_pattern)
+
+
+def test_invalidate_cache_with_multiple_patterns(cache_manager, mock_redis_client):
+    with (
+        patch("rateukma.caching.decorators.redis_cache_manager", return_value=cache_manager),
+        patch.object(cache_manager, "invalidate_pattern") as mock_invalidate,
+    ):
+        # Arrange
+        return_value = "executed"
+        patterns = ["pattern1:*", "pattern2:*", "*common*"]
+
+        @invalidate_cache_for(patterns=patterns)
+        def test_operation():
+            return return_value
+
+        # Act
+        result = test_operation()
+
+        # Assert
+        assert result == return_value
+        assert mock_invalidate.call_count == len(patterns)
+        mock_invalidate.assert_any_call("pattern1:*")
+        mock_invalidate.assert_any_call("pattern2:*")
+        mock_invalidate.assert_any_call("*common*")

--- a/src/backend/rateukma/ioc/test_decorators.py
+++ b/src/backend/rateukma/ioc/test_decorators.py
@@ -109,11 +109,11 @@ def test_exception_propagation_and_retry():
         raise ValueError("Service unavailable")
 
     # Act
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Service unavailable"):
         faulty_init()
     assert call_count == 1, "The function was not called on the first attempt."
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Service unavailable"):
         faulty_init()
 
     # Assert

--- a/src/backend/rating_app/management/commands/test_ingest_instructors_from_csv.py
+++ b/src/backend/rating_app/management/commands/test_ingest_instructors_from_csv.py
@@ -154,7 +154,7 @@ def test_parse_name_ignores_a_fully_spelled_mailbox():
 
 
 @pytest.mark.parametrize(
-    "display_name,upn_local",
+    ("display_name", "upn_local"),
     [
         ("Щербак Софія", "s.shcherbak"),  # щ spelled "sh", not "shch"
         ("Хоменко Катерина", "k.chomenko"),  # х spelled "ch"
@@ -180,7 +180,7 @@ def test_parse_name_uses_the_initial_when_the_surname_segment_is_ambiguous():
 
 
 @pytest.mark.parametrize(
-    "display_name,upn_local",
+    ("display_name", "upn_local"),
     [
         ("Сидоренко Софія", "s.sydorenko"),
         ("Петренко Іван", "x.unrelated"),
@@ -215,6 +215,7 @@ def test_parse_name_latin_multiple_tokens_keeps_last_as_remainder():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_dry_run_makes_no_changes(tmp_path):
     csv_path = _write_csv(
         tmp_path,
@@ -232,6 +233,7 @@ def test_dry_run_makes_no_changes(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_creates_instructor_from_cyrillic_name(tmp_path):
     csv_path = _write_csv(
         tmp_path,
@@ -247,6 +249,7 @@ def test_creates_instructor_from_cyrillic_name(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_creates_instructor_from_reversed_cyrillic_name(tmp_path):
     csv_path = _write_csv(
         tmp_path,
@@ -261,6 +264,7 @@ def test_creates_instructor_from_reversed_cyrillic_name(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_existing_instructor_is_left_alone(tmp_path):
     Instructor.objects.create(
         email="i.petrenko@ukma.edu.ua",
@@ -281,6 +285,7 @@ def test_existing_instructor_is_left_alone(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_refresh_names_rewrites_an_existing_instructor(tmp_path):
     Instructor.objects.create(
         email="i.petrenko@ukma.edu.ua", first_name="Іван", last_name="Петренко"
@@ -301,6 +306,7 @@ def test_refresh_names_rewrites_an_existing_instructor(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_ingests_utf16_encoded_csv(tmp_path):
     # M365 exports occasionally land as UTF-16; the utf-8-sig probe must fail
     # and fall back rather than mis-decoding or raising.
@@ -316,6 +322,7 @@ def test_ingests_utf16_encoded_csv(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_undecodable_csv_raises_command_error(tmp_path):
     csv_path = tmp_path / "users_bad.csv"
     # Invalid as utf-8 and odd-length for utf-16 → neither encoding decodes.
@@ -326,6 +333,7 @@ def test_undecodable_csv_raises_command_error(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_keeps_rows_matching_existing_student_email(tmp_path):
     # Students share the @ukma.edu.ua domain with staff and cannot be told apart
     # in the export, so a student-domain user is intentionally ingested; the
@@ -344,6 +352,7 @@ def test_keeps_rows_matching_existing_student_email(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_filters_service_rows(tmp_path):
     csv_path = _write_csv(
         tmp_path,
@@ -360,6 +369,7 @@ def test_filters_service_rows(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_idempotent_rerun_updates_instead_of_creating(tmp_path):
     csv_path = _write_csv(
         tmp_path,
@@ -373,6 +383,7 @@ def test_idempotent_rerun_updates_instead_of_creating(tmp_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_missing_required_column_raises(tmp_path):
     path = tmp_path / "users.csv"
     path.write_text("displayName,userPrincipalName\nFoo,foo@ukma.edu.ua\n", encoding="utf-8")

--- a/src/backend/rating_app/pagination/test_cursor.py
+++ b/src/backend/rating_app/pagination/test_cursor.py
@@ -10,95 +10,101 @@ from rating_app.exception.feed_exceptions import InvalidCursorError
 from rating_app.pagination.cursor import FeedCursor
 
 
-class TestEncodeDecodeCursor:
-    def test_round_trip_preserves_position(self):
-        occurred_at = datetime(2026, 9, 1, 12, 30, 45, 123456, tzinfo=UTC)
-        item_id = uuid4()
+def test_round_trip_preserves_position():
+    occurred_at = datetime(2026, 9, 1, 12, 30, 45, 123456, tzinfo=UTC)
+    item_id = uuid4()
 
-        cursor = FeedCursor.decode(FeedCursor(occurred_at, item_id).encode())
+    cursor = FeedCursor.decode(FeedCursor(occurred_at, item_id).encode())
 
-        assert cursor.occurred_at == occurred_at
-        assert cursor.item_id == item_id
-
-    def test_round_trip_preserves_microseconds(self):
-        """Truncating to seconds would skip or repeat rows at the boundary."""
-        base = datetime(2026, 9, 1, 12, 30, 45, tzinfo=UTC)
-        item_id = uuid4()
-
-        first = FeedCursor.decode(FeedCursor(base, item_id).encode()).occurred_at
-        later = FeedCursor(base + timedelta(microseconds=1), item_id)
-        second = FeedCursor.decode(later.encode()).occurred_at
-
-        assert second - first == timedelta(microseconds=1)
-
-    def test_round_trip_preserves_non_utc_offset(self):
-        occurred_at = datetime(2026, 9, 1, 12, 0, tzinfo=UTC).astimezone()
-
-        cursor = FeedCursor.decode(FeedCursor(occurred_at, uuid4()).encode())
-
-        assert cursor.occurred_at == occurred_at
-
-    def test_token_is_url_safe_and_unpadded(self):
-        token = FeedCursor(datetime(2026, 9, 1, tzinfo=UTC), uuid4()).encode()
-
-        assert "=" not in token
-        assert "+" not in token
-        assert "/" not in token
-
-    def test_naive_datetime_decodes_as_utc(self):
-        token = FeedCursor(datetime(2026, 9, 1, 12, 0), uuid4()).encode()  # noqa: DTZ001
-
-        assert FeedCursor.decode(token).occurred_at.tzinfo is not None
+    assert cursor.occurred_at == occurred_at
+    assert cursor.item_id == item_id
 
 
-class TestDecodeCursorRejectsMalformed:
-    @pytest.mark.parametrize(
-        "token",
-        [
-            "",
-            "not-base64!!",
-            "!!!!",
-        ],
-        ids=["empty", "invalid_chars", "undecodable"],
+def test_round_trip_preserves_microseconds():
+    """Truncating to seconds would skip or repeat rows at the boundary."""
+    base = datetime(2026, 9, 1, 12, 30, 45, tzinfo=UTC)
+    item_id = uuid4()
+
+    first = FeedCursor.decode(FeedCursor(base, item_id).encode()).occurred_at
+    later = FeedCursor(base + timedelta(microseconds=1), item_id)
+    second = FeedCursor.decode(later.encode()).occurred_at
+
+    assert second - first == timedelta(microseconds=1)
+
+
+def test_round_trip_preserves_non_utc_offset():
+    occurred_at = datetime(2026, 9, 1, 12, 0, tzinfo=UTC).astimezone()
+
+    cursor = FeedCursor.decode(FeedCursor(occurred_at, uuid4()).encode())
+
+    assert cursor.occurred_at == occurred_at
+
+
+def test_token_is_url_safe_and_unpadded():
+    token = FeedCursor(datetime(2026, 9, 1, tzinfo=UTC), uuid4()).encode()
+
+    assert "=" not in token
+    assert "+" not in token
+    assert "/" not in token
+
+
+def test_naive_datetime_decodes_as_utc():
+    token = FeedCursor(datetime(2026, 9, 1, 12, 0), uuid4()).encode()  # noqa: DTZ001
+
+    assert FeedCursor.decode(token).occurred_at.tzinfo is not None
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "not-base64!!",
+        "!!!!",
+    ],
+    ids=["empty", "invalid_chars", "undecodable"],
+)
+def test_rejects_undecodable_token(token):
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(token)
+
+
+def test_rejects_missing_separator():
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(_token_for("2026-09-01T12:00:00+00:00"))
+
+
+def test_rejects_bad_timestamp():
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(_token_for(f"not-a-date|{uuid4()}"))
+
+
+def test_rejects_bad_uuid():
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(_token_for("2026-09-01T12:00:00+00:00|not-a-uuid"))
+
+
+def test_rejects_extra_separator():
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(_token_for(f"2026-09-01T12:00:00+00:00|{uuid4()}|extra"))
+
+
+def test_truncated_token_does_not_raise_raw_error():
+    token = FeedCursor(datetime(2026, 9, 1, tzinfo=UTC), uuid4()).encode()
+
+    with pytest.raises(InvalidCursorError):
+        FeedCursor.decode(token[:-8])
+
+
+def test_matches_strictly_older_or_tied_but_after():
+    occurred_at = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
+    item_id = UUID("00000000-0000-0000-0000-000000000010")
+    cursor = FeedCursor.decode(FeedCursor(occurred_at, item_id).encode())
+
+    condition = cursor.filter("published_at")
+
+    assert condition == Q(published_at__lt=occurred_at) | Q(
+        published_at=occurred_at, id__lt=item_id
     )
-    def test_rejects_undecodable_token(self, token):
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(token)
-
-    def test_rejects_missing_separator(self):
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(_token_for("2026-09-01T12:00:00+00:00"))
-
-    def test_rejects_bad_timestamp(self):
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(_token_for(f"not-a-date|{uuid4()}"))
-
-    def test_rejects_bad_uuid(self):
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(_token_for("2026-09-01T12:00:00+00:00|not-a-uuid"))
-
-    def test_rejects_extra_separator(self):
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(_token_for(f"2026-09-01T12:00:00+00:00|{uuid4()}|extra"))
-
-    def test_truncated_token_does_not_raise_raw_error(self):
-        token = FeedCursor(datetime(2026, 9, 1, tzinfo=UTC), uuid4()).encode()
-
-        with pytest.raises(InvalidCursorError):
-            FeedCursor.decode(token[:-8])
-
-
-class TestFilter:
-    def test_matches_strictly_older_or_tied_but_after(self):
-        occurred_at = datetime(2026, 9, 1, 12, 0, tzinfo=UTC)
-        item_id = UUID("00000000-0000-0000-0000-000000000010")
-        cursor = FeedCursor.decode(FeedCursor(occurred_at, item_id).encode())
-
-        condition = cursor.filter("published_at")
-
-        assert condition == Q(published_at__lt=occurred_at) | Q(
-            published_at=occurred_at, id__lt=item_id
-        )
 
 
 def _token_for(payload: str) -> str:

--- a/src/backend/rating_app/repositories/test_comment_repository.py
+++ b/src/backend/rating_app/repositories/test_comment_repository.py
@@ -18,6 +18,7 @@ def repo():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_create_uses_model_default_id(repo, rating_factory, user):
     rating = rating_factory()
     params = CommentCreateParams(
@@ -36,6 +37,7 @@ def test_create_uses_model_default_id(repo, rating_factory, user):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_get_or_create_creates_comment_with_explicit_upsert_id(repo, rating_factory, user):
     comment_id = uuid.uuid4()
     params = CommentUpsertParams(
@@ -55,6 +57,7 @@ def test_get_or_create_creates_comment_with_explicit_upsert_id(repo, rating_fact
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_get_or_upsert_updates_comment_with_param_id(repo, rating_factory, user):
     comment_id = uuid.uuid4()
     params = CommentUpsertParams(

--- a/src/backend/rating_app/repositories/test_feed_post_repository.py
+++ b/src/backend/rating_app/repositories/test_feed_post_repository.py
@@ -21,111 +21,119 @@ def _at(**offset):
     return timezone.now() - timedelta(**offset)
 
 
-class TestGetPinned:
-    def test_returns_only_pinned_posts(self, repo):
-        pinned = FeedPostFactory(pinned=True, published_at=_at(hours=1))
-        FeedPostFactory(pinned=False, published_at=_at(hours=2))
+def test_get_pinned_returns_only_pinned_posts(repo):
+    pinned = FeedPostFactory(pinned=True, published_at=_at(hours=1))
+    FeedPostFactory(pinned=False, published_at=_at(hours=2))
 
-        result = repo.get_pinned()
+    result = repo.get_pinned()
 
-        assert [item.id for item in result] == [pinned.id]
-
-    def test_excludes_inactive_posts(self, repo):
-        FeedPostFactory(pinned=True, is_active=False, published_at=_at(hours=1))
-
-        assert repo.get_pinned() == []
-
-    def test_excludes_future_published_posts(self, repo):
-        """A scheduled post must stay hidden until its publication time."""
-        FeedPostFactory(pinned=True, published_at=timezone.now() + timedelta(days=1))
-
-        assert repo.get_pinned() == []
-
-    def test_orders_newest_first(self, repo):
-        older = FeedPostFactory(pinned=True, published_at=_at(days=2))
-        newer = FeedPostFactory(pinned=True, published_at=_at(hours=1))
-
-        result = repo.get_pinned()
-
-        assert [item.id for item in result] == [newer.id, older.id]
-
-    def test_caps_the_number_of_pinned_posts(self, repo):
-        """Pinned posts lead every page, so an unbounded count would push the
-        homepage strip past its intended size."""
-        for hours in range(MAX_PINNED + 2):
-            FeedPostFactory(pinned=True, published_at=_at(hours=hours + 1))
-
-        assert len(repo.get_pinned()) == MAX_PINNED
-
-    def test_keeps_the_newest_pinned_posts_when_capped(self, repo):
-        posts = [
-            FeedPostFactory(pinned=True, published_at=_at(hours=hours + 1))
-            for hours in range(MAX_PINNED + 2)
-        ]
-        newest = sorted(posts, key=lambda p: p.published_at, reverse=True)[:MAX_PINNED]
-
-        result = repo.get_pinned()
-
-        assert [item.id for item in result] == [p.id for p in newest]
+    assert [item.id for item in result] == [pinned.id]
 
 
-class TestGetPage:
-    def test_returns_only_unpinned_posts(self, repo):
-        unpinned = FeedPostFactory(pinned=False, published_at=_at(hours=1))
-        FeedPostFactory(pinned=True, published_at=_at(hours=2))
+def test_get_pinned_excludes_inactive_posts(repo):
+    FeedPostFactory(pinned=True, is_active=False, published_at=_at(hours=1))
 
-        result = repo.get_page(cursor=None, limit=10)
+    assert repo.get_pinned() == []
 
-        assert [item.id for item in result] == [unpinned.id]
 
-    def test_excludes_inactive_and_future_posts(self, repo):
-        visible = FeedPostFactory(published_at=_at(hours=1))
-        FeedPostFactory(is_active=False, published_at=_at(hours=2))
-        FeedPostFactory(published_at=timezone.now() + timedelta(days=1))
+def test_get_pinned_excludes_future_published_posts(repo):
+    """A scheduled post must stay hidden until its publication time."""
+    FeedPostFactory(pinned=True, published_at=timezone.now() + timedelta(days=1))
 
-        result = repo.get_page(cursor=None, limit=10)
+    assert repo.get_pinned() == []
 
-        assert [item.id for item in result] == [visible.id]
 
-    def test_returns_one_row_beyond_limit_as_lookahead(self, repo):
-        """The extra row is how the service detects a next page without a COUNT."""
-        for hours in range(5):
-            FeedPostFactory(published_at=_at(hours=hours + 1))
+def test_get_pinned_orders_newest_first(repo):
+    older = FeedPostFactory(pinned=True, published_at=_at(days=2))
+    newer = FeedPostFactory(pinned=True, published_at=_at(hours=1))
 
-        result = repo.get_page(cursor=None, limit=2)
+    result = repo.get_pinned()
 
-        assert len(result) == 3
+    assert [item.id for item in result] == [newer.id, older.id]
 
-    def test_cursor_excludes_everything_up_to_that_position(self, repo):
-        newest = FeedPostFactory(published_at=_at(hours=1))
-        middle = FeedPostFactory(published_at=_at(hours=2))
-        oldest = FeedPostFactory(published_at=_at(hours=3))
 
-        first_page = repo.get_page(cursor=None, limit=1)
-        cursor = FeedCursor(first_page[0].occurred_at, first_page[0].id)
-        second_page = repo.get_page(cursor=cursor, limit=10)
+def test_get_pinned_caps_the_number_of_pinned_posts(repo):
+    """Pinned posts lead every page, so an unbounded count would push the
+    homepage strip past its intended size."""
+    for hours in range(MAX_PINNED + 2):
+        FeedPostFactory(pinned=True, published_at=_at(hours=hours + 1))
 
-        assert first_page[0].id == newest.id
-        assert [item.id for item in second_page] == [middle.id, oldest.id]
+    assert len(repo.get_pinned()) == MAX_PINNED
 
-    def test_cursor_breaks_ties_by_id(self, repo):
-        """Posts sharing a timestamp must not repeat or vanish at a boundary."""
-        published_at = _at(hours=1)
-        posts = [FeedPostFactory(published_at=published_at) for _ in range(3)]
 
-        walked = []
-        cursor = None
-        while True:
-            page = repo.get_page(cursor=cursor, limit=1)
-            if not page:
-                break
-            walked.append(page[0].id)
-            cursor = FeedCursor(page[0].occurred_at, page[0].id)
+def test_get_pinned_keeps_the_newest_pinned_posts_when_capped(repo):
+    posts = [
+        FeedPostFactory(pinned=True, published_at=_at(hours=hours + 1))
+        for hours in range(MAX_PINNED + 2)
+    ]
+    newest = sorted(posts, key=lambda p: p.published_at, reverse=True)[:MAX_PINNED]
 
-        assert sorted(walked) == sorted(post.id for post in posts)
+    result = repo.get_pinned()
 
-    def test_returns_empty_when_cursor_past_the_oldest_post(self, repo):
-        post = FeedPostFactory(published_at=_at(hours=1))
-        cursor = FeedCursor(post.published_at, post.id)
+    assert [item.id for item in result] == [p.id for p in newest]
 
-        assert repo.get_page(cursor=cursor, limit=10) == []
+
+def test_get_page_returns_only_unpinned_posts(repo):
+    unpinned = FeedPostFactory(pinned=False, published_at=_at(hours=1))
+    FeedPostFactory(pinned=True, published_at=_at(hours=2))
+
+    result = repo.get_page(cursor=None, limit=10)
+
+    assert [item.id for item in result] == [unpinned.id]
+
+
+def test_get_page_excludes_inactive_and_future_posts(repo):
+    visible = FeedPostFactory(published_at=_at(hours=1))
+    FeedPostFactory(is_active=False, published_at=_at(hours=2))
+    FeedPostFactory(published_at=timezone.now() + timedelta(days=1))
+
+    result = repo.get_page(cursor=None, limit=10)
+
+    assert [item.id for item in result] == [visible.id]
+
+
+def test_get_page_returns_one_row_beyond_limit_as_lookahead(repo):
+    """The extra row is how the service detects a next page without a COUNT."""
+    for hours in range(5):
+        FeedPostFactory(published_at=_at(hours=hours + 1))
+
+    result = repo.get_page(cursor=None, limit=2)
+
+    assert len(result) == 3
+
+
+def test_get_page_cursor_excludes_everything_up_to_that_position(repo):
+    newest = FeedPostFactory(published_at=_at(hours=1))
+    middle = FeedPostFactory(published_at=_at(hours=2))
+    oldest = FeedPostFactory(published_at=_at(hours=3))
+
+    first_page = repo.get_page(cursor=None, limit=1)
+    cursor = FeedCursor(first_page[0].occurred_at, first_page[0].id)
+    second_page = repo.get_page(cursor=cursor, limit=10)
+
+    assert first_page[0].id == newest.id
+    assert [item.id for item in second_page] == [middle.id, oldest.id]
+
+
+def test_get_page_cursor_breaks_ties_by_id(repo):
+    """Posts sharing a timestamp must not repeat or vanish at a boundary."""
+    published_at = _at(hours=1)
+    posts = [FeedPostFactory(published_at=published_at) for _ in range(3)]
+
+    walked = []
+    cursor = None
+    while True:
+        page = repo.get_page(cursor=cursor, limit=1)
+        if not page:
+            break
+        walked.append(page[0].id)
+        cursor = FeedCursor(page[0].occurred_at, page[0].id)
+
+    assert sorted(walked) == sorted(post.id for post in posts)
+
+
+def test_get_page_returns_empty_when_cursor_past_the_oldest_post(repo):
+    post = FeedPostFactory(published_at=_at(hours=1))
+    cursor = FeedCursor(post.published_at, post.id)
+
+    assert repo.get_page(cursor=cursor, limit=10) == []

--- a/src/backend/rating_app/repositories/test_rating_repository_feed.py
+++ b/src/backend/rating_app/repositories/test_rating_repository_feed.py
@@ -25,91 +25,97 @@ def _rating(comment="Solid course", **kwargs):
     return RatingFactory(comment=comment, **kwargs)
 
 
-class TestGetFeedPage:
-    def test_excludes_ratings_without_a_comment(self, repo):
-        """`comment` is never NULL — "no comment" is the empty string."""
-        with_comment = _rating(comment="Worth taking")
-        _rating(comment="")
+def test_get_feed_page_excludes_ratings_without_a_comment(repo):
+    """`comment` is never NULL — "no comment" is the empty string."""
+    with_comment = _rating(comment="Worth taking")
+    _rating(comment="")
 
-        result = repo.get_feed_page(cursor=None, limit=10)
+    result = repo.get_feed_page(cursor=None, limit=10)
 
-        assert [item.id for item in result] == [with_comment.id]
+    assert [item.id for item in result] == [with_comment.id]
 
-    def test_orders_newest_first(self, repo):
-        older = _rating()
-        newer = _rating()
 
-        result = repo.get_feed_page(cursor=None, limit=10)
+def test_get_feed_page_orders_newest_first(repo):
+    older = _rating()
+    newer = _rating()
 
-        assert [item.id for item in result] == [newer.id, older.id]
+    result = repo.get_feed_page(cursor=None, limit=10)
 
-    def test_maps_course_and_semester_onto_the_card(self, repo):
-        semester = SemesterFactory(year=2025, term="FALL")
-        course = CourseFactory(title="Дискретна математика")
-        offering = CourseOfferingFactory(course=course, semester=semester)
-        rating = _rating(comment="Важко, але корисно", course_offering=offering)
+    assert [item.id for item in result] == [newer.id, older.id]
 
-        item = repo.get_feed_page(cursor=None, limit=10)[0]
 
-        assert item.course_id == course.id
-        assert item.course_title == "Дискретна математика"
-        assert item.semester_year == 2025
-        assert item.semester_term == "FALL"
-        assert item.comment == "Важко, але корисно"
-        assert item.difficulty == rating.difficulty
-        assert item.usefulness == rating.usefulness
+def test_get_feed_page_maps_course_and_semester_onto_the_card(repo):
+    semester = SemesterFactory(year=2025, term="FALL")
+    course = CourseFactory(title="Дискретна математика")
+    offering = CourseOfferingFactory(course=course, semester=semester)
+    rating = _rating(comment="Важко, але корисно", course_offering=offering)
 
-    def test_carries_course_averages_for_the_comparison_arrow(self, repo):
-        course = CourseFactory(avg_difficulty="3.50", avg_usefulness="4.25")
-        offering = CourseOfferingFactory(course=course)
-        _rating(course_offering=offering)
+    item = repo.get_feed_page(cursor=None, limit=10)[0]
 
-        item = repo.get_feed_page(cursor=None, limit=10)[0]
+    assert item.course_id == course.id
+    assert item.course_title == "Дискретна математика"
+    assert item.semester_year == 2025
+    assert item.semester_term == "FALL"
+    assert item.comment == "Важко, але корисно"
+    assert item.difficulty == rating.difficulty
+    assert item.usefulness == rating.usefulness
 
-        assert float(item.course_avg_difficulty) == 3.50
-        assert float(item.course_avg_usefulness) == 4.25
 
-    def test_returns_one_row_beyond_limit_as_lookahead(self, repo):
-        for _ in range(5):
-            _rating()
+def test_get_feed_page_carries_course_averages_for_the_comparison_arrow(repo):
+    course = CourseFactory(avg_difficulty="3.50", avg_usefulness="4.25")
+    offering = CourseOfferingFactory(course=course)
+    _rating(course_offering=offering)
 
-        result = repo.get_feed_page(cursor=None, limit=2)
+    item = repo.get_feed_page(cursor=None, limit=10)[0]
 
-        assert len(result) == 3
+    assert float(item.course_avg_difficulty) == 3.50
+    assert float(item.course_avg_usefulness) == 4.25
 
-    def test_cursor_excludes_everything_up_to_that_position(self, repo):
-        for _ in range(3):
-            _rating()
 
-        first_page = repo.get_feed_page(cursor=None, limit=1)
-        cursor = FeedCursor(first_page[0].occurred_at, first_page[0].id)
-        second_page = repo.get_feed_page(cursor=cursor, limit=10)
-
-        assert len(second_page) == 2
-        assert first_page[0].id not in {item.id for item in second_page}
-
-    def test_walking_the_cursor_yields_every_row_exactly_once(self, repo):
-        expected = {_rating().id for _ in range(5)}
-
-        walked = []
-        cursor = None
-        while True:
-            page = repo.get_feed_page(cursor=cursor, limit=2)
-            if not page:
-                break
-            emitted = page[:2]
-            walked.extend(item.id for item in emitted)
-            cursor = FeedCursor(emitted[-1].occurred_at, emitted[-1].id)
-
-        assert sorted(walked) == sorted(expected)
-
-    def test_uses_the_feed_mapper_not_the_rating_mapper(self, repo):
+def test_get_feed_page_returns_one_row_beyond_limit_as_lookahead(repo):
+    for _ in range(5):
         _rating()
 
-        item = repo.get_feed_page(cursor=None, limit=10)[0]
+    result = repo.get_feed_page(cursor=None, limit=2)
 
-        assert not hasattr(item, "student_id")
-        assert not hasattr(item, "upvotes")
+    assert len(result) == 3
+
+
+def test_get_feed_page_cursor_excludes_everything_up_to_that_position(repo):
+    for _ in range(3):
+        _rating()
+
+    first_page = repo.get_feed_page(cursor=None, limit=1)
+    cursor = FeedCursor(first_page[0].occurred_at, first_page[0].id)
+    second_page = repo.get_feed_page(cursor=cursor, limit=10)
+
+    assert len(second_page) == 2
+    assert first_page[0].id not in {item.id for item in second_page}
+
+
+def test_get_feed_page_walking_the_cursor_yields_every_row_exactly_once(repo):
+    expected = {_rating().id for _ in range(5)}
+
+    walked = []
+    cursor = None
+    while True:
+        page = repo.get_feed_page(cursor=cursor, limit=2)
+        if not page:
+            break
+        emitted = page[:2]
+        walked.extend(item.id for item in emitted)
+        cursor = FeedCursor(emitted[-1].occurred_at, emitted[-1].id)
+
+    assert sorted(walked) == sorted(expected)
+
+
+def test_get_feed_page_uses_the_feed_mapper_not_the_rating_mapper(repo):
+    _rating()
+
+    item = repo.get_feed_page(cursor=None, limit=10)[0]
+
+    assert not hasattr(item, "student_id")
+    assert not hasattr(item, "upvotes")
 
 
 def test_ioc_injects_the_feed_mapper(repo):

--- a/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
+++ b/src/backend/rating_app/services/domain_event_listeners/test_cache_invalidator.py
@@ -74,117 +74,119 @@ def _make_comment_dto(
     )
 
 
-class TestRatingCacheInvalidator:
-    @pytest.fixture
-    def cache_manager(self):
-        return MagicMock()
-
-    @pytest.fixture
-    def invalidator(self, cache_manager):
-        return RatingCacheInvalidator(cache_manager=cache_manager)
-
-    def test_bumps_course_detail_namespace(self, invalidator, cache_manager):
-        event = _make_rating_dto()
-        invalidator.on_event(event)
-        cache_manager.bump_version.assert_any_call(course_detail_namespace(str(event.course)))
-
-    def test_bumps_course_analytics_namespace(self, invalidator, cache_manager):
-        event = _make_rating_dto()
-        invalidator.on_event(event)
-        cache_manager.bump_version.assert_any_call(course_analytics_namespace(str(event.course)))
-
-    def test_bumps_course_ratings_namespace(self, invalidator, cache_manager):
-        event = _make_rating_dto()
-        invalidator.on_event(event)
-        cache_manager.bump_version.assert_any_call(course_ratings_namespace(str(event.course)))
-
-    def test_bumps_feed_namespace(self, invalidator, cache_manager):
-        invalidator.on_event(_make_rating_dto())
-        cache_manager.bump_version.assert_any_call(FEED_NAMESPACE)
-
-    def test_bumps_student_ratings_namespace(self, invalidator, cache_manager):
-        event = _make_rating_dto()
-        invalidator.on_event(event)
-        cache_manager.bump_version.assert_any_call(student_ratings_namespace(str(event.student_id)))
-
-    def test_bumps_all_namespaces(self, invalidator, cache_manager):
-        event = _make_rating_dto()
-        invalidator.on_event(event)
-        assert cache_manager.bump_version.call_count == 5
-
-    def test_anonymous_rating_still_bumps_student_namespace(self, invalidator, cache_manager):
-        """Anonymous ratings carry the real student_id in the domain model.
-        Privacy nulling happens at the serializer layer, not here."""
-        event = _make_rating_dto(is_anonymous=True)
-        invalidator.on_event(event)
-        cache_manager.bump_version.assert_any_call(student_ratings_namespace(str(event.student_id)))
-        assert cache_manager.bump_version.call_count == 5
+@pytest.fixture
+def cache_manager():
+    return MagicMock()
 
 
-class TestCommentCacheInvalidator:
-    @pytest.fixture
-    def cache_manager(self):
-        return MagicMock()
+@pytest.fixture
+def rating_invalidator(cache_manager):
+    return RatingCacheInvalidator(cache_manager=cache_manager)
 
-    @pytest.fixture
-    def invalidator(self, cache_manager):
-        return CommentCacheInvalidator(cache_manager=cache_manager)
 
-    def test_bumps_rating_comments_and_course_ratings_namespaces(
-        self,
-        invalidator,
-        cache_manager,
-    ):
-        course_id = uuid.uuid4()
-        comment = _make_comment_dto(course_id=course_id)
-        event = CommentEvent(comment=comment, action=CommentAction.CREATED)
+@pytest.fixture
+def comment_invalidator(cache_manager):
+    return CommentCacheInvalidator(cache_manager=cache_manager)
 
-        invalidator.on_event(event)
 
-        cache_manager.bump_version.assert_any_call(
-            rating_comments_namespace(str(comment.rating_id))
-        )
-        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(comment.id)))
-        cache_manager.bump_version.assert_any_call(course_ratings_namespace(str(course_id)))
-        assert cache_manager.bump_version.call_count == 3
+def test_rating_invalidator_bumps_course_detail_namespace(rating_invalidator, cache_manager):
+    event = _make_rating_dto()
+    rating_invalidator.on_event(event)
+    cache_manager.bump_version.assert_any_call(course_detail_namespace(str(event.course)))
 
-    def test_bumps_parent_replies_namespace_for_reply(
-        self,
-        invalidator,
-        cache_manager,
-    ):
-        parent_id = uuid.uuid4()
-        course_id = uuid.uuid4()
-        comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
-        event = CommentEvent(comment=comment, action=CommentAction.CREATED)
 
-        invalidator.on_event(event)
+def test_rating_invalidator_bumps_course_analytics_namespace(rating_invalidator, cache_manager):
+    event = _make_rating_dto()
+    rating_invalidator.on_event(event)
+    cache_manager.bump_version.assert_any_call(course_analytics_namespace(str(event.course)))
 
-        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
-        assert cache_manager.bump_version.call_count == 4
 
-    @pytest.mark.parametrize(
-        "action",
-        [CommentAction.CREATED, CommentAction.DELETED],
+def test_rating_invalidator_bumps_course_ratings_namespace(rating_invalidator, cache_manager):
+    event = _make_rating_dto()
+    rating_invalidator.on_event(event)
+    cache_manager.bump_version.assert_any_call(course_ratings_namespace(str(event.course)))
+
+
+def test_rating_invalidator_bumps_feed_namespace(rating_invalidator, cache_manager):
+    rating_invalidator.on_event(_make_rating_dto())
+    cache_manager.bump_version.assert_any_call(FEED_NAMESPACE)
+
+
+def test_rating_invalidator_bumps_student_ratings_namespace(rating_invalidator, cache_manager):
+    event = _make_rating_dto()
+    rating_invalidator.on_event(event)
+    cache_manager.bump_version.assert_any_call(student_ratings_namespace(str(event.student_id)))
+
+
+def test_rating_invalidator_bumps_all_namespaces(rating_invalidator, cache_manager):
+    event = _make_rating_dto()
+    rating_invalidator.on_event(event)
+    assert cache_manager.bump_version.call_count == 5
+
+
+def test_rating_invalidator_anonymous_rating_still_bumps_student_namespace(
+    rating_invalidator, cache_manager
+):
+    """Anonymous ratings carry the real student_id in the domain model.
+    Privacy nulling happens at the serializer layer, not here."""
+    event = _make_rating_dto(is_anonymous=True)
+    rating_invalidator.on_event(event)
+    cache_manager.bump_version.assert_any_call(student_ratings_namespace(str(event.student_id)))
+    assert cache_manager.bump_version.call_count == 5
+
+
+def test_comment_invalidator_bumps_rating_comments_and_course_ratings_namespaces(
+    comment_invalidator,
+    cache_manager,
+):
+    course_id = uuid.uuid4()
+    comment = _make_comment_dto(course_id=course_id)
+    event = CommentEvent(comment=comment, action=CommentAction.CREATED)
+
+    comment_invalidator.on_event(event)
+
+    cache_manager.bump_version.assert_any_call(rating_comments_namespace(str(comment.rating_id)))
+    cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(comment.id)))
+    cache_manager.bump_version.assert_any_call(course_ratings_namespace(str(course_id)))
+    assert cache_manager.bump_version.call_count == 3
+
+
+def test_comment_invalidator_bumps_parent_replies_namespace_for_reply(
+    comment_invalidator,
+    cache_manager,
+):
+    parent_id = uuid.uuid4()
+    course_id = uuid.uuid4()
+    comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
+    event = CommentEvent(comment=comment, action=CommentAction.CREATED)
+
+    comment_invalidator.on_event(event)
+
+    cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
+    assert cache_manager.bump_version.call_count == 4
+
+
+@pytest.mark.parametrize(
+    "action",
+    [CommentAction.CREATED, CommentAction.DELETED],
+)
+def test_comment_invalidator_bumps_replies_for_nested_reply_count_changes(
+    comment_invalidator,
+    cache_manager,
+    action,
+):
+    grandparent_id = uuid.uuid4()
+    parent_id = uuid.uuid4()
+    course_id = uuid.uuid4()
+    comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
+    event = CommentEvent(
+        comment=comment,
+        action=action,
+        parent_parent_id=grandparent_id,
     )
-    def test_bumps_parent_container_replies_namespace_for_nested_reply_count_changes(
-        self,
-        invalidator,
-        cache_manager,
-        action,
-    ):
-        grandparent_id = uuid.uuid4()
-        parent_id = uuid.uuid4()
-        course_id = uuid.uuid4()
-        comment = _make_comment_dto(parent_id=parent_id, course_id=course_id)
-        event = CommentEvent(
-            comment=comment,
-            action=action,
-            parent_parent_id=grandparent_id,
-        )
 
-        invalidator.on_event(event)
+    comment_invalidator.on_event(event)
 
-        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
-        cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(grandparent_id)))
-        assert cache_manager.bump_version.call_count == 5
+    cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(parent_id)))
+    cache_manager.bump_version.assert_any_call(comment_replies_namespace(str(grandparent_id)))
+    assert cache_manager.bump_version.call_count == 5

--- a/src/backend/rating_app/services/domain_event_listeners/test_vote_notification.py
+++ b/src/backend/rating_app/services/domain_event_listeners/test_vote_notification.py
@@ -69,115 +69,122 @@ RECIPIENT_USER_ID = 42
 ACTOR_USER_ID = 99
 
 
-class TestVoteNotificationObserver:
-    @pytest.fixture
-    def notification_service(self):
-        return MagicMock()
+@pytest.fixture
+def notification_service():
+    return MagicMock()
 
-    @pytest.fixture
-    def rating_repository(self):
-        return MagicMock()
 
-    @pytest.fixture
-    def student_repository(self):
-        return MagicMock()
+@pytest.fixture
+def rating_repository():
+    return MagicMock()
 
-    @pytest.fixture
-    def observer(self, notification_service, rating_repository, student_repository):
-        return VoteNotificationObserver(
-            notification_service=notification_service,
-            rating_repository=rating_repository,
-            student_repository=student_repository,
-        )
 
-    def _setup_student_lookups(self, student_repository, rating_student_id, voter_student_id):
-        """Configure student_repository to return proper DTOs for recipient and actor."""
+@pytest.fixture
+def student_repository():
+    return MagicMock()
 
-        def get_by_id(sid):
-            if sid == str(rating_student_id):
-                return _make_student_dto(rating_student_id, user_id=RECIPIENT_USER_ID)
-            if sid == str(voter_student_id):
-                return _make_student_dto(voter_student_id, user_id=ACTOR_USER_ID)
-            raise StudentNotFoundError()
 
-        student_repository.get_by_id.side_effect = get_by_id
+@pytest.fixture
+def observer(notification_service, rating_repository, student_repository):
+    return VoteNotificationObserver(
+        notification_service=notification_service,
+        rating_repository=rating_repository,
+        student_repository=student_repository,
+    )
 
-    def test_creates_notification_on_upvote(
-        self, observer, notification_service, rating_repository, student_repository
-    ):
-        rating = _make_rating_dto()
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.UPVOTE)
-        self._setup_student_lookups(student_repository, rating.student_id, vote.student_id)
 
-        observer.on_event(vote)
+def _setup_student_lookups(student_repository, rating_student_id, voter_student_id):
+    """Configure student_repository to return proper DTOs for recipient and actor."""
 
-        notification_service.create_notification.assert_called_once_with(
-            recipient_id=RECIPIENT_USER_ID,
-            event_type=NotificationEventType.RATING_UPVOTED,
-            group_key=f"{NotificationEventType.RATING_UPVOTED}:{vote.rating_id}",
-            source_model=RatingVoteModel,
-            source_id=str(vote.id),
-            actor_id=ACTOR_USER_ID,
-        )
+    def get_by_id(sid):
+        if sid == str(rating_student_id):
+            return _make_student_dto(rating_student_id, user_id=RECIPIENT_USER_ID)
+        if sid == str(voter_student_id):
+            return _make_student_dto(voter_student_id, user_id=ACTOR_USER_ID)
+        raise StudentNotFoundError()
 
-    def test_creates_notification_on_downvote(
-        self, observer, notification_service, rating_repository, student_repository
-    ):
-        rating = _make_rating_dto()
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.DOWNVOTE)
-        self._setup_student_lookups(student_repository, rating.student_id, vote.student_id)
+    student_repository.get_by_id.side_effect = get_by_id
 
-        observer.on_event(vote)
 
-        notification_service.create_notification.assert_called_once()
-        call_kwargs = notification_service.create_notification.call_args.kwargs
-        assert call_kwargs["event_type"] == NotificationEventType.RATING_DOWNVOTED
+def test_creates_notification_on_upvote(
+    observer, notification_service, rating_repository, student_repository
+):
+    rating = _make_rating_dto()
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.UPVOTE)
+    _setup_student_lookups(student_repository, rating.student_id, vote.student_id)
 
-    def test_skips_self_vote(self, observer, notification_service, rating_repository):
-        shared_student_id = uuid.uuid4()
-        rating = _make_rating_dto(student_id=shared_student_id)
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(student_id=shared_student_id, rating_id=rating.id)
+    observer.on_event(vote)
 
-        observer.on_event(vote)
+    notification_service.create_notification.assert_called_once_with(
+        recipient_id=RECIPIENT_USER_ID,
+        event_type=NotificationEventType.RATING_UPVOTED,
+        group_key=f"{NotificationEventType.RATING_UPVOTED}:{vote.rating_id}",
+        source_model=RatingVoteModel,
+        source_id=str(vote.id),
+        actor_id=ACTOR_USER_ID,
+    )
 
-        notification_service.create_notification.assert_not_called()
 
-    def test_skips_anonymous_rating_without_student(
-        self, observer, notification_service, rating_repository
-    ):
-        rating = _make_rating_dto(student_id=None)
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(rating_id=rating.id)
+def test_creates_notification_on_downvote(
+    observer, notification_service, rating_repository, student_repository
+):
+    rating = _make_rating_dto()
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.DOWNVOTE)
+    _setup_student_lookups(student_repository, rating.student_id, vote.student_id)
 
-        observer.on_event(vote)
+    observer.on_event(vote)
 
-        notification_service.create_notification.assert_not_called()
+    notification_service.create_notification.assert_called_once()
+    call_kwargs = notification_service.create_notification.call_args.kwargs
+    assert call_kwargs["event_type"] == NotificationEventType.RATING_DOWNVOTED
 
-    def test_skips_when_recipient_not_found(
-        self, observer, notification_service, rating_repository, student_repository
-    ):
-        rating = _make_rating_dto()
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(rating_id=rating.id)
-        student_repository.get_by_id.side_effect = StudentNotFoundError()
 
-        observer.on_event(vote)
+def test_skips_self_vote(observer, notification_service, rating_repository):
+    shared_student_id = uuid.uuid4()
+    rating = _make_rating_dto(student_id=shared_student_id)
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(student_id=shared_student_id, rating_id=rating.id)
 
-        notification_service.create_notification.assert_not_called()
+    observer.on_event(vote)
 
-    def test_group_key_contains_event_type_and_rating_id(
-        self, observer, notification_service, rating_repository, student_repository
-    ):
-        rating = _make_rating_dto()
-        rating_repository.get_by_id.return_value = rating
-        vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.UPVOTE)
-        self._setup_student_lookups(student_repository, rating.student_id, vote.student_id)
+    notification_service.create_notification.assert_not_called()
 
-        observer.on_event(vote)
 
-        call_kwargs = notification_service.create_notification.call_args.kwargs
-        expected_group_key = f"{NotificationEventType.RATING_UPVOTED}:{vote.rating_id}"
-        assert call_kwargs["group_key"] == expected_group_key
+def test_skips_anonymous_rating_without_student(observer, notification_service, rating_repository):
+    rating = _make_rating_dto(student_id=None)
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(rating_id=rating.id)
+
+    observer.on_event(vote)
+
+    notification_service.create_notification.assert_not_called()
+
+
+def test_skips_when_recipient_not_found(
+    observer, notification_service, rating_repository, student_repository
+):
+    rating = _make_rating_dto()
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(rating_id=rating.id)
+    student_repository.get_by_id.side_effect = StudentNotFoundError()
+
+    observer.on_event(vote)
+
+    notification_service.create_notification.assert_not_called()
+
+
+def test_group_key_contains_event_type_and_rating_id(
+    observer, notification_service, rating_repository, student_repository
+):
+    rating = _make_rating_dto()
+    rating_repository.get_by_id.return_value = rating
+    vote = _make_vote_dto(rating_id=rating.id, vote_type=RatingVoteType.UPVOTE)
+    _setup_student_lookups(student_repository, rating.student_id, vote.student_id)
+
+    observer.on_event(vote)
+
+    call_kwargs = notification_service.create_notification.call_args.kwargs
+    expected_group_key = f"{NotificationEventType.RATING_UPVOTED}:{vote.rating_id}"
+    assert call_kwargs["group_key"] == expected_group_key

--- a/src/backend/rating_app/services/test_notification_service.py
+++ b/src/backend/rating_app/services/test_notification_service.py
@@ -3,102 +3,104 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from rating_app.models.rating_vote import RatingVote
 from rating_app.services.notification_service import (
     DEFAULT_NOTIFICATION_PAGE_SIZE,
     NotificationService,
 )
 
 
-class TestNotificationService:
-    @pytest.fixture
-    def notification_repository(self):
-        return MagicMock()
+@pytest.fixture
+def notification_repository():
+    return MagicMock()
 
-    @pytest.fixture
-    def cursor_repository(self):
-        return MagicMock()
 
-    @pytest.fixture
-    def service(self, notification_repository, cursor_repository):
-        return NotificationService(
-            notification_repository=notification_repository,
-            cursor_repository=cursor_repository,
-        )
+@pytest.fixture
+def cursor_repository():
+    return MagicMock()
 
-    def test_get_notifications_uses_cursor_value(
-        self, service, notification_repository, cursor_repository
-    ):
-        user_id = 1
-        cursor_time = datetime(2024, 1, 1, tzinfo=UTC)
-        cursor_repository.get_cursor_value.return_value = cursor_time
-        notification_repository.get_grouped_for_user.return_value = []
 
-        service.get_notifications_for_user(user_id)
+@pytest.fixture
+def service(notification_repository, cursor_repository):
+    return NotificationService(
+        notification_repository=notification_repository,
+        cursor_repository=cursor_repository,
+    )
 
-        cursor_repository.get_cursor_value.assert_called_once_with(user_id)
-        notification_repository.get_grouped_for_user.assert_called_once_with(
-            user_id=user_id,
-            cursor_value=cursor_time,
-            limit=DEFAULT_NOTIFICATION_PAGE_SIZE,
-            offset=0,
-        )
 
-    def test_get_notifications_passes_pagination_params(
-        self, service, notification_repository, cursor_repository
-    ):
-        user_id = 1
-        cursor_repository.get_cursor_value.return_value = datetime.now(tz=UTC)
-        notification_repository.get_grouped_for_user.return_value = []
+def test_get_notifications_uses_cursor_value(service, notification_repository, cursor_repository):
+    user_id = 1
+    cursor_time = datetime(2024, 1, 1, tzinfo=UTC)
+    cursor_repository.get_cursor_value.return_value = cursor_time
+    notification_repository.get_grouped_for_user.return_value = []
 
-        service.get_notifications_for_user(user_id, limit=10, offset=5)
+    service.get_notifications_for_user(user_id)
 
-        call_kwargs = notification_repository.get_grouped_for_user.call_args.kwargs
-        assert call_kwargs["limit"] == 10
-        assert call_kwargs["offset"] == 5
+    cursor_repository.get_cursor_value.assert_called_once_with(user_id)
+    notification_repository.get_grouped_for_user.assert_called_once_with(
+        user_id=user_id,
+        cursor_value=cursor_time,
+        limit=DEFAULT_NOTIFICATION_PAGE_SIZE,
+        offset=0,
+    )
 
-    def test_get_unread_count_uses_cursor_value(
-        self, service, notification_repository, cursor_repository
-    ):
-        user_id = 1
-        cursor_time = datetime(2024, 1, 1, tzinfo=UTC)
-        cursor_repository.get_cursor_value.return_value = cursor_time
-        notification_repository.get_unread_group_count.return_value = 3
 
-        count = service.get_unread_count(user_id)
+def test_get_notifications_passes_pagination_params(
+    service, notification_repository, cursor_repository
+):
+    user_id = 1
+    cursor_repository.get_cursor_value.return_value = datetime.now(tz=UTC)
+    notification_repository.get_grouped_for_user.return_value = []
 
-        assert count == 3
-        notification_repository.get_unread_group_count.assert_called_once_with(
-            user_id=user_id,
-            cursor_value=cursor_time,
-        )
+    service.get_notifications_for_user(user_id, limit=10, offset=5)
 
-    def test_mark_all_read_advances_cursor(self, service, cursor_repository):
-        user_id = 1
+    call_kwargs = notification_repository.get_grouped_for_user.call_args.kwargs
+    assert call_kwargs["limit"] == 10
+    assert call_kwargs["offset"] == 5
 
-        service.mark_all_read(user_id)
 
-        cursor_repository.advance_cursor.assert_called_once_with(user_id)
+def test_get_unread_count_uses_cursor_value(service, notification_repository, cursor_repository):
+    user_id = 1
+    cursor_time = datetime(2024, 1, 1, tzinfo=UTC)
+    cursor_repository.get_cursor_value.return_value = cursor_time
+    notification_repository.get_unread_group_count.return_value = 3
 
-    @pytest.mark.django_db
-    def test_create_notification_delegates_to_repository(self, service, notification_repository):
-        from rating_app.models.rating_vote import RatingVote
+    count = service.get_unread_count(user_id)
 
-        notification_repository.create.return_value = MagicMock()
+    assert count == 3
+    notification_repository.get_unread_group_count.assert_called_once_with(
+        user_id=user_id,
+        cursor_value=cursor_time,
+    )
 
-        service.create_notification(
-            recipient_id=1,
-            event_type="RATING_UPVOTED",
-            group_key="RATING_UPVOTED:some-id",
-            source_model=RatingVote,
-            source_id="some-id",
-            actor_id=2,
-        )
 
-        notification_repository.create.assert_called_once()
-        call_args = notification_repository.create.call_args
-        data = call_args.args[0]
-        assert data.recipient_id == 1
-        assert data.event_type == "RATING_UPVOTED"
-        assert data.group_key == "RATING_UPVOTED:some-id"
-        assert data.object_id == "some-id"
-        assert data.actor_id == 2
+def test_mark_all_read_advances_cursor(service, cursor_repository):
+    user_id = 1
+
+    service.mark_all_read(user_id)
+
+    cursor_repository.advance_cursor.assert_called_once_with(user_id)
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_create_notification_delegates_to_repository(service, notification_repository):
+    notification_repository.create.return_value = MagicMock()
+
+    service.create_notification(
+        recipient_id=1,
+        event_type="RATING_UPVOTED",
+        group_key="RATING_UPVOTED:some-id",
+        source_model=RatingVote,
+        source_id="some-id",
+        actor_id=2,
+    )
+
+    notification_repository.create.assert_called_once()
+    call_args = notification_repository.create.call_args
+    data = call_args.args[0]
+    assert data.recipient_id == 1
+    assert data.event_type == "RATING_UPVOTED"
+    assert data.group_key == "RATING_UPVOTED:some-id"
+    assert data.object_id == "some-id"
+    assert data.actor_id == 2

--- a/src/backend/rating_app/services/test_student_service.py
+++ b/src/backend/rating_app/services/test_student_service.py
@@ -59,119 +59,126 @@ def service(student_stats_repo, student_repo, user_repo, semester_service, ratin
     )
 
 
-class TestLinkStudentToUser:
-    def test_returns_false_when_student_has_no_email(self, service):
-        # Arrange
-        student = SimpleNamespace(email="", user_id=None)
+def test_link_student_to_user_returns_false_when_student_has_no_email(service):
+    # Arrange
+    student = SimpleNamespace(email="", user_id=None)
 
-        # Act
-        result = service.link_student_to_user(student)
+    # Act
+    result = service.link_student_to_user(student)
 
-        # Assert
-        assert result is False
-
-    def test_returns_false_when_student_already_has_user(self, service):
-        # Arrange
-        student = SimpleNamespace(email="test@ukma.edu.ua", user_id=1)
-
-        # Act
-        result = service.link_student_to_user(student)
-
-        # Assert
-        assert result is False
-
-    def test_returns_false_when_no_user_with_email(self, service, user_repo):
-        # Arrange
-        student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="student-id")
-        user_repo.get_by_email.return_value = None
-
-        # Act
-        result = service.link_student_to_user(student)
-
-        # Assert
-        assert result is False
-        user_repo.get_by_email.assert_called_once_with("test@ukma.edu.ua")
-
-    def test_returns_false_when_user_already_linked_to_another_student(self, service, user_repo):
-        # Arrange
-        student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="new-student")
-        existing_user = SimpleNamespace(
-            id=1,
-            pk=1,
-            email="test@ukma.edu.ua",
-            student_profile=SimpleNamespace(id="existing-student"),
-        )
-        user_repo.get_by_email.return_value = existing_user
-
-        # Act
-        result = service.link_student_to_user(student)
-
-        # Assert
-        assert result is False
-
-    def test_links_student_to_user_successfully(self, service, user_repo, student_repo):
-        # Arrange
-        student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="student-id")
-        user = SimpleNamespace(id=1, pk=1, email="test@ukma.edu.ua", student_profile=None)
-        user_repo.get_by_email.return_value = user
-
-        # Act
-        result = service.link_student_to_user(student)
-
-        # Assert
-        assert result is True
-        student_repo.link_to_user.assert_called_once_with("student-id", user)
+    # Assert
+    assert result is False
 
 
-class TestLinkUserToStudent:
-    def test_returns_false_when_user_has_no_email(self, service):
-        # Arrange
-        user = SimpleNamespace(email="", id=1)
+def test_link_student_to_user_returns_false_when_student_already_has_user(service):
+    # Arrange
+    student = SimpleNamespace(email="test@ukma.edu.ua", user_id=1)
 
-        # Act
-        result = service.link_user_to_student(user)
+    # Act
+    result = service.link_student_to_user(student)
 
-        # Assert
-        assert result is False
+    # Assert
+    assert result is False
 
-    def test_returns_false_when_user_already_linked_to_student(self, service):
-        # Arrange
-        user = SimpleNamespace(
-            email="test@ukma.edu.ua",
-            id=1,
-            student_profile=SimpleNamespace(id="existing-student"),
-        )
 
-        # Act
-        result = service.link_user_to_student(user)
+def test_link_student_to_user_returns_false_when_no_user_with_email(service, user_repo):
+    # Arrange
+    student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="student-id")
+    user_repo.get_by_email.return_value = None
 
-        # Assert
-        assert result is False
+    # Act
+    result = service.link_student_to_user(student)
 
-    def test_returns_false_when_no_student_with_email(self, service, student_repo):
-        # Arrange
-        user = SimpleNamespace(email="test@ukma.edu.ua", id=1, student_profile=None)
-        student_repo.get_by_email.return_value = None
+    # Assert
+    assert result is False
+    user_repo.get_by_email.assert_called_once_with("test@ukma.edu.ua")
 
-        # Act
-        result = service.link_user_to_student(user)
 
-        # Assert
-        assert result is False
-        student_repo.get_by_email.assert_called_once_with("test@ukma.edu.ua")
+def test_link_student_to_user_returns_false_when_user_already_linked_to_another_student(
+    service, user_repo
+):
+    # Arrange
+    student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="new-student")
+    existing_user = SimpleNamespace(
+        id=1,
+        pk=1,
+        email="test@ukma.edu.ua",
+        student_profile=SimpleNamespace(id="existing-student"),
+    )
+    user_repo.get_by_email.return_value = existing_user
 
-    def test_links_user_to_student_successfully(self, service, student_repo):
-        # Arrange
-        user = SimpleNamespace(email="test@ukma.edu.ua", id=1, student_profile=None)
-        student = SimpleNamespace(id="student-id", email="test@ukma.edu.ua", user_id=None)
-        student_repo.get_by_email.return_value = student
+    # Act
+    result = service.link_student_to_user(student)
 
-        # Act
-        result = service.link_user_to_student(user)
+    # Assert
+    assert result is False
 
-        # Assert
-        assert result is True
-        student_repo.link_to_user.assert_called_once_with("student-id", user)
+
+def test_link_student_to_user_links_student_to_user_successfully(service, user_repo, student_repo):
+    # Arrange
+    student = SimpleNamespace(email="test@ukma.edu.ua", user_id=None, id="student-id")
+    user = SimpleNamespace(id=1, pk=1, email="test@ukma.edu.ua", student_profile=None)
+    user_repo.get_by_email.return_value = user
+
+    # Act
+    result = service.link_student_to_user(student)
+
+    # Assert
+    assert result is True
+    student_repo.link_to_user.assert_called_once_with("student-id", user)
+
+
+def test_link_user_to_student_returns_false_when_user_has_no_email(service):
+    # Arrange
+    user = SimpleNamespace(email="", id=1)
+
+    # Act
+    result = service.link_user_to_student(user)
+
+    # Assert
+    assert result is False
+
+
+def test_link_user_to_student_returns_false_when_user_already_linked_to_student(service):
+    # Arrange
+    user = SimpleNamespace(
+        email="test@ukma.edu.ua",
+        id=1,
+        student_profile=SimpleNamespace(id="existing-student"),
+    )
+
+    # Act
+    result = service.link_user_to_student(user)
+
+    # Assert
+    assert result is False
+
+
+def test_link_user_to_student_returns_false_when_no_student_with_email(service, student_repo):
+    # Arrange
+    user = SimpleNamespace(email="test@ukma.edu.ua", id=1, student_profile=None)
+    student_repo.get_by_email.return_value = None
+
+    # Act
+    result = service.link_user_to_student(user)
+
+    # Assert
+    assert result is False
+    student_repo.get_by_email.assert_called_once_with("test@ukma.edu.ua")
+
+
+def test_link_user_to_student_links_user_to_student_successfully(service, student_repo):
+    # Arrange
+    user = SimpleNamespace(email="test@ukma.edu.ua", id=1, student_profile=None)
+    student = SimpleNamespace(id="student-id", email="test@ukma.edu.ua", user_id=None)
+    student_repo.get_by_email.return_value = student
+
+    # Act
+    result = service.link_user_to_student(user)
+
+    # Assert
+    assert result is True
+    student_repo.link_to_user.assert_called_once_with("student-id", user)
 
 
 # Integration tests exercising real services/DB

--- a/src/backend/rating_app/views/test_feed.py
+++ b/src/backend/rating_app/views/test_feed.py
@@ -13,7 +13,7 @@ from rating_app.tests.factories import (
     SemesterFactory,
 )
 
-pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 @pytest.fixture
@@ -79,54 +79,56 @@ def test_review_items_carry_course_context_and_averages(token_client, feed_url):
     assert item["course_avg_usefulness"] == 4.25
 
 
-class TestPinning:
-    def test_pinned_posts_lead_the_first_page(self, token_client, feed_url):
-        FeedPostFactory(published_at=_at(hours=1))
-        pinned = FeedPostFactory(pinned=True, published_at=_at(days=30))
+def test_pinning_pinned_posts_lead_the_first_page(token_client, feed_url):
+    FeedPostFactory(published_at=_at(hours=1))
+    pinned = FeedPostFactory(pinned=True, published_at=_at(days=30))
 
-        items = token_client.get(feed_url).json()["items"]
+    items = token_client.get(feed_url).json()["items"]
 
-        assert items[0]["id"] == str(pinned.id)
-        assert items[0]["pinned"] is True
-
-    def test_pinned_posts_never_appear_on_later_pages(self, token_client, feed_url):
-        FeedPostFactory(pinned=True, published_at=_at(days=30))
-        for hours in range(4):
-            FeedPostFactory(published_at=_at(hours=hours + 1))
-
-        first = token_client.get(feed_url, {"limit": 2}).json()
-        second = token_client.get(feed_url, {"cursor": first["next_cursor"]}).json()
-
-        assert sum(item["pinned"] for item in second["items"]) == 0
+    assert items[0]["id"] == str(pinned.id)
+    assert items[0]["pinned"] is True
 
 
-class TestPagination:
-    def test_walks_to_exhaustion_without_duplicates_or_gaps(self, token_client, feed_url):
-        expected = {str(RatingFactory(comment=f"Відгук {i}").id) for i in range(4)}
-        expected |= {str(FeedPostFactory(published_at=_at(hours=i + 1)).id) for i in range(3)}
+def test_pinning_pinned_posts_never_appear_on_later_pages(token_client, feed_url):
+    FeedPostFactory(pinned=True, published_at=_at(days=30))
+    for hours in range(4):
+        FeedPostFactory(published_at=_at(hours=hours + 1))
 
-        seen = []
-        cursor = None
-        while True:
-            params = {"limit": 2}
-            if cursor:
-                params["cursor"] = cursor
-            body = token_client.get(feed_url, params).json()
-            seen.extend(item["id"] for item in body["items"])
-            cursor = body["next_cursor"]
-            if cursor is None:
-                break
+    first = token_client.get(feed_url, {"limit": 2}).json()
+    second = token_client.get(feed_url, {"cursor": first["next_cursor"]}).json()
 
-        assert len(seen) == len(set(seen))
-        assert set(seen) == expected
+    assert sum(item["pinned"] for item in second["items"]) == 0
 
-    def test_next_cursor_is_null_on_the_last_page(self, token_client, feed_url):
-        RatingFactory(comment="Єдиний")
 
-        assert token_client.get(feed_url).json()["next_cursor"] is None
+def test_pagination_walks_to_exhaustion_without_duplicates_or_gaps(token_client, feed_url):
+    expected = {str(RatingFactory(comment=f"Відгук {i}").id) for i in range(4)}
+    expected |= {str(FeedPostFactory(published_at=_at(hours=i + 1)).id) for i in range(3)}
 
-    def test_rejects_a_malformed_cursor(self, token_client, feed_url):
-        assert token_client.get(feed_url, {"cursor": "not-a-cursor"}).status_code == 400
+    seen = []
+    cursor = None
+    while True:
+        params = {"limit": 2}
+        if cursor:
+            params["cursor"] = cursor
+        body = token_client.get(feed_url, params).json()
+        seen.extend(item["id"] for item in body["items"])
+        cursor = body["next_cursor"]
+        if cursor is None:
+            break
 
-    def test_rejects_an_out_of_range_limit(self, token_client, feed_url):
-        assert token_client.get(feed_url, {"limit": 0}).status_code == 400
+    assert len(seen) == len(set(seen))
+    assert set(seen) == expected
+
+
+def test_pagination_next_cursor_is_null_on_the_last_page(token_client, feed_url):
+    RatingFactory(comment="Єдиний")
+
+    assert token_client.get(feed_url).json()["next_cursor"] is None
+
+
+def test_pagination_rejects_a_malformed_cursor(token_client, feed_url):
+    assert token_client.get(feed_url, {"cursor": "not-a-cursor"}).status_code == 400
+
+
+def test_pagination_rejects_an_out_of_range_limit(token_client, feed_url):
+    assert token_client.get(feed_url, {"limit": 0}).status_code == 400

--- a/src/backend/scraper/management/commands/test_collect_catalog.py
+++ b/src/backend/scraper/management/commands/test_collect_catalog.py
@@ -6,6 +6,7 @@ import pytest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.collect_catalog.with_authenticated_context")
 @patch("scraper.management.commands.collect_catalog.FilterService")
 def test_collect_catalog_with_default_url(mock_filter_service, mock_auth_context):
@@ -26,6 +27,7 @@ def test_collect_catalog_with_default_url(mock_filter_service, mock_auth_context
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.collect_catalog.with_authenticated_context")
 @patch("scraper.management.commands.collect_catalog.FilterService")
 def test_collect_catalog_with_custom_url(mock_filter_service, mock_auth_context):
@@ -52,6 +54,7 @@ def test_collect_catalog_with_custom_url(mock_filter_service, mock_auth_context)
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.collect_catalog.with_authenticated_context")
 @patch("scraper.management.commands.collect_catalog.FilterService")
 def test_collect_catalog_with_filtered_url(mock_filter_service, mock_auth_context):

--- a/src/backend/scraper/management/commands/test_fetch_courses.py
+++ b/src/backend/scraper/management/commands/test_fetch_courses.py
@@ -7,6 +7,7 @@ import pytest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.fetch_courses.with_authenticated_context")
 @patch("scraper.management.commands.fetch_courses.Path")
 def test_fetch_courses_success(mock_path, mock_auth_context):
@@ -27,6 +28,7 @@ def test_fetch_courses_success(mock_path, mock_auth_context):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.fetch_courses.Path")
 def test_fetch_courses_file_not_found(mock_path):
     # Arrange
@@ -40,6 +42,7 @@ def test_fetch_courses_file_not_found(mock_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.fetch_courses.with_authenticated_context")
 @patch("scraper.management.commands.fetch_courses.Path")
 def test_fetch_courses_with_concurrency(mock_path, mock_auth_context):
@@ -60,6 +63,7 @@ def test_fetch_courses_with_concurrency(mock_path, mock_auth_context):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.fetch_courses.with_authenticated_context")
 @patch("scraper.management.commands.fetch_courses.Path")
 def test_fetch_courses_no_resume(mock_path, mock_auth_context):

--- a/src/backend/scraper/management/commands/test_group_courses.py
+++ b/src/backend/scraper/management/commands/test_group_courses.py
@@ -8,6 +8,7 @@ import pytest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.group_courses.CourseGroupingService")
 @patch("scraper.management.commands.group_courses.Path")
 def test_group_courses_success(mock_path, mock_grouping_service):
@@ -42,6 +43,7 @@ def test_group_courses_success(mock_path, mock_grouping_service):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.group_courses.Path")
 def test_group_courses_input_not_found(mock_path):
     # Arrange
@@ -55,6 +57,7 @@ def test_group_courses_input_not_found(mock_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.group_courses.Path")
 def test_group_courses_same_input_output(mock_path):
     # Arrange
@@ -69,6 +72,7 @@ def test_group_courses_same_input_output(mock_path):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.group_courses.CourseGroupingService")
 @patch("scraper.management.commands.group_courses.Path")
 def test_group_courses_force_overwrite(mock_path, mock_grouping_service):
@@ -104,6 +108,7 @@ def test_group_courses_force_overwrite(mock_path, mock_grouping_service):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.group_courses.Path")
 def test_group_courses_output_exists_no_force(mock_path):
     # Arrange

--- a/src/backend/scraper/management/commands/test_insert_scraped.py
+++ b/src/backend/scraper/management/commands/test_insert_scraped.py
@@ -6,6 +6,7 @@ import pytest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.insert_scraped.courses_ingestion")
 def test_insert_scraped_success(mock_ingestion):
     # Arrange
@@ -21,6 +22,7 @@ def test_insert_scraped_success(mock_ingestion):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.insert_scraped.courses_ingestion")
 def test_insert_scraped_with_batch_size(mock_ingestion):
     # Arrange
@@ -38,6 +40,7 @@ def test_insert_scraped_with_batch_size(mock_ingestion):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.insert_scraped.courses_ingestion")
 def test_insert_scraped_dry_run(mock_ingestion):
     # Arrange

--- a/src/backend/scraper/management/commands/test_prepare_filtered_url.py
+++ b/src/backend/scraper/management/commands/test_prepare_filtered_url.py
@@ -6,6 +6,7 @@ import pytest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.prepare_filtered_url.with_authenticated_context")
 @patch("scraper.management.commands.prepare_filtered_url.FilterService")
 def test_prepare_filtered_url_success(mock_filter_service, mock_auth_context):
@@ -28,6 +29,7 @@ def test_prepare_filtered_url_success(mock_filter_service, mock_auth_context):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.prepare_filtered_url.with_authenticated_context")
 @patch("scraper.management.commands.prepare_filtered_url.FilterService")
 def test_prepare_filtered_url_interactive_mode(mock_filter_service, mock_auth_context):
@@ -51,6 +53,7 @@ def test_prepare_filtered_url_interactive_mode(mock_filter_service, mock_auth_co
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 @patch("scraper.management.commands.prepare_filtered_url.with_authenticated_context")
 @patch("scraper.management.commands.prepare_filtered_url.FilterService")
 def test_prepare_filtered_url_custom_output(mock_filter_service, mock_auth_context):

--- a/src/backend/scraper/parsers/test_catalog.py
+++ b/src/backend/scraper/parsers/test_catalog.py
@@ -406,7 +406,7 @@ def test_course_link_parser_requires_base_url():
     </html>
     """
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="base_url must be a non-empty string"):
         CourseLinkParser().parse(html, base_url="")
 
 
@@ -439,7 +439,7 @@ def test_catalog_parser_requires_base_url():
         </body>
     </html>
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="base_url must be a non-empty string"):
         CatalogParser().parse(html, base_url="")
 
 

--- a/src/backend/scraper/parsers/test_course.py
+++ b/src/backend/scraper/parsers/test_course.py
@@ -1,5 +1,5 @@
+import pytest
 from faker import Faker
-from pytest import approx
 
 from scraper.models import Enrollment, Limits, ParsedCourseDetails, SpecialtyEntry, StudentRow
 from scraper.parsers.course import (
@@ -392,7 +392,7 @@ def test_course_detail_parser_with_basic_course_info():
     assert result.url == url
     assert result.title == title
     assert result.id == course_id
-    assert result.credits == approx(float(credits))
+    assert result.credits == pytest.approx(float(credits))
     assert result.hours == hours
     assert result.year == year
     assert result.format == format_type

--- a/src/backend/scraper/services/db_ingestion/test_injector.py
+++ b/src/backend/scraper/services/db_ingestion/test_injector.py
@@ -49,7 +49,7 @@ def mock_offering_term_objects():
         yield mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def repo_mocks():
     course_repo = MagicMock()
     dept_repo = MagicMock()
@@ -115,7 +115,7 @@ def repo_mocks():
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def injector(repo_mocks) -> CourseDbInjector:
     return CourseDbInjector(
         repo_mocks.course_repo,
@@ -297,6 +297,7 @@ def create_mock_offering(
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_basic_flow_calls_repos_and_tracker(injector, repo_mocks):
     # Arrange
     repo_mocks.course_repo.get_or_upsert.return_value = (repo_mocks.course, True)
@@ -322,6 +323,7 @@ def test_injector_basic_flow_calls_repos_and_tracker(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_passes_course_education_level(injector, repo_mocks):
     models = [
         create_mock_course(
@@ -343,6 +345,7 @@ def test_injector_passes_course_education_level(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_processes_specialities(injector, repo_mocks):
     # Arrange
     existing_spec_dto = SimpleNamespace(id=uuid4())  # DTO returned by get_by_name
@@ -371,6 +374,7 @@ def test_injector_processes_specialities(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_processes_offerings_and_enrollments(injector, repo_mocks):
     # Arrange
     models = create_mock_payload()
@@ -386,6 +390,7 @@ def test_injector_processes_offerings_and_enrollments(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_handles_exception_and_calls_fail(injector, repo_mocks):
     # Arrange
     repo_mocks.faculty_repo.get_or_create.side_effect = RuntimeError("boom")
@@ -401,6 +406,7 @@ def test_injector_handles_exception_and_calls_fail(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_skips_student_creation_when_missing_speciality(injector, repo_mocks):
     # Arrange
     models = create_mock_no_speciality_payload()
@@ -413,6 +419,7 @@ def test_injector_skips_student_creation_when_missing_speciality(injector, repo_
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_handles_empty_education_level(injector, repo_mocks):
     # Arrange
     models = create_mock_empty_education_level_payload()
@@ -429,6 +436,7 @@ def test_injector_handles_empty_education_level(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_passes_program_start_year_and_term_hours_to_repositories(injector, repo_mocks):
     models = [
         create_mock_course(
@@ -478,6 +486,7 @@ def test_injector_passes_program_start_year_and_term_hours_to_repositories(injec
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_persists_course_offering_terms(injector, repo_mocks):
     models = [
         create_mock_course(
@@ -527,6 +536,7 @@ def test_injector_persists_course_offering_terms(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_invalidates_cache_after_successful_execution(injector, repo_mocks):
     # Arrange
     models = create_mock_payload()
@@ -542,6 +552,7 @@ def test_injector_invalidates_cache_after_successful_execution(injector, repo_mo
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_logs_warning_when_type_kind_is_none(injector, repo_mocks):
     # Arrange
     repo_mocks.speciality_repo.get_by_name.return_value = SimpleNamespace(id=uuid4())
@@ -561,6 +572,7 @@ def test_injector_logs_warning_when_type_kind_is_none(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_does_not_invalidate_cache_on_exception(injector, repo_mocks):
     # Arrange
     repo_mocks.faculty_repo.get_or_create.side_effect = RuntimeError("error")
@@ -575,6 +587,7 @@ def test_injector_does_not_invalidate_cache_on_exception(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_processes_offering_specialities(injector, repo_mocks):
     # Arrange — course-level speciality populates the cache; offering references same name
     repo_mocks.speciality_repo.get_by_name.return_value = SimpleNamespace(id=uuid4())
@@ -609,6 +622,7 @@ def test_injector_processes_offering_specialities(injector, repo_mocks):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_injector_skips_offering_speciality_when_not_in_cache(injector, repo_mocks):
     # Arrange — offering references a speciality not processed at course level → not in cache
     repo_mocks.speciality_repo.get_by_name.return_value = None

--- a/src/backend/scraper/services/deduplication/test_grouper.py
+++ b/src/backend/scraper/services/deduplication/test_grouper.py
@@ -1,4 +1,4 @@
-from pytest import approx
+import pytest
 
 from scraper.models import ParsedCourseDetails
 from scraper.models.deduplicated import DeduplicatedCourse
@@ -804,7 +804,7 @@ def test_course_grouper_uses_term_specific_season_details(course_grouper):
     terms_by_term = {term.semester.term.value: term for term in offering.terms}
 
     fall = terms_by_term["FALL"]
-    assert fall.credits == approx(4.0)
+    assert fall.credits == pytest.approx(4.0)
     assert fall.weekly_hours == 3
     assert fall.lecture_count == 22
     assert fall.practice_count == 22
@@ -812,7 +812,7 @@ def test_course_grouper_uses_term_specific_season_details(course_grouper):
     assert fall.exam_type.value == "EXAM"
 
     spring = terms_by_term["SPRING"]
-    assert spring.credits == approx(4.0)
+    assert spring.credits == pytest.approx(4.0)
     assert spring.weekly_hours == 2
     assert spring.lecture_count == 18
     assert spring.practice_count == 12
@@ -860,7 +860,7 @@ def test_course_grouper_falls_back_to_course_credits_when_term_credits_are_zero(
     assert len(grouped.offerings) == 1
 
     spring = grouped.offerings[0]
-    assert spring.credits == approx(4.0)
+    assert spring.credits == pytest.approx(4.0)
     assert spring.weekly_hours == 1
 
 

--- a/src/backend/scraper/services/test_catalog_service.py
+++ b/src/backend/scraper/services/test_catalog_service.py
@@ -2,6 +2,7 @@ import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
 from scraper.services import catalog_service
@@ -103,13 +104,12 @@ def test_fetch_catalog_page_navigation_failure():
             "scraper.services.catalog_service._add_page_param",
             return_value="https://example.com/catalog?page=1",
         ):
-            try:
+            with pytest.raises(Exception, match="Navigation failed") as exc_info:
                 await catalog_service.fetch_catalog_page(
                     context_mock, "https://example.com/catalog", 1
                 )
-                raise AssertionError("Expected exception was not raised")
-            except Exception as e:
-                assert str(e) == "Navigation failed"
+
+            assert str(exc_info.value) == "Navigation failed"
 
         page_mock.close.assert_called_once()
 
@@ -125,13 +125,12 @@ def test_fetch_catalog_page_page_creation_failure():
             "scraper.services.catalog_service._add_page_param",
             return_value="https://example.com/catalog?page=1",
         ):
-            try:
+            with pytest.raises(Exception, match="Failed to create page") as exc_info:
                 await catalog_service.fetch_catalog_page(
                     context_mock, "https://example.com/catalog", 1
                 )
-                raise AssertionError("Expected exception was not raised")
-            except Exception as e:
-                assert str(e) == "Failed to create page"
+
+            assert str(exc_info.value) == "Failed to create page"
 
     asyncio.run(run())
 


### PR DESCRIPTION
Related to #230, follow-up on @stasiaaleks's comment: no AI rules for writing tests existed, so this adds them and unifies the backend suite to match.

- New `docs/testing/backend-tests.md` (layout, structure, markers, test data by layer, exceptions, run recipe, sources); linked from `testing-strategy.md` and a 9-line `## Tests` section in `src/backend/AGENTS.md`.
- Enable ruff `PT` (flake8-pytest-style) in `pyproject.toml`; fix the 15 findings.
- Flatten the remaining 9 `class Test*` groups into module-level functions; `@pytest.mark.integration` under every `django_db` (was missing in scraper/services/management tests).

```
$ uv run ruff check . && uv run ruff format --check . && uv run pytest -q
All checks passed!
344 files already formatted
731 passed in 5.54s
```

Note: `rateukma/ioc/test_decorators.py` shows a full-file diff from CRLF→LF normalization; the real change is 2 lines (`match=`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added backend pytest conventions, including test structure, fixtures, markers, exception checks, test data, and local commands.
  - Linked the backend testing conventions from the broader testing strategy documentation.
  - Updated backend development guidance with testing practices.

- **Tests**
  - Standardized backend tests around module-level functions and clearer parametrization.
  - Classified database-backed tests as integration tests.
  - Strengthened assertions for expected exception messages.
  - Preserved existing test coverage and behavior while improving consistency.

- **Chores**
  - Enabled pytest-specific Ruff checks to enforce testing conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->