### PR TITLE
fix(#392): fail fast on queries without HTTP response

### DIFF
--- a/src/webapp/src/integrations/tanstack-query/RootProvider.test.tsx
+++ b/src/webapp/src/integrations/tanstack-query/RootProvider.test.tsx
@@ -34,11 +34,9 @@ describe("RootProvider", () => {
 		it("retries 5xx up to three attempts, then stops", () => {
 			const serverError = { response: { status: 502 } };
 
-			expect([0, 1, 2].map((count) => shouldRetryQuery(count, serverError))).toEqual([
-				true,
-				true,
-				true,
-			]);
+			expect(
+				[0, 1, 2].map((count) => shouldRetryQuery(count, serverError)),
+			).toEqual([true, true, true]);
 			expect(shouldRetryQuery(3, serverError)).toBe(false);
 		});
 

--- a/src/webapp/src/integrations/tanstack-query/RootProvider.test.tsx
+++ b/src/webapp/src/integrations/tanstack-query/RootProvider.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getContext } from "./RootProvider";
+import { getContext, shouldRetryQuery } from "./RootProvider";
 
 describe("RootProvider", () => {
 	describe("getContext", () => {
@@ -16,6 +16,36 @@ describe("RootProvider", () => {
 			const context2 = getContext();
 
 			expect(context1.queryClient).not.toBe(context2.queryClient);
+		});
+	});
+
+	describe("shouldRetryQuery", () => {
+		it("never retries failures without an HTTP response (timeout, offline)", () => {
+			expect(shouldRetryQuery(0, { code: "ECONNABORTED" })).toBe(false);
+			expect(shouldRetryQuery(0, new TypeError("fetch failed"))).toBe(false);
+			expect(shouldRetryQuery(0, null)).toBe(false);
+		});
+
+		it("never retries 401 or 403", () => {
+			expect(shouldRetryQuery(0, { response: { status: 401 } })).toBe(false);
+			expect(shouldRetryQuery(2, { response: { status: 403 } })).toBe(false);
+		});
+
+		it("retries 5xx up to three attempts, then stops", () => {
+			const serverError = { response: { status: 502 } };
+
+			expect([0, 1, 2].map((count) => shouldRetryQuery(count, serverError))).toEqual([
+				true,
+				true,
+				true,
+			]);
+			expect(shouldRetryQuery(3, serverError)).toBe(false);
+		});
+
+		it("is wired as the queryClient retry default", () => {
+			expect(getContext().queryClient.getDefaultOptions().queries?.retry).toBe(
+				shouldRetryQuery,
+			);
 		});
 	});
 });

--- a/src/webapp/src/integrations/tanstack-query/RootProvider.tsx
+++ b/src/webapp/src/integrations/tanstack-query/RootProvider.tsx
@@ -12,7 +12,10 @@ const MAX_RETRY_DELAY = 30_000; // 30 seconds cap
  * /connection-error on the first failure, so retries would only multiply
  * slow connections while the user is being navigated away.
  */
-export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+export function shouldRetryQuery(
+	failureCount: number,
+	error: unknown,
+): boolean {
 	const errorStatus = (error as { response?: { status?: number } } | null)
 		?.response?.status;
 	// Never retry on 401 (unauthorized) or 403 (forbidden)

--- a/src/webapp/src/integrations/tanstack-query/RootProvider.tsx
+++ b/src/webapp/src/integrations/tanstack-query/RootProvider.tsx
@@ -4,21 +4,34 @@ const STALE_TIME = 5 * 60 * 1000; // 5 minutes
 const MAX_RETRY_ATTEMPTS = 3;
 const MAX_RETRY_DELAY = 30_000; // 30 seconds cap
 
+/**
+ * Decides whether a failed query is worth retrying.
+ *
+ * Failures without an HTTP response (timeouts, aborted or offline requests)
+ * are never retried: the apiClient interceptor already redirects those to
+ * /connection-error on the first failure, so retries would only multiply
+ * slow connections while the user is being navigated away.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+	const errorStatus = (error as { response?: { status?: number } } | null)
+		?.response?.status;
+	// Never retry on 401 (unauthorized) or 403 (forbidden)
+	if (errorStatus === 401 || errorStatus === 403) {
+		return false;
+	}
+	if (errorStatus === undefined) {
+		return false;
+	}
+	// Exponential backoff for other errors, up to MAX_RETRY_ATTEMPTS
+	return failureCount < MAX_RETRY_ATTEMPTS;
+}
+
 export function getContext() {
 	const queryClient = new QueryClient({
 		defaultOptions: {
 			queries: {
 				staleTime: STALE_TIME,
-				retry: (failureCount, error) => {
-					const errorStatus = (error as { response?: { status?: number } })
-						?.response?.status;
-					// Never retry on 401 (unauthorized) or 403 (forbidden)
-					if (errorStatus === 401 || errorStatus === 403) {
-						return false;
-					}
-					// Exponential backoff for other errors, up to MAX_RETRY_ATTEMPTS
-					return failureCount < MAX_RETRY_ATTEMPTS;
-				},
+				retry: shouldRetryQuery,
 				retryDelay: (failureCount) =>
 					Math.min(1000 * 2 ** failureCount, MAX_RETRY_DELAY),
 			},


### PR DESCRIPTION
Timeouts and offline requests retried 3x per query, even though the apiClient interceptor already redirects to /connection-error on the first such failure. Those retries only multiplied slow connections while the user was being navigated away.

This stops retrying failures without an HTTP response. 5xx keeps its 3 attempts, 401/403 unchanged. Load-only change, no UX difference.

Tests: new shouldRetryQuery unit tests, full webapp suite green (335 passed), tsc + oxlint clean.