### PR TITLE
fix(#392): stop connection-error ping-pong

### DIFF
--- a/src/webapp/src/lib/api/networkError.test.ts
+++ b/src/webapp/src/lib/api/networkError.test.ts
@@ -307,19 +307,15 @@ describe("networkError", () => {
 	});
 
 	describe("parseBounceCount", () => {
-		it("parses raw param values", () => {
-			expect(parseBounceCount("3")).toBe(3);
-			expect(parseBounceCount(undefined)).toBe(0);
-			expect(parseBounceCount(null)).toBe(0);
-			expect(parseBounceCount("nope")).toBe(0);
-			expect(parseBounceCount("0")).toBe(0);
-			expect(parseBounceCount("-2")).toBe(0);
-		});
-
-		it("parses full search strings", () => {
-			expect(parseBounceCount("?bounces=2")).toBe(2);
-			expect(parseBounceCount("?foo=bar")).toBe(0);
-			expect(parseBounceCount("")).toBe(0);
+		it.each([
+			["3", 3],
+			[undefined, 0],
+			[null, 0],
+			["nope", 0],
+			["0", 0],
+			["-2", 0],
+		])("parses %s as %i", (value, expected) => {
+			expect(parseBounceCount(value)).toBe(expected);
 		});
 	});
 

--- a/src/webapp/src/lib/api/networkError.test.ts
+++ b/src/webapp/src/lib/api/networkError.test.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosError } from "axios";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+	BOUNCE_WINDOW_MS,
 	CONNECTION_ERROR_PATH,
 	handleConnectionIssue,
 	isOffline,
@@ -57,6 +58,7 @@ describe("networkError", () => {
 
 	afterEach(() => {
 		resetRedirectFlag();
+		sessionStorage.clear();
 		vi.unstubAllGlobals();
 	});
 
@@ -265,6 +267,12 @@ describe("networkError", () => {
 		const timeoutError = () => createAxiosError({ response: undefined });
 		const redirectUrl = () =>
 			new URL(mockWindowReplace.mock.calls[0][0] as string);
+		const startCycle = (ageMs = 0) => {
+			sessionStorage.setItem(
+				"rateukma.connection-error-ts",
+				String(Date.now() - ageMs),
+			);
+		};
 
 		it("stamps bounces=1 on the first redirect", () => {
 			stubNavigatorOnline();
@@ -274,7 +282,7 @@ describe("networkError", () => {
 			expect(redirectUrl().searchParams.get("bounces")).toBe("1");
 		});
 
-		it("increments the counter carried by the return target", () => {
+		it("increments the counter within one outage", () => {
 			mockWindowReplace = stubBrowserLocation({
 				pathname: "/",
 				search: "?bounces=2",
@@ -282,10 +290,26 @@ describe("networkError", () => {
 				origin: "http://localhost:3000",
 			}).replace;
 			stubNavigatorOnline();
+			startCycle();
 
 			handleConnectionIssue(timeoutError());
 
 			expect(redirectUrl().searchParams.get("bounces")).toBe("3");
+		});
+
+		it("restarts at 1 when the previous cycle aged out", () => {
+			mockWindowReplace = stubBrowserLocation({
+				pathname: "/",
+				search: "?bounces=5",
+				hash: "",
+				origin: "http://localhost:3000",
+			}).replace;
+			stubNavigatorOnline();
+			startCycle(BOUNCE_WINDOW_MS + 60_000);
+
+			handleConnectionIssue(timeoutError());
+
+			expect(redirectUrl().searchParams.get("bounces")).toBe("1");
 		});
 
 		it.each(["?foo=bar", "?bounces=nope", "?bounces=-4"])(

--- a/src/webapp/src/lib/api/networkError.test.ts
+++ b/src/webapp/src/lib/api/networkError.test.ts
@@ -1,14 +1,14 @@
 import axios, { type AxiosError } from "axios";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { stubBrowserLocation } from "./browserMocks.test-support";
 import {
 	CONNECTION_ERROR_PATH,
 	handleConnectionIssue,
 	isOffline,
+	parseBounceCount,
 	resetRedirectFlag,
 } from "./networkError";
-
+import { stubBrowserLocation } from "./browserMocks.test-support";
 const DEFAULT_WINDOW_LOCATION = {
 	pathname: "/some-page",
 	search: "?foo=bar",
@@ -258,6 +258,68 @@ describe("networkError", () => {
 				// Assert
 				expect(mockWindowReplace).toHaveBeenCalledTimes(2);
 			});
+		});
+	});
+
+	describe("bounce counter", () => {
+		const timeoutError = () => createAxiosError({ response: undefined });
+		const redirectUrl = () =>
+			new URL(mockWindowReplace.mock.calls[0][0] as string);
+
+		it("stamps bounces=1 on the first redirect", () => {
+			stubNavigatorOnline();
+
+			handleConnectionIssue(timeoutError());
+
+			expect(redirectUrl().searchParams.get("bounces")).toBe("1");
+		});
+
+		it("increments the counter carried by the return target", () => {
+			mockWindowReplace = stubBrowserLocation({
+				pathname: "/",
+				search: "?bounces=2",
+				hash: "",
+				origin: "http://localhost:3000",
+			}).replace;
+			stubNavigatorOnline();
+
+			handleConnectionIssue(timeoutError());
+
+			expect(redirectUrl().searchParams.get("bounces")).toBe("3");
+		});
+
+		it.each(["?foo=bar", "?bounces=nope", "?bounces=-4"])(
+			"restarts at 1 when the counter is %s",
+			(search) => {
+				mockWindowReplace = stubBrowserLocation({
+					pathname: "/",
+					search,
+					hash: "",
+					origin: "http://localhost:3000",
+				}).replace;
+				stubNavigatorOnline();
+
+				handleConnectionIssue(timeoutError());
+
+				expect(redirectUrl().searchParams.get("bounces")).toBe("1");
+			},
+		);
+	});
+
+	describe("parseBounceCount", () => {
+		it("parses raw param values", () => {
+			expect(parseBounceCount("3")).toBe(3);
+			expect(parseBounceCount(undefined)).toBe(0);
+			expect(parseBounceCount(null)).toBe(0);
+			expect(parseBounceCount("nope")).toBe(0);
+			expect(parseBounceCount("0")).toBe(0);
+			expect(parseBounceCount("-2")).toBe(0);
+		});
+
+		it("parses full search strings", () => {
+			expect(parseBounceCount("?bounces=2")).toBe(2);
+			expect(parseBounceCount("?foo=bar")).toBe(0);
+			expect(parseBounceCount("")).toBe(0);
 		});
 	});
 

--- a/src/webapp/src/lib/api/networkError.ts
+++ b/src/webapp/src/lib/api/networkError.ts
@@ -7,6 +7,15 @@ export type ConnectionIssueReason = "offline" | "server" | "unknown";
 export const BOUNCES_PARAM = "bounces";
 
 /**
+ * Bounces only count as one outage while failures arrive back-to-back. The
+ * cycle start lives in sessionStorage (per tab) rather than the URL: a
+ * lingering ?bounces=N from an old outage ages out instead of disabling
+ * auto-return on the next, unrelated one.
+ */
+export const BOUNCE_WINDOW_MS = 10 * 60_000;
+const BOUNCE_TS_KEY = "rateukma.connection-error-ts";
+
+/**
  * Reads the bounce counter from a raw param value.
  * Anything missing or unparseable counts as zero so a hand-typed URL
  * never breaks the page.
@@ -14,6 +23,39 @@ export const BOUNCES_PARAM = "bounces";
 export const parseBounceCount = (value?: string | null): number => {
 	const parsed = Number.parseInt(value ?? "", 10);
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const readCycleStart = (): number => {
+	try {
+		const parsed = Number.parseInt(
+			sessionStorage.getItem(BOUNCE_TS_KEY) ?? "",
+			10,
+		);
+		return Number.isInteger(parsed) ? parsed : 0;
+	} catch {
+		// Storage unavailable (private mode): every redirect starts a new cycle.
+		return 0;
+	}
+};
+
+const nextBounceCount = (now: number): number => {
+	if (now - readCycleStart() > BOUNCE_WINDOW_MS) {
+		return 1;
+	}
+	return (
+		parseBounceCount(
+			new URLSearchParams(globalThis.location.search).get(BOUNCES_PARAM),
+		) + 1
+	);
+};
+
+const stampCycleStart = (now: number): void => {
+	try {
+		sessionStorage.setItem(BOUNCE_TS_KEY, String(now));
+	} catch {
+		// Storage unavailable (private mode): the counter still works,
+		// it just never spans more than one redirect.
+	}
 };
 
 let isRedirecting = false;
@@ -44,14 +86,8 @@ const redirectToConnectionError = (
 	const url = new URL(CONNECTION_ERROR_PATH, globalThis.location.origin);
 	url.searchParams.set("reason", reason);
 	url.searchParams.set("from", from);
-	url.searchParams.set(
-		BOUNCES_PARAM,
-		String(
-			parseBounceCount(
-				new URLSearchParams(globalThis.location.search).get(BOUNCES_PARAM),
-			) + 1,
-		),
-	);
+	url.searchParams.set(BOUNCES_PARAM, String(nextBounceCount(Date.now())));
+	stampCycleStart(Date.now());
 
 	globalThis.location.replace(url.toString());
 };

--- a/src/webapp/src/lib/api/networkError.ts
+++ b/src/webapp/src/lib/api/networkError.ts
@@ -4,6 +4,21 @@ export const CONNECTION_ERROR_PATH = "/connection-error";
 
 export type ConnectionIssueReason = "offline" | "server" | "unknown";
 
+export const BOUNCES_PARAM = "bounces";
+
+/**
+ * Reads the bounce counter from a raw param value or search string.
+ * Anything missing or unparseable counts as zero so a hand-typed URL
+ * never breaks the page.
+ */
+export const parseBounceCount = (value?: string | null): number => {
+	const raw = (value ?? "").startsWith("?")
+		? new URLSearchParams(value ?? "").get(BOUNCES_PARAM)
+		: value;
+	const parsed = Number.parseInt(raw ?? "", 10);
+	return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+};
+
 let isRedirecting = false;
 
 export const resetRedirectFlag = () => {
@@ -32,6 +47,10 @@ const redirectToConnectionError = (
 	const url = new URL(CONNECTION_ERROR_PATH, globalThis.location.origin);
 	url.searchParams.set("reason", reason);
 	url.searchParams.set("from", from);
+	url.searchParams.set(
+		BOUNCES_PARAM,
+		String(parseBounceCount(globalThis.location.search) + 1),
+	);
 
 	globalThis.location.replace(url.toString());
 };

--- a/src/webapp/src/lib/api/networkError.ts
+++ b/src/webapp/src/lib/api/networkError.ts
@@ -7,15 +7,12 @@ export type ConnectionIssueReason = "offline" | "server" | "unknown";
 export const BOUNCES_PARAM = "bounces";
 
 /**
- * Reads the bounce counter from a raw param value or search string.
+ * Reads the bounce counter from a raw param value.
  * Anything missing or unparseable counts as zero so a hand-typed URL
  * never breaks the page.
  */
 export const parseBounceCount = (value?: string | null): number => {
-	const raw = (value ?? "").startsWith("?")
-		? new URLSearchParams(value ?? "").get(BOUNCES_PARAM)
-		: value;
-	const parsed = Number.parseInt(raw ?? "", 10);
+	const parsed = Number.parseInt(value ?? "", 10);
 	return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
 };
 
@@ -49,7 +46,11 @@ const redirectToConnectionError = (
 	url.searchParams.set("from", from);
 	url.searchParams.set(
 		BOUNCES_PARAM,
-		String(parseBounceCount(globalThis.location.search) + 1),
+		String(
+			parseBounceCount(
+				new URLSearchParams(globalThis.location.search).get(BOUNCES_PARAM),
+			) + 1,
+		),
 	);
 
 	globalThis.location.replace(url.toString());

--- a/src/webapp/src/routes/connection-error.test.tsx
+++ b/src/webapp/src/routes/connection-error.test.tsx
@@ -1,0 +1,233 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { env } from "@/env";
+import {
+	ConnectionErrorPage,
+	MAX_AUTO_RETURN_BOUNCES,
+	getSafeRedirectTarget,
+	shouldAutoReturn,
+	withBounceCount,
+} from "./connection-error";
+
+const { sessionRetrieveMock } = vi.hoisted(() => ({
+	sessionRetrieveMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api/generated", async () => ({
+	...(await vi.importActual("@/lib/api/generated")),
+	authSessionRetrieve: sessionRetrieveMock,
+}));
+
+vi.mock("@/components/ModeToggle", () => ({
+	ModeToggle: () => null,
+}));
+
+vi.mock("@/components/Logo", () => ({
+	Logo: () => null,
+}));
+
+vi.mock("@/env", async () => {
+	const actual = await vi.importActual<{ env: typeof env }>("@/env");
+	return {
+		...actual,
+		env: { ...actual.env, VITE_SKIP_OFFLINE_CHECK: false },
+	};
+});
+
+const stubNavigatorOnline = (onLine = true) =>
+	vi.stubGlobal("navigator", { onLine } as Navigator);
+
+const stubLocation = () => {
+	const replace = vi.fn();
+	vi.stubGlobal("location", {
+		pathname: "/connection-error",
+		search: "",
+		hash: "",
+		origin: "http://localhost:3000",
+		replace,
+	});
+	return { replace };
+};
+
+const renderPage = (
+	props: Parameters<typeof ConnectionErrorPage>[0] = {},
+) => {
+	const location = stubLocation();
+	stubNavigatorOnline();
+	return { ...location, view: render(<ConnectionErrorPage {...props} />) };
+};
+
+const settle = async () => {
+	// Executor form: tsconfig lib is ES2022, without Promise.withResolvers.
+	await new Promise<void>((resolve) => setTimeout(resolve, 50));
+};
+
+beforeEach(() => {
+	sessionRetrieveMock.mockReset();
+	sessionRetrieveMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("shouldAutoReturn", () => {
+	it("allows silent return only for offline within the cap", () => {
+		expect(shouldAutoReturn("offline", 0)).toBe(true);
+		expect(shouldAutoReturn("offline", MAX_AUTO_RETURN_BOUNCES)).toBe(true);
+		expect(shouldAutoReturn("offline", MAX_AUTO_RETURN_BOUNCES + 1)).toBe(
+			false,
+		);
+	});
+
+	it("never silently returns on server or unknown reasons", () => {
+		expect(shouldAutoReturn("server", 0)).toBe(false);
+		expect(shouldAutoReturn("unknown", 0)).toBe(false);
+	});
+});
+
+describe("getSafeRedirectTarget", () => {
+	it("falls back to / without a source", () => {
+		expect(getSafeRedirectTarget(undefined)).toBe("/");
+	});
+
+	it("keeps the same-origin source untouched when no bounces", () => {
+		expect(getSafeRedirectTarget("/courses?x=1#top")).toBe("/courses?x=1#top");
+	});
+
+	it("stamps the bounce count so the next failure counts up", () => {
+		expect(getSafeRedirectTarget("/", 1)).toBe("/?bounces=1");
+		expect(getSafeRedirectTarget("/courses?x=1", 2)).toBe(
+			"/courses?x=1&bounces=2",
+		);
+	});
+
+	it("rejects cross-origin and invalid sources", () => {
+		expect(getSafeRedirectTarget("https://evil.example/phish", 1)).toBe("/");
+		expect(getSafeRedirectTarget("http://%zz", 1)).toBe("/");
+	});
+});
+
+describe("withBounceCount", () => {
+	it("leaves the target untouched at zero", () => {
+		expect(withBounceCount("/", 0)).toBe("/");
+	});
+
+	it("sets and overwrites the param", () => {
+		expect(withBounceCount("/", 1)).toBe("/?bounces=1");
+		expect(withBounceCount("/?bounces=1", 2)).toBe("/?bounces=2");
+	});
+});
+
+describe("ConnectionErrorPage auto-return", () => {
+	it("does not probe on mount for a server reason", async () => {
+		renderPage({ reason: "server" });
+
+		await screen.findByRole("heading", { name: "Проблема з'єднання" });
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+	});
+
+	it("probes silently on mount for offline and returns on success", async () => {
+		const { replace } = renderPage({ reason: "offline", bounces: 1 });
+
+		await waitFor(() => expect(sessionRetrieveMock).toHaveBeenCalledOnce());
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/?bounces=1"));
+	});
+
+	it("returns on the browser online event, not before", async () => {
+		stubLocation();
+		stubNavigatorOnline(false);
+		render(<ConnectionErrorPage reason="offline" />);
+		await screen.findByRole("heading", { name: "Проблема з'єднання" });
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+
+		stubNavigatorOnline(true);
+		act(() => {
+			globalThis.dispatchEvent(new Event("online"));
+		});
+
+		await waitFor(() => expect(sessionRetrieveMock).toHaveBeenCalledOnce());
+	});
+
+	it("ignores online events for server reasons", async () => {
+		renderPage({ reason: "server" });
+		await screen.findByRole("heading", { name: "Проблема з'єднання" });
+
+		act(() => {
+			globalThis.dispatchEvent(new Event("online"));
+		});
+		await settle();
+
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+	});
+
+	it("stops auto-return past the bounce cap", async () => {
+		renderPage({
+			reason: "offline",
+			bounces: MAX_AUTO_RETURN_BOUNCES + 1,
+		});
+		await screen.findByRole("heading", { name: "Проблема з'єднання" });
+
+		act(() => {
+			globalThis.dispatchEvent(new Event("online"));
+		});
+		await settle();
+
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+	});
+
+	it("removes the online listener on unmount", async () => {
+		const { view } = renderPage({ reason: "offline", bounces: 0 });
+		await waitFor(() => expect(sessionRetrieveMock).toHaveBeenCalled());
+		sessionRetrieveMock.mockClear();
+		view.unmount();
+
+		act(() => {
+			globalThis.dispatchEvent(new Event("online"));
+		});
+		await settle();
+
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+	});
+});
+
+describe("ConnectionErrorPage manual retry", () => {
+	it("always probes on click and navigates on success", async () => {
+		const { replace } = renderPage({ reason: "server", from: "/courses" });
+		await screen.findByRole("heading", { name: "Проблема з'єднання" });
+		expect(sessionRetrieveMock).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+
+		await waitFor(() => expect(sessionRetrieveMock).toHaveBeenCalledOnce());
+		await waitFor(() => expect(replace).toHaveBeenCalledWith("/courses"));
+	});
+
+	it("shows an inline error when the probe fails", async () => {
+		sessionRetrieveMock.mockRejectedValue(new Error("boom"));
+		renderPage({ reason: "server" });
+
+		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+
+		await screen.findByRole("alert");
+		expect(
+			screen.getByText("Не вдалося встановити з'єднання. Спробуйте пізніше."),
+		).toBeInTheDocument();
+	});
+
+	it("sends 401 probes to login with the return target", async () => {
+		sessionRetrieveMock.mockRejectedValue({
+			isAxiosError: true,
+			response: { status: 401 },
+		});
+		const { replace } = renderPage({ reason: "server", from: "/courses" });
+
+		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+
+		await waitFor(() => expect(replace).toHaveBeenCalledOnce());
+		const loginUrl = new URL(replace.mock.calls[0][0] as string);
+		expect(loginUrl.pathname).toBe("/login");
+		expect(loginUrl.searchParams.get("redirect")).toBe("/courses");
+	});
+});

--- a/src/webapp/src/routes/connection-error.test.tsx
+++ b/src/webapp/src/routes/connection-error.test.tsx
@@ -1,4 +1,10 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { env } from "@/env";
@@ -50,9 +56,7 @@ const stubLocation = () => {
 	return { replace };
 };
 
-const renderPage = (
-	props: Parameters<typeof ConnectionErrorPage>[0] = {},
-) => {
+const renderPage = (props: Parameters<typeof ConnectionErrorPage>[0] = {}) => {
 	const location = stubLocation();
 	stubNavigatorOnline();
 	return { ...location, view: render(<ConnectionErrorPage {...props} />) };
@@ -198,7 +202,9 @@ describe("ConnectionErrorPage manual retry", () => {
 		await screen.findByRole("heading", { name: "Проблема з'єднання" });
 		expect(sessionRetrieveMock).not.toHaveBeenCalled();
 
-		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Перевірити з'єднання" }),
+		);
 
 		await waitFor(() => expect(sessionRetrieveMock).toHaveBeenCalledOnce());
 		await waitFor(() => expect(replace).toHaveBeenCalledWith("/courses"));
@@ -208,7 +214,9 @@ describe("ConnectionErrorPage manual retry", () => {
 		sessionRetrieveMock.mockRejectedValue(new Error("boom"));
 		renderPage({ reason: "server" });
 
-		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Перевірити з'єднання" }),
+		);
 
 		await screen.findByRole("alert");
 		expect(
@@ -223,7 +231,9 @@ describe("ConnectionErrorPage manual retry", () => {
 		});
 		const { replace } = renderPage({ reason: "server", from: "/courses" });
 
-		fireEvent.click(screen.getByRole("button", { name: "Перевірити з'єднання" }));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Перевірити з'єднання" }),
+		);
 
 		await waitFor(() => expect(replace).toHaveBeenCalledOnce());
 		const loginUrl = new URL(replace.mock.calls[0][0] as string);

--- a/src/webapp/src/routes/connection-error.tsx
+++ b/src/webapp/src/routes/connection-error.tsx
@@ -10,35 +10,62 @@ import { env } from "@/env";
 import { authSessionRetrieve } from "@/lib/api/generated";
 import {
 	type ConnectionIssueReason,
+	BOUNCES_PARAM,
 	isOffline,
+	parseBounceCount,
 	resetRedirectFlag,
 } from "@/lib/api/networkError";
 
-type ConnectionErrorSearch = {
+export type ConnectionErrorSearch = {
 	reason?: ConnectionIssueReason;
 	from?: string;
+	bounces?: number;
 };
 
+/**
+ * Silent auto-return is only trustworthy for a real offline→online
+ * transition (the browser fires `online`, and a session probe success means
+ * the API is reachable again). A `server` probe can succeed while the heavy
+ * page that bounced still times out, which ping-pongs the user between the
+ * page and this error screen — so server reasons always wait for a manual
+ * retry. Past the cap even offline returns stay manual.
+ */
+export const MAX_AUTO_RETURN_BOUNCES = 2;
+
+export const shouldAutoReturn = (
+	reason: ConnectionIssueReason,
+	bounces: number,
+): boolean => reason === "offline" && bounces <= MAX_AUTO_RETURN_BOUNCES;
+
 export const Route = createFileRoute("/connection-error")({
-	component: ConnectionErrorPage,
+	component: ConnectionErrorRoute,
 	validateSearch: (search: Record<string, string>): ConnectionErrorSearch => {
+		const validated: ConnectionErrorSearch = {
+			bounces: parseBounceCount(search.bounces),
+		};
 		const reason = search.reason;
 		if (reason === "offline" || reason === "server" || reason === "unknown") {
-			return {
-				reason,
-				from: search.from,
-			};
+			validated.reason = reason;
+			validated.from = search.from;
 		}
-		return {};
+		return validated;
 	},
 });
+
+function ConnectionErrorRoute() {
+	const search = Route.useSearch();
+	return <ConnectionErrorPage {...search} />;
+}
 
 type AttemptOptions = {
 	silent?: boolean;
 };
 
-function ConnectionErrorPage() {
-	const { reason = "unknown", from } = Route.useSearch();
+export function ConnectionErrorPage({
+	reason = "unknown",
+	from,
+	bounces = 0,
+}: ConnectionErrorSearch) {
 	const [isChecking, setIsChecking] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const skipOfflineCheck = env.VITE_SKIP_OFFLINE_CHECK;
@@ -64,11 +91,11 @@ function ConnectionErrorPage() {
 
 			try {
 				await authSessionRetrieve();
-				globalThis.location.replace(getSafeRedirectTarget(from));
+				globalThis.location.replace(getSafeRedirectTarget(from, bounces));
 				return true;
 			} catch (error) {
 				if (axios.isAxiosError(error) && error.response?.status === 401) {
-					redirectToLogin(from);
+					redirectToLogin(from, bounces);
 					return true;
 				}
 
@@ -84,13 +111,24 @@ function ConnectionErrorPage() {
 
 			return false;
 		},
-		[skipOfflineCheck, from],
+		[skipOfflineCheck, from, bounces],
 	);
 
 	useEffect(() => {
 		resetRedirectFlag();
+		if (!shouldAutoReturn(reason, bounces)) {
+			return;
+		}
 		attemptReconnect({ silent: true }).catch(() => undefined);
-	}, [attemptReconnect]);
+
+		const onOnline = () => {
+			attemptReconnect({ silent: true }).catch(() => undefined);
+		};
+		globalThis.addEventListener("online", onOnline);
+		return () => {
+			globalThis.removeEventListener("online", onOnline);
+		};
+	}, [attemptReconnect, reason, bounces]);
 
 	const handleRetry = () => {
 		attemptReconnect().catch(() => undefined);
@@ -215,17 +253,17 @@ const getReconnectErrorMessage = (
 	return "Не вдалося встановити з'єднання. Спробуйте пізніше.";
 };
 
-const redirectToLogin = (from?: string) => {
-	const redirectTarget = getSafeRedirectTarget(from);
+const redirectToLogin = (from?: string, bounces = 0) => {
+	const redirectTarget = getSafeRedirectTarget(from, bounces);
 	const loginUrl = new URL("/login", globalThis.location.origin);
 	loginUrl.searchParams.set("redirect", redirectTarget);
 
 	globalThis.location.replace(loginUrl.toString());
 };
 
-const getSafeRedirectTarget = (from?: string) => {
+export const getSafeRedirectTarget = (from?: string, bounces = 0) => {
 	if (!from) {
-		return DEFAULT_REDIRECT_TARGET;
+		return withBounceCount(DEFAULT_REDIRECT_TARGET, bounces);
 	}
 
 	try {
@@ -235,10 +273,24 @@ const getSafeRedirectTarget = (from?: string) => {
 		}
 
 		const normalized = `${url.pathname}${url.search}${url.hash}`;
-		return normalized || DEFAULT_REDIRECT_TARGET;
+		return withBounceCount(normalized || DEFAULT_REDIRECT_TARGET, bounces);
 	} catch {
 		return DEFAULT_REDIRECT_TARGET;
 	}
+};
+
+/**
+ * Stamps the current bounce count onto the return target, so the next
+ * failure can count one higher instead of restarting at one. Zero leaves
+ * the URL untouched.
+ */
+export const withBounceCount = (target: string, bounces: number): string => {
+	if (bounces <= 0) {
+		return target;
+	}
+	const url = new URL(target, globalThis.location.origin);
+	url.searchParams.set(BOUNCES_PARAM, String(bounces));
+	return `${url.pathname}${url.search}${url.hash}`;
 };
 
 const getReasonIcon = (reason: ConnectionIssueReason) => {


### PR DESCRIPTION
On a slow backend the app bounced between the page and /connection-error: the error screen silently probed the light session endpoint on mount and auto-returned on success, even though the heavy page would just time out again.

Silent auto-return now happens only on a real offline-to-online transition and stops after 2 bounces; server failures wait for a manual retry. Redirects carry ?bounces=N so repeat visits count up instead of restarting.

Tests: bounce-counter and auto-return unit + component tests, full webapp suite green (359 passed), tsc + oxlint clean.