### PR TITLE
fix(#664): filter courses by instructor rating mentions

### DIFF
--- a/docs/api/openapi-generated.yaml
+++ b/docs/api/openapi-generated.yaml
@@ -1857,6 +1857,11 @@ paths:
           format: uuid
         description: Boost instructors most mentioned on this course offering
       - in: query
+        name: mentioned_only
+        schema:
+          type: boolean
+        description: Only return instructors mentioned in at least one rating
+      - in: query
         name: page
         schema:
           type: integer

--- a/src/backend/rating_app/application_schemas/instructor.py
+++ b/src/backend/rating_app/application_schemas/instructor.py
@@ -40,6 +40,10 @@ class InstructorListParams(BaseModel):
         default=None,
         description="Boost instructors most mentioned on this speciality",
     )
+    mentioned_only: bool = Field(
+        default=False,
+        description="Only return instructors mentioned in at least one rating",
+    )
 
 
 @dataclass(frozen=True)

--- a/src/backend/rating_app/models/course_instructor.py
+++ b/src/backend/rating_app/models/course_instructor.py
@@ -6,6 +6,9 @@ from .choices import InstructorRole
 
 
 class CourseInstructor(models.Model):
+    # NOTE: prod-empty — only generate_mock_data.py creates rows; the scraper
+    # injector never populates this table, so instructor filters match nothing
+    # in prod (see #664). Follow-up proposes removal: #687.
     instructor_id: uuid.UUID
     course_offering_id: uuid.UUID
 

--- a/src/backend/rating_app/repositories/course_repository.py
+++ b/src/backend/rating_app/repositories/course_repository.py
@@ -320,8 +320,10 @@ class CourseRepository(
 
         if filters.instructor:
             # Match offerings with a rating that mentions this instructor.
-            # CourseInstructor assignment rows are unpopulated in real data
-            # (see #664), so mentions are the only reliable signal.
+            # CourseInstructor assignment rows are prod-empty: only
+            # generate_mock_data.py creates them while the scraper injector
+            # never populates the table, so mentions are the only reliable
+            # signal (see #664). Follow-up proposes removal: #687.
             mentioned = Rating.objects.filter(
                 course_offering_id=OuterRef("pk"),
                 instructors__id=filters.instructor,

--- a/src/backend/rating_app/repositories/course_repository.py
+++ b/src/backend/rating_app/repositories/course_repository.py
@@ -35,7 +35,7 @@ from rating_app.exception.department_exceptions import (
     DepartmentNotFoundError,
     InvalidDepartmentIdentifierError,
 )
-from rating_app.models import Course, CourseOffering, CourseOfferingSpeciality, Department
+from rating_app.models import Course, CourseOffering, CourseOfferingSpeciality, Department, Rating
 from rating_app.models.choices import SemesterTerm
 from rating_app.pagination import GenericQuerysetPaginator, PaginationFilters, PaginationResult
 from rating_app.repositories.protocol import IPaginatedRepository
@@ -319,7 +319,14 @@ class CourseRepository(
             has_offering_filter = True
 
         if filters.instructor:
-            offering_query = offering_query.filter(instructors__id=filters.instructor)
+            # Match offerings with a rating that mentions this instructor.
+            # CourseInstructor assignment rows are unpopulated in real data
+            # (see #664), so mentions are the only reliable signal.
+            mentioned = Rating.objects.filter(
+                course_offering_id=OuterRef("pk"),
+                instructors__id=filters.instructor,
+            )
+            offering_query = offering_query.filter(Exists(mentioned))
             has_offering_filter = True
 
         if filters.credits_min is not None:

--- a/src/backend/rating_app/repositories/instructor_repository.py
+++ b/src/backend/rating_app/repositories/instructor_repository.py
@@ -58,6 +58,7 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         course_id: uuid.UUID | None = None,
         speciality_id: uuid.UUID | None = None,
         exclude_current_students: bool = True,
+        mentioned_only: bool = False,
     ) -> QuerySet[InstructorModel]:
         """Annotate instructors with mention counts and order by relevance.
 
@@ -76,6 +77,9 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
         never been rated. Masters and rated instructors are always kept, and a
         non-empty ``search`` bypasses the rule entirely, so no real teacher is
         unreachable.
+        #
+        # ``mentioned_only`` drops every instructor with zero global mentions,
+        # so the course-filter dropdown offers only pickable teachers (#664).
         """
         offering_filter = (
             Q(ratings__course_offering_id=course_offering_id)
@@ -133,7 +137,8 @@ class InstructorRepository(IDomainOrmRepository[Instructor, InstructorModel]):
                 email_lower__in=Subquery(current_bachelor_emails),
                 global_mentions=0,
             )
-
+        if mentioned_only:
+            qs = qs.filter(global_mentions__gt=0)
         if search:
             for token in search.split():
                 qs = qs.filter(

--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -83,6 +83,30 @@ def test_filter_by_instructor_combined_with_department(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_filter_by_instructor_combined_with_education_level(repo):
+    # Mention on a bachelor course must not leak into a master-scoped
+    # instructor query.
+    instructor = InstructorFactory()
+    wanted = CourseFactory(education_level=EducationLevel.MASTER)
+    wanted_offering = CourseOfferingFactory(course=wanted)
+    wanted_rating = RatingFactory(course_offering=wanted_offering)
+    wanted_rating.instructors.add(instructor)
+
+    other = CourseFactory(education_level=EducationLevel.BACHELOR)
+    other_offering = CourseOfferingFactory(course=other)
+    other_rating = RatingFactory(course_offering=other_offering)
+    other_rating.instructors.add(instructor)
+
+    filters = CourseFilterCriteriaInternal(
+        instructor=instructor.id, education_level=EducationLevel.MASTER
+    )
+    result = repo.filter(filters)
+
+    assert {course.id for course in result} == {str(wanted.id)}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_filter_by_instructor_pagination_edge_clamps_to_last_page(repo):
     # One mentioned course; asking for page 2 clamps to page 1 (Django
     # get_page) without error or leaking rows.

--- a/src/backend/rating_app/repositories/test_course_repository.py
+++ b/src/backend/rating_app/repositories/test_course_repository.py
@@ -8,9 +8,9 @@ from rating_app.repositories.course_repository import CourseRepository
 from rating_app.repositories.to_domain_mappers import CourseMapper
 from rating_app.tests.factories import (
     CourseFactory,
-    CourseInstructorFactory,
     CourseOfferingFactory,
     InstructorFactory,
+    RatingFactory,
     SemesterFactory,
 )
 
@@ -22,24 +22,81 @@ def repo():
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_filter_by_instructor_returns_only_assigned_courses(repo):
-    # Arrange
+def test_filter_by_instructor_returns_mentioned_courses(repo):
+    # Arrange — instructor mentioned in a rating, with NO CourseInstructor
+    # assignment row (assignments are unpopulated in real data; mentions are
+    # the signal). Regression test for #664.
     instructor = InstructorFactory()
-    course_with_instructor = CourseFactory()
-    offering_with_instructor = CourseOfferingFactory(course=course_with_instructor)
-    CourseInstructorFactory(course_offering=offering_with_instructor, instructor=instructor)
+    course_with_mention = CourseFactory()
+    offering_with_mention = CourseOfferingFactory(course=course_with_mention)
+    rating = RatingFactory(course_offering=offering_with_mention)
+    rating.instructors.add(instructor)
 
     # Act
-    course_without_instructor = CourseFactory()
-    CourseOfferingFactory(course=course_without_instructor)
+    course_without_mention = CourseFactory()
+    CourseOfferingFactory(course=course_without_mention)
     filters = CourseFilterCriteriaInternal(instructor=instructor.id)
     result = repo.filter(filters)
 
     # Assert
     returned_ids = {course.id for course in result}
-    assert returned_ids == {str(course_with_instructor.id)}
+    assert returned_ids == {str(course_with_mention.id)}
     assert len(result) == 1
-    assert result[0].title == course_with_instructor.title
+    assert result[0].title == course_with_mention.title
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_by_instructor_with_zero_mentions_returns_empty(repo):
+    # An instructor nobody mentioned matches nothing, even when offerings exist.
+    instructor = InstructorFactory()
+    CourseOfferingFactory()
+
+    result = repo.filter(CourseFilterCriteriaInternal(instructor=instructor.id))
+
+    assert result == []
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_by_instructor_combined_with_department(repo):
+    # Mention on a course in another department must not leak through the
+    # combined filter.
+    instructor = InstructorFactory()
+    wanted = CourseFactory()
+    wanted_offering = CourseOfferingFactory(course=wanted)
+    wanted_rating = RatingFactory(course_offering=wanted_offering)
+    wanted_rating.instructors.add(instructor)
+
+    other = CourseFactory()
+    other_offering = CourseOfferingFactory(course=other)
+    other_rating = RatingFactory(course_offering=other_offering)
+    other_rating.instructors.add(instructor)
+
+    filters = CourseFilterCriteriaInternal(
+        instructor=instructor.id, department=str(wanted.department_id)
+    )
+    result = repo.filter(filters)
+
+    assert {course.id for course in result} == {str(wanted.id)}
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_filter_by_instructor_pagination_edge_clamps_to_last_page(repo):
+    # One mentioned course; asking for page 2 clamps to page 1 (Django
+    # get_page) without error or leaking rows.
+    instructor = InstructorFactory()
+    offering = CourseOfferingFactory()
+    rating = RatingFactory(course_offering=offering)
+    rating.instructors.add(instructor)
+
+    filters = CourseFilterCriteriaInternal(instructor=instructor.id)
+    result = repo.filter(filters, PaginationFilters(page=2, page_size=1))
+
+    assert result.metadata.total == 1
+    assert result.metadata.page == 1
+    assert len(result.page_objects) == 1
 
 
 @pytest.mark.django_db

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -170,6 +170,33 @@ def test_list_ranked_tiers_offering_then_course_then_global(repo):
 
 @pytest.mark.django_db
 @pytest.mark.integration
+def test_list_ranked_mentioned_only_drops_never_rated(repo):
+    rated = InstructorFactory.create(last_name="Rated")
+    never_rated = InstructorFactory.create(last_name="NeverRated")
+    RatingFactory.create().instructors.add(rated)
+
+    ranked_ids = {i.id for i in repo.list_ranked(mentioned_only=True)}
+
+    assert rated.id in ranked_ids
+    assert never_rated.id not in ranked_ids
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_ranked_without_mentioned_only_keeps_never_rated(repo):
+    rated = InstructorFactory.create(last_name="Rated")
+    never_rated = InstructorFactory.create(last_name="NeverRated")
+    RatingFactory.create().instructors.add(rated)
+
+    ranked_ids = {i.id for i in repo.list_ranked()}
+
+    assert rated.id in ranked_ids
+    assert never_rated.id in ranked_ids
+
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_list_ranked_hides_unrated_current_bachelor_student(repo):
     # Instructor row that is really a still-enrolled bachelor student (matched
     # by email) and was never rated: dropped by default, shown when the filter

--- a/src/backend/rating_app/repositories/test_instructor_repository.py
+++ b/src/backend/rating_app/repositories/test_instructor_repository.py
@@ -194,7 +194,6 @@ def test_list_ranked_without_mentioned_only_keeps_never_rated(repo):
     assert never_rated.id in ranked_ids
 
 
-
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_list_ranked_hides_unrated_current_bachelor_student(repo):

--- a/src/backend/rating_app/services/instructor_service.py
+++ b/src/backend/rating_app/services/instructor_service.py
@@ -32,6 +32,7 @@ class InstructorService(IFilterable):
             course_offering_id=params.course_offering_id,
             course_id=params.course_id,
             speciality_id=params.speciality_id,
+            mentioned_only=params.mentioned_only,
         )
         paginated = self.paginator.process(
             qs,

--- a/src/backend/rating_app/views/test_course.py
+++ b/src/backend/rating_app/views/test_course.py
@@ -93,6 +93,7 @@ def test_filter_by_instructor(
     data = response.json()
     assert {item["id"] for item in data["items"]} == {str(course.id)}
 
+
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_filter_by_name(token_client, course_factory):

--- a/src/backend/rating_app/views/test_course.py
+++ b/src/backend/rating_app/views/test_course.py
@@ -72,13 +72,16 @@ def test_filter_by_instructor(
     course_factory,
     course_offering_factory,
     instructor_factory,
-    course_instructor_factory,
+    rating_factory,
 ):
-    # Arrange
+    # Arrange — instructor mentioned in a rating, no CourseInstructor row (#664)
     course = course_factory.create()
     offering = course_offering_factory.create(course=course)
     instructor = instructor_factory.create()
-    course_instructor_factory.create(course_offering=offering, instructor=instructor)
+    rating = rating_factory.create(course_offering=offering)
+    rating.instructors.add(instructor)
+    other_course = course_factory.create()
+    course_offering_factory.create(course=other_course)
 
     url = f"/api/v1/courses/?instructor={instructor.id}"
 
@@ -87,7 +90,8 @@ def test_filter_by_instructor(
 
     # Assert
     assert response.status_code == 200, f"Expected 200, got {response.status_code}"
-
+    data = response.json()
+    assert {item["id"] for item in data["items"]} == {str(course.id)}
 
 @pytest.mark.django_db
 @pytest.mark.integration

--- a/src/backend/rating_app/views/test_instructor.py
+++ b/src/backend/rating_app/views/test_instructor.py
@@ -204,14 +204,13 @@ def test_list_instructors_global_fallback(token_client, instructor_factory):
     ids = [item["id"] for item in data["items"][:2]]
     assert ids == [str(more.id), str(less.id)]
 
+
 @pytest.mark.django_db
-@pytest.mark.integration
 def test_list_instructors_mentioned_only_filters_unrated(token_client, instructor_factory):
     rated = instructor_factory.create(last_name="Rated")
-    unrated = instructor_factory.create(last_name="Unrated")
+    instructor_factory.create(last_name="Unrated")
     rating = RatingFactory.create()
     rating.instructors.add(rated)
-
     url = reverse("instructor-list")
     response = token_client.get(url, {"mentioned_only": "true"})
 
@@ -223,9 +222,7 @@ def test_list_instructors_mentioned_only_filters_unrated(token_client, instructo
 
 @pytest.mark.django_db
 @pytest.mark.integration
-def test_list_instructors_without_mentioned_only_keeps_unrated(
-    token_client, instructor_factory
-):
+def test_list_instructors_without_mentioned_only_keeps_unrated(token_client, instructor_factory):
     rated = instructor_factory.create(last_name="Rated")
     unrated = instructor_factory.create(last_name="Unrated")
     rating = RatingFactory.create()

--- a/src/backend/rating_app/views/test_instructor.py
+++ b/src/backend/rating_app/views/test_instructor.py
@@ -203,3 +203,38 @@ def test_list_instructors_global_fallback(token_client, instructor_factory):
     data = response.json()
     ids = [item["id"] for item in data["items"][:2]]
     assert ids == [str(more.id), str(less.id)]
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_mentioned_only_filters_unrated(token_client, instructor_factory):
+    rated = instructor_factory.create(last_name="Rated")
+    unrated = instructor_factory.create(last_name="Unrated")
+    rating = RatingFactory.create()
+    rating.instructors.add(rated)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url, {"mentioned_only": "true"})
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = [item["id"] for item in data["items"]]
+    assert ids == [str(rated.id)]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_list_instructors_without_mentioned_only_keeps_unrated(
+    token_client, instructor_factory
+):
+    rated = instructor_factory.create(last_name="Rated")
+    unrated = instructor_factory.create(last_name="Unrated")
+    rating = RatingFactory.create()
+    rating.instructors.add(rated)
+
+    url = reverse("instructor-list")
+    response = token_client.get(url)
+
+    assert response.status_code == 200
+    data = response.json()
+    ids = {item["id"] for item in data["items"]}
+    assert {str(rated.id), str(unrated.id)} <= ids


### PR DESCRIPTION
Course filter matched CourseInstructor assignments, which are unpopulated in real data, so any instructor filter returned empty. It now matches offerings with a rating mentioning the instructor via Exists, and the instructors endpoint gains mentioned_only for a usable dropdown.

Failing-first: new repo tests failed pre-fix (3 failed), green post-fix; shell repro on local data went 0 courses to 5 for an instructor with 13 mentions. Suites: rating_app repositories/views/services 397 passed; ruff check and format green. Spectacular warnings/errors match main baseline; spec diff is only the new query param.

Part 1 of #664 (backend matching + endpoint support); part 2 wires the dropdown to mentioned_only — Resolves lives there.