### PR TITLE
feat(#571): system theme option in picker

### DIFF
--- a/src/webapp/index.html
+++ b/src/webapp/index.html
@@ -26,6 +26,26 @@
 		<meta name="twitter:card" content="summary" />
 		<link rel="manifest" href="/manifest.json" />
 		<title>Rate UKMA - Оцінюй. Відгукуйся. Обирай найкращі курси НаУКМА</title>
+		<!-- Set the theme class before first paint to avoid a flash (mirrors ThemeProvider defaults). -->
+		<script>
+			try {
+				var storedTheme = localStorage.getItem("rate-ukma-theme") || "system";
+				if (
+					storedTheme !== "light" &&
+					storedTheme !== "dark" &&
+					storedTheme !== "system"
+				) {
+					storedTheme = "system";
+				}
+				var resolvedTheme =
+					storedTheme === "system"
+						? matchMedia("(prefers-color-scheme: dark)").matches
+							? "dark"
+							: "light"
+						: storedTheme;
+				document.documentElement.classList.add(resolvedTheme);
+			} catch (error) {}
+		</script>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/src/webapp/src/components/Header/MobileMenu.tsx
+++ b/src/webapp/src/components/Header/MobileMenu.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { Link } from "@tanstack/react-router";
-import { LogOut, Moon, Sun, X } from "lucide-react";
+import { LogOut, X } from "lucide-react";
 
 import { Drawer } from "@/components/ui/Drawer";
 import {
@@ -11,6 +11,7 @@ import {
 import type { AuthUser } from "@/lib/auth";
 import { testIds } from "@/lib/test-ids";
 import type { NavigationItem, ThemeOption } from "./navigationData";
+import { themeOptions } from "./navigationData";
 import { Logo } from "../Logo";
 import { Button } from "../ui/Button";
 
@@ -52,31 +53,34 @@ function ThemeSwitcher({
 	theme,
 	setTheme,
 }: Readonly<Pick<MobileMenuProps, "theme" | "setTheme">>) {
-	const toggleTheme = () => {
-		if (theme === "system") {
-			const systemTheme = globalThis.matchMedia("(prefers-color-scheme: dark)")
-				.matches
-				? "dark"
-				: "light";
-			setTheme(systemTheme === "dark" ? "light" : "dark");
-		} else {
-			setTheme(theme === "dark" ? "light" : "dark");
-		}
-	};
-
 	return (
 		<div className="mb-3 flex items-center justify-between">
 			<span className="text-sm text-muted-foreground">Тема</span>
-			<Button
-				variant="ghost"
-				size="icon"
-				onClick={toggleTheme}
-				className="h-9 w-9"
+			<div
+				className="flex items-center gap-1"
+				role="group"
+				aria-label="Обрати тему"
 			>
-				<Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-				<Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-				<span className="sr-only">Перемкнути тему</span>
-			</Button>
+				{themeOptions.map((option) => {
+					const Icon = option.icon;
+					const isActive = theme === option.value;
+					return (
+						<Button
+							key={option.value}
+							variant={isActive ? "secondary" : "ghost"}
+							size="icon"
+							onClick={() => setTheme(option.value)}
+							className="h-9 w-9"
+							aria-pressed={isActive}
+							title={option.label}
+							data-testid={`${testIds.header.themeToggle}-mobile-${option.value}`}
+						>
+							<Icon className="h-[1.2rem] w-[1.2rem]" />
+							<span className="sr-only">{option.label}</span>
+						</Button>
+					);
+				})}
+			</div>
 		</div>
 	);
 }

--- a/src/webapp/src/components/ModeToggle.test.tsx
+++ b/src/webapp/src/components/ModeToggle.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { testIds } from "@/lib/test-ids";
+import { ModeToggle } from "./ModeToggle";
+import { ThemeProvider } from "./ThemeProvider";
+
+const STORAGE_KEY = "rate-ukma-theme";
+
+function renderToggle() {
+	return render(
+		<ThemeProvider>
+			<ModeToggle />
+		</ThemeProvider>,
+	);
+}
+
+beforeEach(() => {
+	localStorage.clear();
+	document.documentElement.classList.remove("light", "dark");
+});
+
+describe("ModeToggle", () => {
+	it("offers Light, Dark and System options in the menu", async () => {
+		const user = userEvent.setup();
+		renderToggle();
+
+		await user.click(screen.getByTestId(testIds.header.themeToggle));
+
+		expect(
+			screen.getByTestId(`${testIds.header.themeToggle}-option-light`),
+		).toHaveTextContent("Світла");
+		expect(
+			screen.getByTestId(`${testIds.header.themeToggle}-option-dark`),
+		).toHaveTextContent("Темна");
+		expect(
+			screen.getByTestId(`${testIds.header.themeToggle}-option-system`),
+		).toHaveTextContent("Система");
+	});
+
+	it("selecting System persists the choice and follows the OS theme", async () => {
+		const user = userEvent.setup();
+		renderToggle();
+
+		await user.click(screen.getByTestId(testIds.header.themeToggle));
+		await user.click(
+			screen.getByTestId(`${testIds.header.themeToggle}-option-system`),
+		);
+
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+		// Global matchMedia mock reports light OS theme.
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+	});
+
+	it("selecting Dark applies it instantly without a reload", async () => {
+		const user = userEvent.setup();
+		renderToggle();
+
+		await user.click(screen.getByTestId(testIds.header.themeToggle));
+		await user.click(
+			screen.getByTestId(`${testIds.header.themeToggle}-option-dark`),
+		);
+
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+});

--- a/src/webapp/src/components/ModeToggle.tsx
+++ b/src/webapp/src/components/ModeToggle.tsx
@@ -1,34 +1,51 @@
-import { Moon, Sun } from "lucide-react";
+import { Check, Moon, Sun } from "lucide-react";
 
+import { themeOptions } from "@/components/Header/navigationData";
 import { useTheme } from "@/components/ThemeProvider";
 import { Button } from "@/components/ui/Button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/DropdownMenu";
 import { testIds } from "@/lib/test-ids";
 
 export function ModeToggle() {
 	const { theme, setTheme } = useTheme();
 
-	const toggleTheme = () => {
-		if (theme === "system") {
-			const systemTheme = globalThis.matchMedia("(prefers-color-scheme: dark)")
-				.matches
-				? "dark"
-				: "light";
-			setTheme(systemTheme === "dark" ? "light" : "dark");
-		} else {
-			setTheme(theme === "dark" ? "light" : "dark");
-		}
-	};
-
 	return (
-		<Button
-			variant="ghost"
-			size="icon"
-			onClick={toggleTheme}
-			data-testid={testIds.header.themeToggle}
-		>
-			<Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
-			<Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
-			<span className="sr-only">Перемкнути тему</span>
-		</Button>
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					aria-label="Обрати тему"
+					data-testid={testIds.header.themeToggle}
+				>
+					<Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+					<Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+					<span className="sr-only">Обрати тему</span>
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{themeOptions.map((option) => {
+					const Icon = option.icon;
+					const isActive = theme === option.value;
+					return (
+						<DropdownMenuItem
+							key={option.value}
+							onSelect={() => setTheme(option.value)}
+							className="pr-8"
+							data-testid={`${testIds.header.themeToggle}-option-${option.value}`}
+						>
+							<Icon className="size-4" />
+							{option.label}
+							{isActive && <Check className="absolute right-2 size-4" />}
+						</DropdownMenuItem>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }

--- a/src/webapp/src/components/ThemeProvider.test.tsx
+++ b/src/webapp/src/components/ThemeProvider.test.tsx
@@ -177,4 +177,31 @@ describe("ThemeProvider", () => {
 		expect(screen.getByTestId("current-theme")).toHaveTextContent("system");
 		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 	});
+
+	it("picks up an OS flip between init and effect subscription", () => {
+		let calls = 0;
+		vi.mocked(globalThis.matchMedia).mockImplementation(((query: string) => {
+			calls += 1;
+			// The OS flips to dark after lazy init but before the effect runs.
+			const matches = calls > 1;
+			return {
+				matches,
+				media: query,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			};
+		}) as typeof globalThis.matchMedia);
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+		expect(document.documentElement.classList.contains("light")).toBe(false);
+	});
 });

--- a/src/webapp/src/components/ThemeProvider.test.tsx
+++ b/src/webapp/src/components/ThemeProvider.test.tsx
@@ -1,0 +1,180 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+
+type ChangeListener = (event: { matches: boolean }) => void;
+
+function mockMatchMedia(initialMatches: boolean) {
+	let matches = initialMatches;
+	const listeners = new Set<ChangeListener>();
+	const mql = {
+		get matches() {
+			return matches;
+		},
+		media: "(prefers-color-scheme: dark)",
+		addEventListener: vi.fn((_type: string, listener: ChangeListener) => {
+			listeners.add(listener);
+		}),
+		removeEventListener: vi.fn((_type: string, listener: ChangeListener) => {
+			listeners.delete(listener);
+		}),
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	};
+	vi.mocked(globalThis.matchMedia).mockReturnValue(
+		mql as unknown as MediaQueryList,
+	);
+	return {
+		setMatches(next: boolean) {
+			matches = next;
+			for (const listener of listeners) listener({ matches: next });
+		},
+		mql,
+	};
+}
+
+function ThemeProbe() {
+	const { theme, setTheme } = useTheme();
+	return (
+		<div>
+			<span data-testid="current-theme">{theme}</span>
+			<button type="button" onClick={() => setTheme("light")}>
+				to-light
+			</button>
+			<button type="button" onClick={() => setTheme("dark")}>
+				to-dark
+			</button>
+			<button type="button" onClick={() => setTheme("system")}>
+				to-system
+			</button>
+			<button type="button" onClick={() => setTheme("banana" as "light")}>
+				to-invalid
+			</button>
+		</div>
+	);
+}
+
+const STORAGE_KEY = "rate-ukma-theme";
+
+beforeEach(() => {
+	localStorage.clear();
+	document.documentElement.classList.remove("light", "dark");
+});
+
+describe("ThemeProvider", () => {
+	it("follows the OS dark theme when nothing is stored", () => {
+		mockMatchMedia(true);
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(screen.getByTestId("current-theme")).toHaveTextContent("system");
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+	});
+
+	it("falls back to the OS theme when the stored value is invalid", () => {
+		mockMatchMedia(false);
+		localStorage.setItem(STORAGE_KEY, "banana");
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(screen.getByTestId("current-theme")).toHaveTextContent("system");
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+	});
+
+	it("keeps an explicit choice even when the OS theme differs", () => {
+		mockMatchMedia(true);
+		localStorage.setItem(STORAGE_KEY, "light");
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+		expect(document.documentElement.classList.contains("dark")).toBe(false);
+	});
+
+	it("applies the OS change instantly while System is selected", () => {
+		const { setMatches } = mockMatchMedia(false);
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+
+		act(() => {
+			setMatches(true);
+		});
+
+		expect(document.documentElement.classList.contains("dark")).toBe(true);
+		expect(document.documentElement.classList.contains("light")).toBe(false);
+	});
+
+	it("ignores OS changes while an explicit theme is selected", () => {
+		const { setMatches } = mockMatchMedia(false);
+		localStorage.setItem(STORAGE_KEY, "light");
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		act(() => {
+			setMatches(true);
+		});
+
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+	});
+
+	it("persists the choice and ends rapid toggling on the last value", async () => {
+		mockMatchMedia(false);
+		const user = userEvent.setup();
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "to-light" }));
+		await user.click(screen.getByRole("button", { name: "to-dark" }));
+		await user.click(screen.getByRole("button", { name: "to-system" }));
+
+		expect(screen.getByTestId("current-theme")).toHaveTextContent("system");
+		expect(localStorage.getItem(STORAGE_KEY)).toBe("system");
+		expect(document.documentElement.classList.contains("light")).toBe(true);
+	});
+
+	it("ignores invalid theme values passed to setTheme", async () => {
+		mockMatchMedia(false);
+		const user = userEvent.setup();
+
+		render(
+			<ThemeProvider>
+				<ThemeProbe />
+			</ThemeProvider>,
+		);
+
+		await user.click(screen.getByRole("button", { name: "to-invalid" }));
+
+		expect(screen.getByTestId("current-theme")).toHaveTextContent("system");
+		expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+	});
+});

--- a/src/webapp/src/components/ThemeProvider.tsx
+++ b/src/webapp/src/components/ThemeProvider.tsx
@@ -1,6 +1,13 @@
-import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 
-type Theme = "dark" | "light" | "system";
+export type Theme = "dark" | "light" | "system";
 
 type ThemeProviderProps = {
 	children: React.ReactNode;
@@ -20,43 +27,62 @@ const initialState: ThemeProviderState = {
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
+const SYSTEM_THEME_QUERY = "(prefers-color-scheme: dark)";
+
+function isTheme(value: string | null): value is Theme {
+	return value === "dark" || value === "light" || value === "system";
+}
+
+function resolveSystemTheme(): "dark" | "light" {
+	return globalThis.matchMedia(SYSTEM_THEME_QUERY).matches ? "dark" : "light";
+}
+
 export function ThemeProvider({
 	children,
 	defaultTheme = "system",
 	storageKey = "rate-ukma-theme",
 	...props
 }: Readonly<ThemeProviderProps>) {
-	const [theme, setTheme] = useState<Theme>(
-		() => (localStorage.getItem(storageKey) as Theme) || defaultTheme,
+	const [theme, setThemeState] = useState<Theme>(() => {
+		const stored = localStorage.getItem(storageKey);
+		return isTheme(stored) ? stored : defaultTheme;
+	});
+	const [systemTheme, setSystemTheme] = useState<"dark" | "light">(
+		resolveSystemTheme,
 	);
+
+	// Follow the OS theme while "System" is selected so the switch is instant.
+	useEffect(() => {
+		const mediaQuery = globalThis.matchMedia(SYSTEM_THEME_QUERY);
+		const handleChange = (event: MediaQueryListEvent) => {
+			setSystemTheme(event.matches ? "dark" : "light");
+		};
+		mediaQuery.addEventListener("change", handleChange);
+		return () => mediaQuery.removeEventListener("change", handleChange);
+	}, []);
 
 	useEffect(() => {
 		const root = globalThis.document.documentElement;
 
 		root.classList.remove("light", "dark");
+		root.classList.add(theme === "system" ? systemTheme : theme);
+	}, [theme, systemTheme]);
 
-		if (theme === "system") {
-			const systemTheme = globalThis.matchMedia("(prefers-color-scheme: dark)")
-				.matches
-				? "dark"
-				: "light";
-
-			root.classList.add(systemTheme);
-			return;
-		}
-
-		root.classList.add(theme);
-	}, [theme]);
+	const setTheme = useCallback(
+		(newTheme: Theme) => {
+			if (!isTheme(newTheme)) return;
+			localStorage.setItem(storageKey, newTheme);
+			setThemeState(newTheme);
+		},
+		[storageKey],
+	);
 
 	const value = useMemo(
 		() => ({
 			theme,
-			setTheme: (newTheme: Theme) => {
-				localStorage.setItem(storageKey, newTheme);
-				setTheme(newTheme);
-			},
+			setTheme,
 		}),
-		[theme, storageKey],
+		[theme, setTheme],
 	);
 
 	return (

--- a/src/webapp/src/components/ThemeProvider.tsx
+++ b/src/webapp/src/components/ThemeProvider.tsx
@@ -58,6 +58,8 @@ export function ThemeProvider({
 			setSystemTheme(event.matches ? "dark" : "light");
 		};
 		mediaQuery.addEventListener("change", handleChange);
+		// Re-sync: the OS theme may have flipped between init and subscribe.
+		setSystemTheme(mediaQuery.matches ? "dark" : "light");
 		return () => mediaQuery.removeEventListener("change", handleChange);
 	}, []);
 


### PR DESCRIPTION
ModeToggle is now a Light / Dark / System menu and ThemeProvider follows the OS setting live, persisting the choice across sessions with instant apply and no reload.

Stored garbage falls back to System, a blocking head script sets the class before first paint, and the mobile drawer gets the same three options. Proof screenshots and validation counts are in the issue comment.

Resolves #571

**Proof** (mock data):
Before, mobile menu (two-state toggle): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/571/mobile-menu-before.png?raw=true)
After, mobile menu (Light/Dark/System): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/571/mobile-menu-after.png?raw=true)
Before, desktop (no System option): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/571/desktop-theme-before.png?raw=true)
After, desktop (System selected): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/571/desktop-theme-after.png?raw=true)