### PR TITLE
feat(#533): add prune_legacy_specialities command

### DIFF
--- a/src/backend/rating_app/management/commands/prune_legacy_specialities.py
+++ b/src/backend/rating_app/management/commands/prune_legacy_specialities.py
@@ -1,0 +1,78 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
+
+from rating_app.models import CourseOfferingSpeciality, Speciality
+from rating_app.models.choices import SemesterTerm
+
+
+def get_current_academic_year_start(now=None) -> int:
+    now = now or timezone.now()
+    return now.year if now.month >= 9 else now.year - 1
+
+
+def recent_offering_q() -> Q:
+    current_start = get_current_academic_year_start()
+    return (
+        Q(offering__semester__year=current_start, offering__semester__term=SemesterTerm.FALL)
+        | Q(
+            offering__semester__year=current_start + 1,
+            offering__semester__term__in=[SemesterTerm.SPRING, SemesterTerm.SUMMER],
+        )
+        | Q(
+            offering__semester__year=current_start - 1,
+            offering__semester__term=SemesterTerm.FALL,
+        )
+        | Q(
+            offering__semester__year=current_start,
+            offering__semester__term__in=[SemesterTerm.SPRING, SemesterTerm.SUMMER],
+        )
+    )
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete legacy specialities with 0 students and no recent offerings (dry-run by default)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Actually delete. Without it, only show what would be deleted.",
+        )
+
+    def handle(self, *args, **options):
+        apply = options["apply"]
+        candidate_ids = list(self._find_candidates().values_list("id", flat=True))
+        link_count = CourseOfferingSpeciality.objects.filter(
+            speciality_id__in=candidate_ids
+        ).count()
+
+        if not apply:
+            self.stdout.write(
+                f"Would delete {len(candidate_ids)} specialities ({link_count} offering links)."
+            )
+            for spec_id in candidate_ids:
+                self.stdout.write(f"  {spec_id}")
+            self.stdout.write(self.style.WARNING("Dry run — no changes made."))
+            return
+
+        with transaction.atomic():
+            deleted_links, _ = CourseOfferingSpeciality.objects.filter(
+                speciality_id__in=candidate_ids
+            ).delete()
+            deleted_specs, _ = Speciality.objects.filter(id__in=candidate_ids).delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Deleted {deleted_specs} specialities ({deleted_links} offering links)."
+            )
+        )
+
+    def _find_candidates(self):
+        recent_spec_ids = CourseOfferingSpeciality.objects.filter(recent_offering_q()).values(
+            "speciality_id"
+        )
+        return Speciality.objects.filter(students__isnull=True).exclude(pk__in=recent_spec_ids)

--- a/src/backend/rating_app/management/commands/prune_legacy_specialities.py
+++ b/src/backend/rating_app/management/commands/prune_legacy_specialities.py
@@ -1,15 +1,26 @@
+from collections import Counter
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
-from rating_app.models import CourseOfferingSpeciality, Speciality
+from rating_app.models import (
+    CourseOffering,
+    CourseOfferingSpeciality,
+    Speciality,
+    Student,
+)
 from rating_app.models.choices import SemesterTerm
 
 
 def get_current_academic_year_start(now=None) -> int:
     now = now or timezone.now()
     return now.year if now.month >= 9 else now.year - 1
+
+
+def academic_year_label(start: int) -> str:
+    return f"{start}–{start + 1}"
 
 
 def recent_offering_q() -> Q:
@@ -31,6 +42,77 @@ def recent_offering_q() -> Q:
     )
 
 
+def find_legacy_speciality_ids() -> list:
+    recent_spec_ids = CourseOfferingSpeciality.objects.filter(recent_offering_q()).values(
+        "speciality_id"
+    )
+    return list(
+        Speciality.objects.filter(students__isnull=True)
+        .exclude(pk__in=recent_spec_ids)
+        .values_list("id", flat=True)
+    )
+
+
+def collect_report() -> dict:
+    current_start = get_current_academic_year_start()
+    previous_start = current_start - 1
+    scanned = Speciality.objects.count()
+    students = Student.objects.count()
+    links = CourseOfferingSpeciality.objects.count()
+
+    year_counts: Counter[int] = Counter()
+    for year, term in CourseOffering.objects.values_list("semester__year", "semester__term"):
+        if year is None or not term:
+            continue
+        start = year if term == SemesterTerm.FALL else year - 1
+        year_counts[start] += 1
+
+    return {
+        "scanned": scanned,
+        "students": students,
+        "links": links,
+        "current_start": current_start,
+        "previous_start": previous_start,
+        "offerings_current": year_counts.get(current_start, 0),
+        "offerings_previous": year_counts.get(previous_start, 0),
+        "offerings_older": sum(
+            count
+            for start, count in year_counts.items()
+            if start not in (current_start, previous_start)
+        ),
+    }
+
+
+def run_prune(*, apply: bool) -> dict:
+    candidate_ids = find_legacy_speciality_ids()
+    candidate_links = CourseOfferingSpeciality.objects.filter(
+        speciality_id__in=candidate_ids
+    ).count()
+
+    if not apply:
+        return {
+            "deleted_specs": 0,
+            "deleted_links": 0,
+            "candidate_specs": len(candidate_ids),
+            "candidate_links": candidate_links,
+            "candidate_ids": candidate_ids,
+        }
+
+    with transaction.atomic():
+        deleted_links, _ = CourseOfferingSpeciality.objects.filter(
+            speciality_id__in=candidate_ids
+        ).delete()
+        deleted_specs, _ = Speciality.objects.filter(id__in=candidate_ids).delete()
+
+    return {
+        "deleted_specs": deleted_specs,
+        "deleted_links": deleted_links,
+        "candidate_specs": len(candidate_ids),
+        "candidate_links": candidate_links,
+        "candidate_ids": candidate_ids,
+    }
+
+
 class Command(BaseCommand):
     help = (
         "Delete legacy specialities with 0 students and no recent offerings (dry-run by default)."
@@ -45,34 +127,35 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         apply = options["apply"]
-        candidate_ids = list(self._find_candidates().values_list("id", flat=True))
-        link_count = CourseOfferingSpeciality.objects.filter(
-            speciality_id__in=candidate_ids
-        ).count()
+        report = collect_report()
+        result = run_prune(apply=apply)
+
+        self.stdout.write(
+            f"Scanned {report['scanned']} specialities "
+            f"({report['students']} students, {report['links']} offering links)."
+        )
+        self.stdout.write(
+            f"Current academic year: {academic_year_label(report['current_start'])}; "
+            f"previous: {academic_year_label(report['previous_start'])}."
+        )
+        self.stdout.write(
+            f"Offerings by academic year: current {report['offerings_current']}, "
+            f"previous {report['offerings_previous']}, older {report['offerings_older']}."
+        )
 
         if not apply:
             self.stdout.write(
-                f"Would delete {len(candidate_ids)} specialities ({link_count} offering links)."
+                f"Would delete {result['candidate_specs']} specialities "
+                f"({result['candidate_links']} offering links)."
             )
-            for spec_id in candidate_ids:
+            for spec_id in result["candidate_ids"]:
                 self.stdout.write(f"  {spec_id}")
             self.stdout.write(self.style.WARNING("Dry run — no changes made."))
             return
 
-        with transaction.atomic():
-            deleted_links, _ = CourseOfferingSpeciality.objects.filter(
-                speciality_id__in=candidate_ids
-            ).delete()
-            deleted_specs, _ = Speciality.objects.filter(id__in=candidate_ids).delete()
-
         self.stdout.write(
             self.style.SUCCESS(
-                f"Deleted {deleted_specs} specialities ({deleted_links} offering links)."
+                f"Deleted {result['deleted_specs']} specialities "
+                f"({result['deleted_links']} offering links)."
             )
         )
-
-    def _find_candidates(self):
-        recent_spec_ids = CourseOfferingSpeciality.objects.filter(recent_offering_q()).values(
-            "speciality_id"
-        )
-        return Speciality.objects.filter(students__isnull=True).exclude(pk__in=recent_spec_ids)

--- a/src/backend/rating_app/management/commands/test_prune_legacy_specialities.py
+++ b/src/backend/rating_app/management/commands/test_prune_legacy_specialities.py
@@ -1,0 +1,106 @@
+from django.core.management import call_command
+
+import pytest
+
+from rating_app.management.commands.prune_legacy_specialities import (
+    get_current_academic_year_start,
+)
+from rating_app.models import CourseOfferingSpeciality, Speciality
+from rating_app.models.choices import SemesterTerm
+from rating_app.tests.factories import (
+    CourseOfferingFactory,
+    CourseOfferingSpecialityFactory,
+    SemesterFactory,
+    SpecialityFactory,
+    StudentFactory,
+)
+
+
+def _old_semester():
+    start = get_current_academic_year_start()
+    return SemesterFactory(year=start - 3, term=SemesterTerm.FALL)
+
+
+def _recent_semester():
+    start = get_current_academic_year_start()
+    return SemesterFactory(year=start, term=SemesterTerm.FALL)
+
+
+@pytest.mark.django_db
+def test_dry_run_by_default_deletes_nothing():
+    spec = SpecialityFactory()
+    CourseOfferingSpecialityFactory(
+        offering=CourseOfferingFactory(semester=_old_semester()),
+        speciality=spec,
+    )
+    before = Speciality.objects.count()
+
+    call_command("prune_legacy_specialities")
+
+    assert Speciality.objects.count() == before
+    assert Speciality.objects.filter(pk=spec.pk).exists()
+
+
+@pytest.mark.django_db
+def test_apply_deletes_speciality_with_no_students_and_only_old_offerings():
+    spec = SpecialityFactory()
+    CourseOfferingSpecialityFactory(
+        offering=CourseOfferingFactory(semester=_old_semester()),
+        speciality=spec,
+    )
+
+    call_command("prune_legacy_specialities", "--apply")
+
+    assert not Speciality.objects.filter(pk=spec.pk).exists()
+    assert CourseOfferingSpeciality.objects.filter(speciality_id=spec.pk).count() == 0
+
+
+@pytest.mark.django_db
+def test_apply_deletes_speciality_with_no_offerings_at_all():
+    spec = SpecialityFactory()
+
+    call_command("prune_legacy_specialities", "--apply")
+
+    assert not Speciality.objects.filter(pk=spec.pk).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_speciality_with_students():
+    spec = SpecialityFactory()
+    StudentFactory(speciality=spec)
+    CourseOfferingSpecialityFactory(
+        offering=CourseOfferingFactory(semester=_old_semester()),
+        speciality=spec,
+    )
+
+    call_command("prune_legacy_specialities", "--apply")
+
+    assert Speciality.objects.filter(pk=spec.pk).exists()
+
+
+@pytest.mark.django_db
+def test_keeps_speciality_with_recent_offering():
+    spec = SpecialityFactory()
+    CourseOfferingSpecialityFactory(
+        offering=CourseOfferingFactory(semester=_recent_semester()),
+        speciality=spec,
+    )
+
+    call_command("prune_legacy_specialities", "--apply")
+
+    assert Speciality.objects.filter(pk=spec.pk).exists()
+
+
+@pytest.mark.django_db
+def test_apply_is_idempotent():
+    spec = SpecialityFactory()
+    CourseOfferingSpecialityFactory(
+        offering=CourseOfferingFactory(semester=_old_semester()),
+        speciality=spec,
+    )
+
+    call_command("prune_legacy_specialities", "--apply")
+    assert not Speciality.objects.filter(pk=spec.pk).exists()
+
+    call_command("prune_legacy_specialities", "--apply")
+    assert not Speciality.objects.filter(pk=spec.pk).exists()

--- a/src/backend/scraper/services/db_ingestion/composite.py
+++ b/src/backend/scraper/services/db_ingestion/composite.py
@@ -70,3 +70,15 @@ class CoursesIngestion(IOperation[[Path, int, bool]]):
                 total=total_records,
                 percentage="100.0%",
             )
+
+        if not dry_run:
+            # Prune legacy specialities after each ingest so recreated stale
+            # names from old snapshots do not accumulate (#533).
+            from rating_app.management.commands.prune_legacy_specialities import run_prune
+
+            pruned = run_prune(apply=True)
+            logger.info(
+                "legacy_specialities_pruned",
+                deleted_specs=pruned["deleted_specs"],
+                deleted_links=pruned["deleted_links"],
+            )

--- a/src/backend/scraper/services/db_ingestion/test_composite.py
+++ b/src/backend/scraper/services/db_ingestion/test_composite.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from rating_app.models import Speciality
+from rating_app.tests.factories import SpecialityFactory
+from scraper.services.db_ingestion.composite import CoursesIngestion
+
+
+@pytest.mark.django_db
+def test_execute_prunes_legacy_specialities_after_ingest(tmp_path):
+    legacy = SpecialityFactory()
+    assert Speciality.objects.filter(pk=legacy.pk).exists()
+
+    data_file = tmp_path / "courses.jsonl"
+    data_file.write_text("", encoding="utf-8")
+    file_reader = MagicMock()
+    file_reader.provide.return_value = iter([[]])
+    db_injector = MagicMock(spec=["execute", "reset_state", "set_batch_number"])
+
+    CoursesIngestion(file_reader=file_reader, db_injector=db_injector).execute(
+        file_path=data_file, batch_size=100, dry_run=False
+    )
+
+    assert not Speciality.objects.filter(pk=legacy.pk).exists()
+
+
+@pytest.mark.django_db
+def test_execute_dry_run_does_not_prune(tmp_path):
+    legacy = SpecialityFactory()
+
+    data_file = tmp_path / "courses.jsonl"
+    data_file.write_text("", encoding="utf-8")
+    file_reader = MagicMock()
+    file_reader.provide.return_value = iter([[]])
+    db_injector = MagicMock(spec=["execute", "reset_state", "set_batch_number"])
+
+    CoursesIngestion(file_reader=file_reader, db_injector=db_injector).execute(
+        file_path=data_file, batch_size=100, dry_run=True
+    )
+
+    assert Speciality.objects.filter(pk=legacy.pk).exists()


### PR DESCRIPTION
Adds idempotent dry-run-by-default cleanup for specialities with 0 students and no offerings in the current or previous academic year. Runs automatically after each ingest so stale names do not accumulate.

Blast radius from the tool against local data:

| Scope | Count |
| --- | --- |
| Specialities scanned | 12 |
| Students | 41 |
| Offering links | 166 |
| Offerings current 2026–2027 | 18 |
| Offerings previous 2025–2026 | 24 |
| Offerings older | 94 |
| Would delete | 0 |
| Students affected | 0 |

Dry-run executed twice with identical no-op output. Proof: proof/533/dry-run-1.txt and dry-run-2.txt on the proof branch. Backend suites and ruff are green.

Resolves #533