### PR TITLE
fix(#664): mentioned-only instructors in courses filter dropdown

### DIFF
--- a/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
+++ b/src/webapp/src/features/courses/components/CourseFiltersPanel.tsx
@@ -508,6 +508,7 @@ function SelectFilters({
 									onChange={(nextValue) => onSelectChange(key, nextValue)}
 									placeholder={placeholder}
 									data-testid={testId}
+									mentionedOnly
 								/>
 							</div>
 						);

--- a/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorFilterSelect.tsx
@@ -30,6 +30,8 @@ interface InstructorFilterSelectProps {
 	readonly searchPlaceholder?: string;
 	readonly emptyText?: string;
 	readonly className?: string;
+	/** List only instructors mentioned in ratings (courses filter). */
+	readonly mentionedOnly?: boolean;
 	readonly "data-testid"?: string;
 }
 
@@ -42,6 +44,7 @@ function InstructorFilterSelect({
 	searchPlaceholder = "Пошук викладача…",
 	emptyText = "Викладачів не знайдено.",
 	className,
+	mentionedOnly = false,
 	"data-testid": testId,
 }: InstructorFilterSelectProps) {
 	const [open, setOpen] = React.useState(false);
@@ -73,6 +76,7 @@ function InstructorFilterSelect({
 	const { allInstructors, hasMore, isFetchingNextPage, isLoading, loaderRef } =
 		useInfiniteInstructors({
 			search: debouncedSearch || undefined,
+			mentionedOnly,
 			enabled: open,
 		});
 

--- a/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
+++ b/src/webapp/src/features/instructors/components/InstructorMultiSelect.test.tsx
@@ -268,4 +268,18 @@ describe("InstructorMultiSelect", () => {
 			expect(onChange).toHaveBeenCalledWith([]);
 		});
 	});
+
+	describe("Directory scope", () => {
+		it("should list all instructors without the mentioned-only filter", () => {
+			mockInstructors([createMockInstructor()]);
+
+			renderWithProviders(
+				<InstructorMultiSelect value={[]} onChange={vi.fn()} />,
+			);
+
+			const calls = mockedInfinite.mock.calls;
+			expect(calls.length).toBeGreaterThan(0);
+			expect(calls[calls.length - 1]?.[0]).not.toHaveProperty("mentioned_only");
+		});
+	});
 });

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.test.ts
@@ -90,6 +90,15 @@ describe("useInfiniteInstructors", () => {
 
 			expect(lastCallParams()).toEqual({ page_size: 50 });
 		});
+
+		it("should request only mentioned instructors when mentionedOnly is set", () => {
+			renderHook(() => useInfiniteInstructors({ mentionedOnly: true }));
+
+			expect(lastCallParams()).toEqual({
+				page_size: 20,
+				mentioned_only: true,
+			});
+		});
 	});
 
 	describe("Derived Output", () => {

--- a/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
+++ b/src/webapp/src/features/instructors/hooks/useInfiniteInstructors.ts
@@ -18,6 +18,7 @@ export interface UseInfiniteInstructorsOptions {
 	readonly courseOfferingId?: string;
 	readonly courseId?: string;
 	readonly specialityId?: string;
+	readonly mentionedOnly?: boolean;
 	readonly pageSize?: number;
 	readonly enabled?: boolean;
 }
@@ -29,6 +30,7 @@ export function useInfiniteInstructors({
 	courseOfferingId,
 	courseId,
 	specialityId,
+	mentionedOnly = false,
 	pageSize = DEFAULT_PAGE_SIZE,
 	enabled = true,
 }: UseInfiniteInstructorsOptions = {}): UseInfiniteInstructorsReturn {
@@ -39,8 +41,9 @@ export function useInfiniteInstructors({
 			...(courseOfferingId ? { course_offering_id: courseOfferingId } : {}),
 			...(courseId ? { course_id: courseId } : {}),
 			...(specialityId ? { speciality_id: specialityId } : {}),
+			...(mentionedOnly ? { mentioned_only: true } : {}),
 		}),
-		[search, courseOfferingId, courseId, specialityId, pageSize],
+		[search, courseOfferingId, courseId, specialityId, mentionedOnly, pageSize],
 	);
 
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =


### PR DESCRIPTION
The courses-filter instructor dropdown now passes mentioned_only=true, so it lists only instructors the filter can actually match. The rating-form autocomplete keeps the default full directory.

Backend part is #678 (part 1, stacked base); this completes it. New tests: dropdown forwards mentioned_only, form omits it. File suites 24/24 + CoursesTable 32/32, tsc, oxlint, oxfmt green.

Resolves #664

**Proof** (mock data):
Before, desktop (unmentioned names listed): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/664/dropdown-before-desktop.png?raw=true)
After, desktop (only mentioned): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/664/dropdown-after-desktop.png?raw=true)
Before, mobile (unmentioned names listed): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/664/dropdown-before-mobile.png?raw=true)
After, mobile (only mentioned): ![](https://github.com/ukma-cs-ssdm-2025/rate-ukma/blob/proof/overnight-2026-09-09/proof/664/dropdown-after-mobile.png?raw=true)