### PR TITLE
chore: bump js-yaml override to 4.3.2 to clear high audit advisory

### DIFF
--- a/src/webapp/pnpm-lock.yaml
+++ b/src/webapp/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   markdown-it: 14.2.0
   fast-uri: 3.1.7
   brace-expansion: 5.0.9
-  js-yaml: 4.3.1
+  js-yaml: 4.3.2
   postcss: 8.5.23
   ip-address: 10.3.1
   nanoid: ^3.3.18
@@ -3452,8 +3452,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -7073,7 +7073,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 7.0.2
@@ -7692,7 +7692,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -8059,7 +8059,7 @@ snapshots:
       fs-extra: 11.4.0
       get-tsconfig: 4.14.1
       jiti: 2.7.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       remeda: 2.39.0
       string-argv: 0.3.2
       typedoc: 0.28.20(typescript@7.0.2)

--- a/src/webapp/pnpm-workspace.yaml
+++ b/src/webapp/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ overrides:
   markdown-it: 14.2.0
   fast-uri: 3.1.7
   brace-expansion: 5.0.9
-  js-yaml: 4.3.1
+  js-yaml: 4.3.2
   postcss: 8.5.23
   ip-address: 10.3.1
   # postcss expects nanoid ^3; 3.3.18 is the patched release for GHSA-2v37-7h3g-55p8.


### PR DESCRIPTION
## Summary

The newly published js-yaml high advisory (GHSA-2883-xcg3-v3hh, 4.3.1 via `shadcn` cosmiconfig and `orval` devDeps) reds the Frontend Security Audit on every branch. This bumps the existing `pnpm-workspace.yaml` override to the patched 4.3.2, following the fast-uri 3.1.7 precedent in the same file. No Resolves — it unblocks CI repo-wide.

## Testing

`pnpm install` + `pnpm audit --audit-level high` green locally (high gone, only pre-existing moderates remain); lockfile diff is js-yaml version + integrity only.

## Notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled YAML parsing dependency to version 4.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->